### PR TITLE
ENH: absolute imports + dependency checker + style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cov.xml
 
 .*.swp
 *~
+
+dask-worker-space

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cov.xml
 *~
 
 dask-worker-space
+test_outputs

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ dist: clean
 clean-pyc:
 	find . -name '*.pyc' -type f -exec rm {} +
 	find . -name '*.pyo' -type f -exec rm {} +
-	find . -name '__pycache__' -type d -exec rm --recursive {} +
+	find . -name '__pycache__' -type d -exec rm -r {} +
 
 clean-build:
-	rm --recursive --force build/
-	rm --recursive --force dist/
+	rm -rf build/
+	rm -rf dist/
 
 clean: clean-pyc clean-build
 

--- a/pydra/__about__.py
+++ b/pydra/__about__.py
@@ -3,7 +3,7 @@ settings in setup.py, the nipy top-level docstring, and for building the
 docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 """
 
-from pydra.engine._version import get_versions
+from pydra._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 

--- a/pydra/__about__.py
+++ b/pydra/__about__.py
@@ -3,7 +3,7 @@ settings in setup.py, the nipy top-level docstring, and for building the
 docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 """
 
-from ._version import get_versions
+from pydra.engine._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 

--- a/pydra/__init__.py
+++ b/pydra/__init__.py
@@ -1,2 +1,2 @@
-from .__about__ import (__version__, __author__, __license__, __maintainer__, __email__,
+from pydra.engine.__about__ import (__version__, __author__, __license__, __maintainer__, __email__,
                         __status__, __url__, __packagename__, __description__, __longdesc__)

--- a/pydra/__init__.py
+++ b/pydra/__init__.py
@@ -1,2 +1,2 @@
-from pydra.engine.__about__ import (__version__, __author__, __license__, __maintainer__, __email__,
-                        __status__, __url__, __packagename__, __description__, __longdesc__)
+from pydra.__about__ import (__version__, __author__, __license__, __maintainer__, __email__,
+                             __status__, __url__, __packagename__, __description__, __longdesc__)

--- a/pydra/engine/auxiliary.py
+++ b/pydra/engine/auxiliary.py
@@ -1,7 +1,10 @@
-import pdb
-import inspect, os
+"""Auxiliary elements."""
+import inspect
+import os
 import logging
+
 from nipype import Node as Nipype1Node
+
 logger = logging.getLogger('nipype.workflow')
 
 # dj: might create a new class or move to State
@@ -17,36 +20,36 @@ def mapper2rpn(mapper, other_mappers=None):
 
 def _ordering(el, i, output_mapper, current_sign=None, other_mappers=None):
     """ Used in the mapper2rpn to get a proper order of fields and signs. """
-    if type(el) is tuple:
+    if isinstance(el, tuple):
         # checking if the mapper dont contain mapper from previous nodes, i.e. has str "_NA", etc.
-        if type(el[0]) is str and el[0].startswith("_"):
+        if isinstance(el[0], str) and el[0].startswith("_"):
             node_nm = el[0][1:]
             if node_nm not in other_mappers:
                 raise Exception("can't ask for mapper from {}".format(node_nm))
             mapper_mod = change_mapper(mapper=other_mappers[node_nm], name=node_nm)
             el = (mapper_mod, el[1])
-        if type(el[1]) is str and el[1].startswith("_"):
+        if isinstance(el[1], str) and el[1].startswith("_"):
             node_nm = el[1][1:]
             if node_nm not in other_mappers:
                 raise Exception("can't ask for mapper from {}".format(node_nm))
             mapper_mod = change_mapper(mapper=other_mappers[node_nm], name=node_nm)
             el = (el[0], mapper_mod)
         _iterate_list(el, ".", other_mappers, output_mapper=output_mapper)
-    elif type(el) is list:
-        if type(el[0]) is str and el[0].startswith("_"):
+    elif isinstance(el, list):
+        if isinstance(el[0], str) and el[0].startswith("_"):
             node_nm = el[0][1:]
             if node_nm not in other_mappers:
                 raise Exception("can't ask for mapper from {}".format(node_nm))
             mapper_mod = change_mapper(mapper=other_mappers[node_nm], name=node_nm)
             el[0] = mapper_mod
-        if type(el[1]) is str and el[1].startswith("_"):
+        if isinstance(el[1], str) and el[1].startswith("_"):
             node_nm = el[1][1:]
             if node_nm not in other_mappers:
                 raise Exception("can't ask for mapper from {}".format(node_nm))
             mapper_mod = change_mapper(mapper=other_mappers[node_nm], name=node_nm)
             el[1] = mapper_mod
         _iterate_list(el, "*", other_mappers, output_mapper=output_mapper)
-    elif type(el) is str:
+    elif isinstance(el, str):
         output_mapper.append(el)
     else:
         raise Exception("mapper has to be a string, a tuple or a list")
@@ -71,7 +74,7 @@ def mapping_axis(state_inputs, mapper_rpn):
     stack = []
     current_axis = None
     current_shape = None
-    #pdb.set_trace()
+
     for el in mapper_rpn:
         if el == ".":
             right = stack.pop()
@@ -208,7 +211,7 @@ class FunctionInterface(object):
 
     def __init__(self, function, output_nm, out_read=False, input_map=None):
         self.function = function
-        if type(output_nm) is list:
+        if isinstance(output_nm, list):
             self._output_nm = output_nm
         else:
             raise Exception("output_nm should be a list")
@@ -231,7 +234,7 @@ class FunctionInterface(object):
                     raise Exception("no {} in the input dictionary".format(key_inp))
         fun_output = self.function(**input)
         logger.debug("Function Interf, input={}, fun_out={}".format(input, fun_output))
-        if type(fun_output) is tuple:
+        if isinstance(fun_output, tuple):
             if len(self._output_nm) == len(fun_output):
                 for i, out in enumerate(fun_output):
                     self.output[self._output_nm[i]] = out

--- a/pydra/engine/auxiliary.py
+++ b/pydra/engine/auxiliary.py
@@ -1,7 +1,7 @@
 """Auxiliary elements."""
 import inspect
-import os
 import logging
+import os
 
 from nipype import Node as Nipype1Node
 
@@ -217,8 +217,7 @@ class FunctionInterface(object):
             raise Exception("output_nm should be a list")
         if not input_map:
             self.input_map = {}
-        # TODO use signature
-        for key in inspect.getargspec(function)[0]:
+        for key in inspect.getfullargspec(function).args:
             if key not in self.input_map.keys():
                 self.input_map[key] = key
         # flags if we want to read the txt file to save in node.output

--- a/pydra/engine/node.py
+++ b/pydra/engine/node.py
@@ -1,19 +1,38 @@
-"""Basic compute graph elements"""
+"""Basic compute graph elements."""
 import os
 import itertools
-import pdb
+
 import networkx as nx
 import numpy as np
 
 from nipype.utils.filemanip import loadpkl
 from nipype import logging
 
-from . import state
-from . import auxiliary as aux
+from pydra.engine import state
+from pydra.engine import auxiliary as aux
+
 logger = logging.getLogger('nipype.workflow')
 
 
 class NodeBase(object):
+    """A base structure for nodes in the computational graph (i.e. both
+    ``Node`` and ``Workflow``).
+
+    Parameters
+    ----------
+    name : str
+        Unique name of this node
+    mapper : str or (list or tuple of (str or mappers))
+        Whether inputs should be mapped at run time
+    inputs : dictionary (input name, input value or list of values)
+        States this node's input names
+    other_mappers : dictionary (name of a node, mapper of the node)
+        information about other nodes' mappers from workflow (in case the mapper
+        from previous node is used)
+    write_state : True
+        flag that says if value of state input should be written out to output
+        and directories (otherwise indices are used)
+    """
     def __init__(self,
                  name,
                  mapper=None,
@@ -22,28 +41,7 @@ class NodeBase(object):
                  write_state=True,
                  *args,
                  **kwargs):
-        """A base structure for nodes in the computational graph (i.e. both
-        ``Node`` and ``Workflow``).
 
-        Parameters
-        ----------
-
-        name : str
-            Unique name of this node
-        mapper : str or (list or tuple of (str or mappers))
-            Whether inputs should be mapped at run time
-        inputs : dictionary (input name, input value or list of values)
-            States this node's input names
-        other_mappers : dictionary (name of a node, mapper of the node)
-            information about other nodes' mappers from workflow (in case the mapper
-            from previous node is used)
-        write_state : True
-            flag that says if value of state input should be written out to output
-            and directories (otherwise indices are used)
-
-
-
-        """
         self.name = name
         self._inputs = {}
         self._state_inputs = {}
@@ -218,9 +216,9 @@ class NodeBase(object):
         raise NotImplementedError
 
     def _dict_tuple2list(self, container):
-        if type(container) is dict:
+        if isinstance(container, dict):
             val_l = [val for (_, val) in container.items()]
-        elif type(container) is tuple:
+        elif isinstance(container, tuple):
             val_l = [container]
         else:
             raise Exception("{} has to be dict or tuple".format(container))
@@ -569,7 +567,7 @@ class Workflow(NodeBase):
                     for val in val_l:
                         #TODO: I think that val shouldn't be dict here...
                         # TMP solution
-                        if type(val) is dict:
+                        if isinstance(val, dict):
                             val = [v for k, v in val.items()][0]
                         with open(val[1]) as fout:
                             logger.debug('Reading Results: file={}, st_dict={}'.format(
@@ -736,11 +734,11 @@ def is_function(obj):
 
 
 def is_function_interface(obj):
-    return type(obj) is aux.FunctionInterface
+    return isinstance(obj, aux.FunctionInterface)
 
 
 def is_current_interface(obj):
-    return type(obj) is aux.CurrentInterface
+    return isinstance(obj, aux.CurrentInterface)
 
 
 def is_nipype_interface(obj):
@@ -748,8 +746,8 @@ def is_nipype_interface(obj):
 
 
 def is_node(obj):
-    return type(obj) is Node
+    return isinstance(obj, Node)
 
 
 def is_workflow(obj):
-    return type(obj) is Workflow
+    return isinstance(obj, Workflow)

--- a/pydra/engine/node.py
+++ b/pydra/engine/node.py
@@ -3,10 +3,9 @@ import os
 import itertools
 
 import networkx as nx
-import numpy as np
-
 from nipype.utils.filemanip import loadpkl
 from nipype import logging
+import numpy as np
 
 from pydra.engine import state
 from pydra.engine import auxiliary as aux
@@ -33,6 +32,7 @@ class NodeBase(object):
         flag that says if value of state input should be written out to output
         and directories (otherwise indices are used)
     """
+
     def __init__(self,
                  name,
                  mapper=None,
@@ -66,10 +66,6 @@ class NodeBase(object):
         # flag that says if node finished all jobs
         self._is_complete = False
         self.write_state = write_state
-
-    # TBD
-    def join(self, field):
-        pass
 
     @property
     def state(self):
@@ -144,7 +140,7 @@ class NodeBase(object):
         try:
             self.get_input_el(ind)
             return True
-        except:  #TODO specify
+        except Exception:  #TODO specify
             return False
 
     # dj: this is not used for a single node

--- a/pydra/engine/state.py
+++ b/pydra/engine/state.py
@@ -1,8 +1,8 @@
+"""State object."""
 from collections import OrderedDict
 import itertools
-import pdb
 
-from . import auxiliary as aux
+from pydra.engine import auxiliary as aux
 
 
 class State(object):

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -14,7 +14,7 @@ class Submitter(object):
         self.node_line = []
         self._to_finish = []  # used only for wf
 
-        self.worker = _get_worker(plugin=plugin)
+        self.worker = _get_worker(plugin=plugin)()
 
         if hasattr(runnable, 'interface'):  # a node
             self.node = runnable

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -1,9 +1,10 @@
-import os, pdb, time
 from copy import deepcopy
-
-from .workers import MpWorker, SerialWorker, DaskWorker, ConcurrentFuturesWorker
-
 import logging
+import os
+import time
+
+from pydra.engine.workers import _get_worker
+
 logger = logging.getLogger('nipype.workflow')
 
 
@@ -13,16 +14,8 @@ class Submitter(object):
         self.plugin = plugin
         self.node_line = []
         self._to_finish = []  # used only for wf
-        if self.plugin == "mp":
-            self.worker = MpWorker()
-        elif self.plugin == "serial":
-            self.worker = SerialWorker()
-        elif self.plugin == "dask":
-            self.worker = DaskWorker()
-        elif self.plugin == "cf":
-            self.worker = ConcurrentFuturesWorker()
-        else:
-            raise Exception("plugin {} not available".format(self.plugin))
+
+        self.worker = _get_worker(plugin=plugin)
 
         if hasattr(runnable, 'interface'):  # a node
             self.node = runnable

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 import logging
-import os
 import time
 
 from pydra.engine.workers import _get_worker

--- a/pydra/engine/tests/test_auxiliary.py
+++ b/pydra/engine/tests/test_auxiliary.py
@@ -1,4 +1,4 @@
-from .. import auxiliary as aux
+from pydra.engine import auxiliary as aux
 
 import numpy as np
 import pytest

--- a/pydra/engine/tests/test_newnode.py
+++ b/pydra/engine/tests/test_newnode.py
@@ -27,7 +27,7 @@ def change_dir(request):
     request.addfinalizer(move2orig)
 
 
-plugins = ["serial", "mp", "cf", "dask"]
+PLUGINS = ["serial", "mp", "cf", "dask"]
 
 
 def fun_addtwo(a):
@@ -102,7 +102,7 @@ def test_node_4a():
     assert nn.state.state_values([1]) == {"NA.a": 5}
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_node_5(plugin, change_dir):
     """Node with interface and inputs, no mapper, running interface"""
@@ -131,7 +131,7 @@ def test_node_5(plugin, change_dir):
         assert nn.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_node_6(plugin, change_dir):
     """Node with interface, inputs and the simplest mapper, running interface"""
@@ -158,7 +158,7 @@ def test_node_6(plugin, change_dir):
         assert nn.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_node_7(plugin, change_dir):
     """Node with interface, inputs and scalar mapper, running interface"""
@@ -187,7 +187,7 @@ def test_node_7(plugin, change_dir):
         assert nn.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_node_8(plugin, change_dir):
     """Node with interface, inputs and vector mapper, running interface"""
@@ -245,7 +245,7 @@ def test_workflow_0(plugin="serial"):
     assert len(wf.graph.nodes) == 1
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_1(plugin, change_dir):
     """workflow with one node with a mapper"""
@@ -268,7 +268,7 @@ def test_workflow_1(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_2(plugin, change_dir):
     """workflow with two nodes, second node without mapper"""
@@ -309,7 +309,7 @@ def test_workflow_2(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_2a(plugin, change_dir):
     """workflow with two nodes, second node with a scalar mapper"""
@@ -351,7 +351,7 @@ def test_workflow_2a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_2b(plugin):
     """workflow with two nodes, second node with a vector mapper"""
@@ -408,7 +408,7 @@ def test_workflow_2b(plugin):
 # using add method to add nodes
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_3(plugin, change_dir):
     """using add(node) method"""
@@ -434,7 +434,7 @@ def test_workflow_3(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_3a(plugin, change_dir):
     """using add(interface) method"""
@@ -459,7 +459,7 @@ def test_workflow_3a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_3b(plugin, change_dir):
     """using add (function) method"""
@@ -482,7 +482,7 @@ def test_workflow_3b(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_4(plugin, change_dir):
     """ using add(node) method
@@ -524,7 +524,7 @@ def test_workflow_4(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_4a(plugin, change_dir):
     """ using add(node) method with kwarg arg to connect nodes (instead of wf.connect) """
@@ -565,7 +565,7 @@ def test_workflow_4a(plugin, change_dir):
 # using map after add method
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_5(plugin, change_dir):
     """using a map method for one node"""
@@ -590,7 +590,7 @@ def test_workflow_5(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_5a(plugin, change_dir):
     """using a map method for one node (using add and map in one chain)"""
@@ -613,7 +613,7 @@ def test_workflow_5a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_6(plugin, change_dir):
     """using a map method for two nodes (using last added node as default)"""
@@ -651,7 +651,7 @@ def test_workflow_6(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_6a(plugin, change_dir):
     """using a map method for two nodes (specifying the node)"""
@@ -690,7 +690,7 @@ def test_workflow_6a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_6b(plugin, change_dir):
     """using a map method for two nodes (specifying the node), using kwarg arg instead of connect"""
@@ -730,7 +730,7 @@ def test_workflow_6b(plugin, change_dir):
 # tests for a workflow that have its own input
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_7(plugin, change_dir):
     """using inputs for workflow and connect_workflow"""
@@ -757,7 +757,7 @@ def test_workflow_7(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_7a(plugin, change_dir):
     """using inputs for workflow and kwarg arg in add (instead of connect)"""
@@ -781,7 +781,7 @@ def test_workflow_7a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_8(plugin, change_dir):
     """using inputs for workflow and connect_wf_input for the second node"""
@@ -822,7 +822,7 @@ def test_workflow_8(plugin, change_dir):
 # testing if _NA in mapper works, using interfaces in add
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_9(plugin, change_dir):
     """using add(interface) method and mapper from previous nodes"""
@@ -858,7 +858,7 @@ def test_workflow_9(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_10(plugin, change_dir):
     """using add(interface) method and scalar mapper from previous nodes"""
@@ -897,7 +897,7 @@ def test_workflow_10(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_10a(plugin, change_dir):
     """using add(interface) method and vector mapper from previous nodes"""
@@ -964,7 +964,7 @@ def test_workflow_10a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_11(plugin, change_dir):
     """using add(interface) method and vector mapper from previous two nodes"""
@@ -1026,7 +1026,7 @@ def test_workflow_11(plugin, change_dir):
 # checking workflow.result
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_12(plugin, change_dir):
     """testing if wf.result works (the same workflow as in test_workflow_6)"""
@@ -1073,7 +1073,7 @@ def test_workflow_12(plugin, change_dir):
         assert wf.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_12a(plugin, change_dir):
     """testing if wf.result raises exceptione (the same workflow as in test_workflow_6)"""
@@ -1103,7 +1103,7 @@ def test_workflow_12a(plugin, change_dir):
 # tests for a workflow that have its own input and mapper
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_13(plugin, change_dir):
     """using inputs for workflow and connect_wf_input"""
@@ -1130,7 +1130,7 @@ def test_workflow_13(plugin, change_dir):
         assert wf.result["NA_out"][i][1][0][1] == res[1][0][1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_13a(plugin, change_dir):
     """using inputs for workflow and connect_wf_input (the node has 2 inputs)"""
@@ -1175,7 +1175,7 @@ def test_workflow_13a(plugin, change_dir):
             assert wf.result["NA_out"][i][1][j][1] == res[1][j][1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_13c(plugin, change_dir):
     """using inputs for workflow and connect_wf_input, using wf.map(mapper, inputs)"""
@@ -1199,7 +1199,7 @@ def test_workflow_13c(plugin, change_dir):
         assert wf.result["NA_out"][i][1][0][0] == res[1][0][0]
         assert wf.result["NA_out"][i][1][0][1] == res[1][0][1]
 
-    @pytest.mark.parametrize("plugin", plugins)
+    @pytest.mark.parametrize("plugin", PLUGINS)
     @python35_only
     def test_workflow_13b(plugin, change_dir):
         """using inputs for workflow and connect_wf_input, using wf.map(mapper)"""
@@ -1228,7 +1228,7 @@ def test_workflow_13c(plugin, change_dir):
 # workflow as a node
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_14(plugin, change_dir):
     """workflow with a workflow as a node (no mapper)"""
@@ -1254,7 +1254,7 @@ def test_workflow_14(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_14a(plugin, change_dir):
     """workflow with a workflow as a node (no mapper, using connect_wf_input in wfa)"""
@@ -1285,7 +1285,7 @@ def test_workflow_14a(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_14b(plugin, change_dir):
     """workflow with a workflow as a node (no mapper, using connect_wf_input in wfa and wf)"""
@@ -1314,7 +1314,7 @@ def test_workflow_14b(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_15(plugin, change_dir):
     """workflow with a workflow as a node with mapper (like 14 but with a mapper)"""
@@ -1341,7 +1341,7 @@ def test_workflow_15(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_16(plugin, change_dir):
     """workflow with two nodes, and one is a workflow (no mapper)"""
@@ -1386,7 +1386,7 @@ def test_workflow_16(plugin, change_dir):
         assert wf.result["NB_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_workflow_16a(plugin, change_dir):
     """workflow with two nodes, and one is a workflow (with mapper)"""
@@ -1443,7 +1443,7 @@ def test_workflow_16a(plugin, change_dir):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_node_1(change_dir, plugin):
     """Node with a current interface and inputs, no mapper, running interface"""
@@ -1468,7 +1468,7 @@ def test_current_node_1(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_node_2(change_dir, plugin):
     """Node with a current interface and mapper"""
@@ -1498,7 +1498,7 @@ def test_current_node_2(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_wf_1(change_dir, plugin):
     """Wf with a current interface, no mapper"""
@@ -1531,7 +1531,7 @@ def test_current_wf_1(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_wf_1a(change_dir, plugin):
     """Wf with a current interface, no mapper"""
@@ -1564,7 +1564,7 @@ def test_current_wf_1a(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_wf_1b(change_dir, plugin):
     """Wf with a current interface, no mapper; using wf.add(nipype CurrentInterface)"""
@@ -1595,7 +1595,7 @@ def test_current_wf_1b(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_wf_1c(change_dir, plugin):
     """Wf with a current interface, no mapper; using wf.add(nipype interface) """
@@ -1625,7 +1625,7 @@ def test_current_wf_1c(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_wf_2(change_dir, plugin):
     """Wf with a current interface and mapper"""
@@ -1664,7 +1664,7 @@ def test_current_wf_2(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", plugins)
+@pytest.mark.parametrize("plugin", PLUGINS)
 @python35_only
 def test_current_wf_2a(change_dir, plugin):
     """Wf with a current interface and mapper"""

--- a/pydra/engine/tests/test_newnode.py
+++ b/pydra/engine/tests/test_newnode.py
@@ -1,13 +1,15 @@
+import os
+import sys
+import time
+
 from nipype.utils.filemanip import save_json, makedirs, to_str
 from nipype.interfaces import fsl
-
-from ..node import Node, Workflow
-from ..auxiliary import FunctionInterface, CurrentInterface
-from ..submitter import Submitter
-
-import sys, time, os
 import numpy as np
-import pytest, pdb
+import pytest
+
+from pydra.engine.node import Node, Workflow
+from pydra.engine.auxiliary import FunctionInterface, CurrentInterface
+from pydra.engine.submitter import Submitter
 
 python35_only = pytest.mark.skipif(sys.version_info < (3, 5), reason="requires Python>3.4")
 
@@ -25,8 +27,7 @@ def change_dir(request):
     request.addfinalizer(move2orig)
 
 
-Plugins = ["serial"]
-Plugins = ["serial", "mp", "cf", "dask"]
+plugins = ["serial", "mp", "cf", "dask"]
 
 
 def fun_addtwo(a):
@@ -101,7 +102,7 @@ def test_node_4a():
     assert nn.state.state_values([1]) == {"NA.a": 5}
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_node_5(plugin, change_dir):
     """Node with interface and inputs, no mapper, running interface"""
@@ -130,7 +131,7 @@ def test_node_5(plugin, change_dir):
         assert nn.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_node_6(plugin, change_dir):
     """Node with interface, inputs and the simplest mapper, running interface"""
@@ -157,7 +158,7 @@ def test_node_6(plugin, change_dir):
         assert nn.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_node_7(plugin, change_dir):
     """Node with interface, inputs and scalar mapper, running interface"""
@@ -186,7 +187,7 @@ def test_node_7(plugin, change_dir):
         assert nn.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_node_8(plugin, change_dir):
     """Node with interface, inputs and vector mapper, running interface"""
@@ -244,7 +245,7 @@ def test_workflow_0(plugin="serial"):
     assert len(wf.graph.nodes) == 1
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_1(plugin, change_dir):
     """workflow with one node with a mapper"""
@@ -267,7 +268,7 @@ def test_workflow_1(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_2(plugin, change_dir):
     """workflow with two nodes, second node without mapper"""
@@ -308,7 +309,7 @@ def test_workflow_2(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_2a(plugin, change_dir):
     """workflow with two nodes, second node with a scalar mapper"""
@@ -350,7 +351,7 @@ def test_workflow_2a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_2b(plugin):
     """workflow with two nodes, second node with a vector mapper"""
@@ -407,7 +408,7 @@ def test_workflow_2b(plugin):
 # using add method to add nodes
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_3(plugin, change_dir):
     """using add(node) method"""
@@ -433,7 +434,7 @@ def test_workflow_3(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_3a(plugin, change_dir):
     """using add(interface) method"""
@@ -458,7 +459,7 @@ def test_workflow_3a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_3b(plugin, change_dir):
     """using add (function) method"""
@@ -481,7 +482,7 @@ def test_workflow_3b(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_4(plugin, change_dir):
     """ using add(node) method
@@ -523,7 +524,7 @@ def test_workflow_4(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_4a(plugin, change_dir):
     """ using add(node) method with kwarg arg to connect nodes (instead of wf.connect) """
@@ -564,7 +565,7 @@ def test_workflow_4a(plugin, change_dir):
 # using map after add method
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_5(plugin, change_dir):
     """using a map method for one node"""
@@ -589,7 +590,7 @@ def test_workflow_5(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_5a(plugin, change_dir):
     """using a map method for one node (using add and map in one chain)"""
@@ -612,7 +613,7 @@ def test_workflow_5a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_6(plugin, change_dir):
     """using a map method for two nodes (using last added node as default)"""
@@ -650,7 +651,7 @@ def test_workflow_6(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_6a(plugin, change_dir):
     """using a map method for two nodes (specifying the node)"""
@@ -689,7 +690,7 @@ def test_workflow_6a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_6b(plugin, change_dir):
     """using a map method for two nodes (specifying the node), using kwarg arg instead of connect"""
@@ -729,7 +730,7 @@ def test_workflow_6b(plugin, change_dir):
 # tests for a workflow that have its own input
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_7(plugin, change_dir):
     """using inputs for workflow and connect_workflow"""
@@ -756,7 +757,7 @@ def test_workflow_7(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_7a(plugin, change_dir):
     """using inputs for workflow and kwarg arg in add (instead of connect)"""
@@ -780,7 +781,7 @@ def test_workflow_7a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_8(plugin, change_dir):
     """using inputs for workflow and connect_wf_input for the second node"""
@@ -821,7 +822,7 @@ def test_workflow_8(plugin, change_dir):
 # testing if _NA in mapper works, using interfaces in add
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_9(plugin, change_dir):
     """using add(interface) method and mapper from previous nodes"""
@@ -857,7 +858,7 @@ def test_workflow_9(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_10(plugin, change_dir):
     """using add(interface) method and scalar mapper from previous nodes"""
@@ -896,7 +897,7 @@ def test_workflow_10(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_10a(plugin, change_dir):
     """using add(interface) method and vector mapper from previous nodes"""
@@ -963,7 +964,7 @@ def test_workflow_10a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_11(plugin, change_dir):
     """using add(interface) method and vector mapper from previous two nodes"""
@@ -1025,7 +1026,7 @@ def test_workflow_11(plugin, change_dir):
 # checking workflow.result
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_12(plugin, change_dir):
     """testing if wf.result works (the same workflow as in test_workflow_6)"""
@@ -1058,7 +1059,6 @@ def test_workflow_12(plugin, change_dir):
     key_sort = list(expected[0][0].keys())
     expected.sort(key=lambda t: [t[0][key] for key in key_sort])
     wf.result["NA_out"].sort(key=lambda t: [t[0][key] for key in key_sort])
-    #pdb.set_trace()
     assert wf.is_complete
     for i, res in enumerate(expected):
         assert wf.result["NA_out"][i][0] == res[0]
@@ -1073,7 +1073,7 @@ def test_workflow_12(plugin, change_dir):
         assert wf.result["out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_12a(plugin, change_dir):
     """testing if wf.result raises exceptione (the same workflow as in test_workflow_6)"""
@@ -1103,7 +1103,7 @@ def test_workflow_12a(plugin, change_dir):
 # tests for a workflow that have its own input and mapper
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_13(plugin, change_dir):
     """using inputs for workflow and connect_wf_input"""
@@ -1130,7 +1130,7 @@ def test_workflow_13(plugin, change_dir):
         assert wf.result["NA_out"][i][1][0][1] == res[1][0][1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_13a(plugin, change_dir):
     """using inputs for workflow and connect_wf_input (the node has 2 inputs)"""
@@ -1175,7 +1175,7 @@ def test_workflow_13a(plugin, change_dir):
             assert wf.result["NA_out"][i][1][j][1] == res[1][j][1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_13c(plugin, change_dir):
     """using inputs for workflow and connect_wf_input, using wf.map(mapper, inputs)"""
@@ -1199,7 +1199,7 @@ def test_workflow_13c(plugin, change_dir):
         assert wf.result["NA_out"][i][1][0][0] == res[1][0][0]
         assert wf.result["NA_out"][i][1][0][1] == res[1][0][1]
 
-    @pytest.mark.parametrize("plugin", Plugins)
+    @pytest.mark.parametrize("plugin", plugins)
     @python35_only
     def test_workflow_13b(plugin, change_dir):
         """using inputs for workflow and connect_wf_input, using wf.map(mapper)"""
@@ -1228,7 +1228,7 @@ def test_workflow_13c(plugin, change_dir):
 # workflow as a node
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_14(plugin, change_dir):
     """workflow with a workflow as a node (no mapper)"""
@@ -1254,7 +1254,7 @@ def test_workflow_14(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_14a(plugin, change_dir):
     """workflow with a workflow as a node (no mapper, using connect_wf_input in wfa)"""
@@ -1285,7 +1285,7 @@ def test_workflow_14a(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_14b(plugin, change_dir):
     """workflow with a workflow as a node (no mapper, using connect_wf_input in wfa and wf)"""
@@ -1314,7 +1314,7 @@ def test_workflow_14b(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_15(plugin, change_dir):
     """workflow with a workflow as a node with mapper (like 14 but with a mapper)"""
@@ -1341,7 +1341,7 @@ def test_workflow_15(plugin, change_dir):
         assert wf.result["wfa_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_16(plugin, change_dir):
     """workflow with two nodes, and one is a workflow (no mapper)"""
@@ -1386,7 +1386,7 @@ def test_workflow_16(plugin, change_dir):
         assert wf.result["NB_out"][i][1] == res[1]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_workflow_16a(plugin, change_dir):
     """workflow with two nodes, and one is a workflow (with mapper)"""
@@ -1443,7 +1443,7 @@ def test_workflow_16a(plugin, change_dir):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_node_1(change_dir, plugin):
     """Node with a current interface and inputs, no mapper, running interface"""
@@ -1468,7 +1468,7 @@ def test_current_node_1(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_node_2(change_dir, plugin):
     """Node with a current interface and mapper"""
@@ -1498,7 +1498,7 @@ def test_current_node_2(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_wf_1(change_dir, plugin):
     """Wf with a current interface, no mapper"""
@@ -1531,7 +1531,7 @@ def test_current_wf_1(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_wf_1a(change_dir, plugin):
     """Wf with a current interface, no mapper"""
@@ -1564,7 +1564,7 @@ def test_current_wf_1a(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_wf_1b(change_dir, plugin):
     """Wf with a current interface, no mapper; using wf.add(nipype CurrentInterface)"""
@@ -1595,7 +1595,7 @@ def test_current_wf_1b(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_wf_1c(change_dir, plugin):
     """Wf with a current interface, no mapper; using wf.add(nipype interface) """
@@ -1625,7 +1625,7 @@ def test_current_wf_1c(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_wf_2(change_dir, plugin):
     """Wf with a current interface and mapper"""
@@ -1664,7 +1664,7 @@ def test_current_wf_2(change_dir, plugin):
 
 @pytest.mark.skipif(
     not os.path.exists("/Users/dorota/nipype_workshop/data/ds000114"), reason="adding data")
-@pytest.mark.parametrize("plugin", Plugins)
+@pytest.mark.parametrize("plugin", plugins)
 @python35_only
 def test_current_wf_2a(change_dir, plugin):
     """Wf with a current interface and mapper"""

--- a/pydra/engine/tests/test_newnode_neuro.py
+++ b/pydra/engine/tests/test_newnode_neuro.py
@@ -32,7 +32,7 @@ def change_dir(request):
 name = "example"
 DEFAULT_MEMORY_MIN_GB = None
 # TODO, adding fields to inputs (subject_id)
-inputs = {
+INPUTS = {
     "subject_id":
     "sub-01",
     "output_spaces": ["fsaverage", "fsaverage5"],
@@ -68,7 +68,7 @@ def test_neuro(change_dir, plugin):
 
     wf = Workflow(
         name=name,
-        inputs=inputs,
+        inputs=INPUTS,
         workingdir="test_neuro_{}".format(plugin),
         write_state=False,
         wf_output_names=[("sampler", "out_file", "sampler_out"), ("targets", "out", "target_out")])
@@ -86,7 +86,7 @@ def test_neuro(change_dir, plugin):
 
     wf.add(runnable=select_target, name="targets", subject_id="subject_id", output_names=["out"],
            out_read=True, write_state=False)\
-        .map_node(mapper="space", inputs={"space": [space for space in inputs["output_spaces"]
+        .map_node(mapper="space", inputs={"space": [space for space in INPUTS["output_spaces"]
                                                if space.startswith("fs")]})
 
     # wf.add('rename_src', Rename(format_string='%(subject)s',
@@ -99,7 +99,7 @@ def test_neuro(change_dir, plugin):
                                 in_file="source_file",
                                 output_names=["out_file"],
            write_state=False)\
-        .map_node('subject', inputs={"subject": [space for space in inputs["output_spaces"]
+        .map_node('subject', inputs={"subject": [space for space in INPUTS["output_spaces"]
                                                if space.startswith("fs")]}) #TODO: now it's only one subject
 
     # wf.add('resampling_xfm',

--- a/pydra/engine/tests/test_utils.py
+++ b/pydra/engine/tests/test_utils.py
@@ -1,0 +1,18 @@
+"""Tests for `pydra.engine.utils`."""
+import pytest
+
+from pydra.engine import utils
+
+def test__check_dependencies():
+    @utils._check_dependencies("42", "hunter3")
+    def foo():
+        return True
+
+    with pytest.raises(ImportError):
+        foo()
+
+    @utils._check_dependencies("os")
+    def bar():
+        return True
+
+    assert bar()

--- a/pydra/engine/tests/test_workers.py
+++ b/pydra/engine/tests/test_workers.py
@@ -1,0 +1,20 @@
+"""Tests for `pydra.engine.workers`."""
+import pytest
+
+from pydra.engine import workers
+
+
+def test__get_worker():
+    assert isinstance(workers._get_worker("mp")(), workers.MpWorker)
+    assert isinstance(workers._get_worker("serial")(), workers.SerialWorker)
+    assert isinstance(workers._get_worker("cf")(), workers.ConcurrentFuturesWorker)
+    assert isinstance(workers._get_worker("dask")(), workers.DaskWorker)
+
+    w = workers.SerialWorker
+    assert workers._get_worker(w) is w
+
+    w = workers.SerialWorker()
+    assert workers._get_worker(w) is w
+
+    with pytest.raises(KeyError):
+        workers._get_worker("not_a_plugin")

--- a/pydra/engine/utils.py
+++ b/pydra/engine/utils.py
@@ -1,0 +1,23 @@
+"""Utilities for `pydra.engine`."""
+import functools
+import importlib
+
+
+def _check_dependencies(*pkgs):
+    """Decorator to check that `*pkgs` are available."""
+
+    def f(function):
+        @functools.wraps(function)
+        def g(*args, **kwargs):
+            for p in pkgs:
+                try:
+                    importlib.import_module(p)
+                except ModuleNotFoundError:
+                    msg = "The Python package '{}' is required for this functionality but is not installed."
+                    raise ImportError(msg.format(p))
+
+            return function(*args, **kwargs)
+
+        return g
+
+    return f


### PR DESCRIPTION
This PR proposes

- using absolute imports
- adding a function decorator `pydra.engine.utils._check_dependencies` to verify that python dependencies are installed (e.g., dask and distributed for `DaskWorker`)
- function `pydra.engine.workers._get_worker` to get a worker object from a string (cleans up the code in `Submitter`).
- changes to style (e.g., using `isinstance(x, y) instead of `type(x) is y`.
- tests for `pydra.engine.utils._check_dependencies` and `pydra.engine.workers._get_worker`.