### PR TITLE
Fix: loop management

### DIFF
--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -13,7 +13,7 @@ class Submitter:
     # TODO: runnable in init or run
     def __init__(self, plugin):
         self.loop = get_open_loop()
-        self._running_loop = self.loop.is_running()
+        self._own_loop = not self.loop.is_running()
         self.plugin = plugin
         if self.plugin == "serial":
             self.worker = SerialWorker()

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -13,6 +13,7 @@ class Submitter:
     # TODO: runnable in init or run
     def __init__(self, plugin):
         self.loop = get_open_loop()
+        self._running_loop = self.loop.is_running()
         self.plugin = plugin
         if self.plugin == "serial":
             self.worker = SerialWorker()
@@ -147,7 +148,9 @@ class Submitter:
             return futures
 
     def close(self):
-        self.loop.close()
+        # do not close previously running loop
+        if not self._running_loop:
+            self.loop.close()
         self.worker.close()
 
 

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -149,7 +149,7 @@ class Submitter:
 
     def close(self):
         # do not close previously running loop
-        if not self._running_loop:
+        if self._own_loop:
             self.loop.close()
         self.worker.close()
 


### PR DESCRIPTION
Only close event loops that we create.

This should make it possible to submit Pydra tasks with a Jupyter notebook, after patching nested event loops with:

```python
import nest_asyncio
nest_asyncio.apply()
```