### PR TITLE
Fix/checksum

### DIFF
--- a/pydra/engine/audit.py
+++ b/pydra/engine/audit.py
@@ -1,5 +1,6 @@
 import os, json
 from pathlib import Path
+import dataclasses as dc
 from ..utils.messenger import send_message, make_message, gen_uuid, now, AuditFlag
 from .helpers import ensure_list, gather_runtime_info
 

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -164,10 +164,16 @@ class TaskBase:
         """calculating checksum
         """
         if self.state is None:
-            input_hash = self.inputs.hash
+            input_hash = self.inputs.hash()
             self._checksum = "_".join((self.__class__.__name__, input_hash))
         else:
-            self._checksum = {sidx: res[1] for (sidx, res) in self.results_dict.items()}
+            self._checksum = {}
+            self.state.prepare_states(self.inputs)
+            self.state.prepare_inputs()
+            for sidx, inp in enumerate(self.state.states_val):
+                inp_repl = {key.split(".")[1]: val for (key, val) in inp.items()}
+                input_hash = self.inputs.hash(replace=inp_repl)
+                self._checksum[sidx] = "_".join((self.__class__.__name__, input_hash))
         return self._checksum
 
     def set_state(self, splitter, combiner=None):

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -152,10 +152,6 @@ def execute(cmd):
     return rc, stdout, stderr
 
 
-def create_checksum(name, inputs):
-    return "_".join((name, inputs.hash))
-
-
 def record_error(error_path, error):
     with (error_path / "_error.pklz").open("wb") as fp:
         cp.dump(error, fp)

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -5,6 +5,7 @@ import cloudpickle as cp
 from pathlib import Path
 import os
 import sys
+from hashlib import sha256
 
 from .specs import Runtime
 
@@ -152,6 +153,10 @@ def execute(cmd):
     return rc, stdout, stderr
 
 
+def create_checksum(name, inputs):
+    return "_".join((name, inputs))
+
+
 def record_error(error_path, error):
     with (error_path / "_error.pklz").open("wb") as fp:
         cp.dump(error, fp)
@@ -172,3 +177,7 @@ def get_open_loop():
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     return loop
+
+
+def hash_function(obj):
+    return sha256(str(obj).encode()).hexdigest()

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -18,18 +18,19 @@ class SpecInfo:
 class BaseSpec:
     """The base dataclass specs for all inputs and outputs"""
 
-    @property
-    def hash(self):
+    def hash(self, replace=None):
         """Compute a basic hash for any given set of fields"""
         inp_dict = {
             field.name: getattr(self, field.name)
             for field in dc.fields(self)
             if field.name not in ["_graph"]
         }
+        if replace:
+            inp_dict.update(replace)
         inp_hash = self._hash(inp_dict)
         if hasattr(self, "_graph"):
-
-            graph_hash = [nd.checksum for nd in self._graph]
+            # calculating inputs.hash for every node inside the graph
+            graph_hash = [nd.inputs.hash() for nd in self._graph]
             return self._hash((inp_hash, graph_hash))
         else:
             return inp_hash
@@ -44,7 +45,6 @@ class BaseSpec:
             if isinstance(value, LazyField):
                 value = value.get_value(wf, state_index=state_index)
                 temp_values[field.name] = value
-        # dj: changes the outputd_dir (node is updating input)
         for field, value in temp_values.items():
             setattr(self, field, value)
 

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -148,7 +148,7 @@ def to_task(func_to_decorate):
 class ShellCommandTask(TaskBase):
     def __init__(
         self,
-        name,
+        name=None,
         input_spec: ty.Optional[SpecInfo] = None,
         output_spec: ty.Optional[SpecInfo] = None,
         audit_flags: AuditFlag = AuditFlag.NONE,

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -192,6 +192,7 @@ def test_task_nostate_1(plugin):
     nn = fun_addtwo(name="NA", a=3)
     assert np.allclose(nn.inputs.a, [3])
     assert nn.state is None
+    odir_orig = nn.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -199,6 +200,9 @@ def test_task_nostate_1(plugin):
     # checking the results
     results = nn.result()
     assert results.output.out == 5
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    assert nn.output_dir.exists()
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -207,6 +211,7 @@ def test_task_nostate_1_call_subm(plugin):
     nn = fun_addtwo(name="NA", a=3)
     assert np.allclose(nn.inputs.a, [3])
     assert nn.state is None
+    odir_orig = nn.output_dir
 
     with Submitter(plugin=plugin) as sub:
         nn(submitter=sub)
@@ -214,6 +219,9 @@ def test_task_nostate_1_call_subm(plugin):
     # checking the results
     results = nn.result()
     assert results.output.out == 5
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    assert nn.output_dir.exists()
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -228,6 +236,8 @@ def test_task_nostate_1_call_plug(plugin):
     # checking the results
     results = nn.result()
     assert results.output.out == 5
+    # checking the output_dir
+    assert nn.output_dir.exists()
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -237,6 +247,7 @@ def test_task_nostate_2(plugin):
     assert np.allclose(nn.inputs.n, [3])
     assert np.allclose(nn.inputs.lst, [2, 3, 4])
     assert nn.state is None
+    odir_orig = nn.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -244,6 +255,9 @@ def test_task_nostate_2(plugin):
     # checking the results
     results = nn.result()
     assert results.output.out == 33
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    assert nn.output_dir.exists()
 
 
 # Testing caching for tasks without states
@@ -351,6 +365,8 @@ def test_task_state_1(plugin):
     assert nn.state.splitter == "NA.a"
     assert nn.state.splitter_rpn == ["NA.a"]
     assert (nn.inputs.a == np.array([3, 5])).all()
+    odir_orig = nn.output_dir
+    assert odir_orig  # checking if this is not an empty dictionary
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -360,6 +376,10 @@ def test_task_state_1(plugin):
     expected = [({"NA.a": 3}, 5), ({"NA.a": 5}, 7)]
     for i, res in enumerate(expected):
         assert results[i].output.out == res[1]
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    for _, odir in nn.output_dir.items():
+        assert odir.exists()
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -416,6 +436,8 @@ def test_task_state_2(plugin, splitter, state_splitter, state_rpn, expected):
     assert nn.state.splitter_rpn == state_rpn
     assert nn.state.splitter_final == state_splitter
     assert nn.state.splitter_rpn_final == state_rpn
+    odir_orig = nn.output_dir
+    assert odir_orig
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -424,6 +446,10 @@ def test_task_state_2(plugin, splitter, state_splitter, state_rpn, expected):
     results = nn.result()
     for i, res in enumerate(expected):
         assert results[i].output.out == res[1]
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    for _, odir in nn.output_dir.items():
+        assert odir.exists()
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -439,6 +465,8 @@ def test_task_state_singl_1(plugin):
     assert nn.state.splitter_rpn == ["NA.a"]
     assert nn.state.splitter_final == "NA.a"
     assert nn.state.splitter_rpn_final == ["NA.a"]
+    odir_orig = nn.output_dir
+    assert odir_orig
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -448,6 +476,10 @@ def test_task_state_singl_1(plugin):
     results = nn.result()
     for i, res in enumerate(expected):
         assert results[i].output.out == res[1]
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    for _, odir in nn.output_dir.items():
+        assert odir.exists()
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -462,6 +494,8 @@ def test_task_state_comb_1(plugin):
     assert nn.state.combiner == ["NA.a"]
     assert nn.state.splitter_final is None
     assert nn.state.splitter_rpn_final == []
+    odir_orig = nn.output_dir
+    assert odir_orig
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -476,6 +510,10 @@ def test_task_state_comb_1(plugin):
     expected = [({}, [5, 7])]
     for i, res in enumerate(expected):
         assert combined_results[i] == res[1]
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    for _, odir in nn.output_dir.items():
+        assert odir.exists()
 
 
 @pytest.mark.parametrize(
@@ -568,6 +606,8 @@ def test_task_state_comb_2(
     assert nn.state.splitter_final == state_splitter_final
     assert nn.state.splitter_rpn_final == state_rpn_final
     assert set(nn.state.right_combiner_all) == set(state_combiner_all)
+    odir_orig = nn.output_dir
+    assert odir_orig
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -578,6 +618,10 @@ def test_task_state_comb_2(
     combined_results = [[res.output.out for res in res_l] for res_l in results]
     for i, res in enumerate(expected):
         assert combined_results[i] == res[1]
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    for _, odir in nn.output_dir.items():
+        assert odir.exists()
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -594,6 +638,8 @@ def test_task_state_comb_singl_1(plugin):
     assert nn.state.combiner == ["NA.a"]
     assert nn.state.splitter_final == None
     assert nn.state.splitter_rpn_final == []
+    odir_orig = nn.output_dir
+    assert odir_orig
 
     with Submitter(plugin=plugin) as sub:
         sub(nn)
@@ -604,6 +650,10 @@ def test_task_state_comb_singl_1(plugin):
     combined_results = [[res.output.out for res in res_l] for res_l in results]
     for i, res in enumerate(expected):
         assert combined_results[i] == res[1]
+    # checking the output_dir
+    assert nn.output_dir == odir_orig
+    for _, odir in nn.output_dir.items():
+        assert odir.exists()
 
 
 # Testing caching for tasks with states

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -74,10 +74,6 @@ def test_task_init_2():
     # adding NA to the name of the variable
     assert getattr(nn.inputs, "a") == 3
     assert nn.state is None
-    assert (
-        nn.checksum
-        == "FunctionTask_3cdd9d5ca28649cc1c823bfb06365cf5ecf19551b8823df87a3ba9e5439bc32c"
-    )
 
 
 @pytest.mark.parametrize(

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -74,6 +74,10 @@ def test_task_init_2():
     # adding NA to the name of the variable
     assert getattr(nn.inputs, "a") == 3
     assert nn.state is None
+    assert (
+        nn.checksum
+        == "FunctionTask_3cdd9d5ca28649cc1c823bfb06365cf5ecf19551b8823df87a3ba9e5439bc32c"
+    )
 
 
 @pytest.mark.parametrize(

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -15,8 +15,7 @@ import pytest
 def test_basespec():
     spec = BaseSpec()
     assert (
-        spec.hash()
-        == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        spec.hash == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
     )
 
 

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -15,7 +15,8 @@ import pytest
 def test_basespec():
     spec = BaseSpec()
     assert (
-        spec.hash == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        spec.hash()
+        == "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
     )
 
 

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -32,7 +32,7 @@ def test_annotated_func():
     assert getattr(funky.inputs, "_func") is not None
     assert set(funky.output_names) == set(["out1"])
     # assert funky.inputs.hash == '17772c3aec9540a8dd3e187eecd2301a09c9a25c6e371ddd86e31e3a1ecfeefa'
-    assert funky.__class__.__name__ + "_" + funky.inputs.hash == funky.checksum
+    assert funky.__class__.__name__ + "_" + funky.inputs.hash() == funky.checksum
 
     result = funky()
     assert hasattr(result, "output")
@@ -73,7 +73,7 @@ def test_halfannotated_func():
     assert getattr(funky.inputs, "b") == 20
     assert getattr(funky.inputs, "_func") is not None
     assert set(funky.output_names) == set(["out1", "out2"])
-    assert funky.__class__.__name__ + "_" + funky.inputs.hash == funky.checksum
+    assert funky.__class__.__name__ + "_" + funky.inputs.hash() == funky.checksum
 
     result = funky()
     assert hasattr(result, "output")

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -32,7 +32,7 @@ def test_annotated_func():
     assert getattr(funky.inputs, "_func") is not None
     assert set(funky.output_names) == set(["out1"])
     # assert funky.inputs.hash == '17772c3aec9540a8dd3e187eecd2301a09c9a25c6e371ddd86e31e3a1ecfeefa'
-    assert funky.__class__.__name__ + "_" + funky.inputs.hash() == funky.checksum
+    assert funky.__class__.__name__ + "_" + funky.inputs.hash == funky.checksum
 
     result = funky()
     assert hasattr(result, "output")
@@ -73,7 +73,7 @@ def test_halfannotated_func():
     assert getattr(funky.inputs, "b") == 20
     assert getattr(funky.inputs, "_func") is not None
     assert set(funky.output_names) == set(["out1", "out2"])
-    assert funky.__class__.__name__ + "_" + funky.inputs.hash() == funky.checksum
+    assert funky.__class__.__name__ + "_" + funky.inputs.hash == funky.checksum
 
     result = funky()
     assert hasattr(result, "output")

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -175,7 +175,7 @@ def test_shell_cmd(tmpdir):
     assert res.output.stdout == " ".join(cmd[1:]) + "\n"
 
     # separate command into exec + args
-    shelly = ShellCommandTask(name="test", executable=cmd[0], args=cmd[1:])
+    shelly = ShellCommandTask(executable=cmd[0], args=cmd[1:])
     assert shelly.inputs.executable == "echo"
     assert shelly.cmdline == " ".join(cmd)
     res = shelly._run()

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -18,10 +18,6 @@ def test_output():
     assert res.output.out == 5
 
 
-@pytest.mark.xfail(
-    reason="when task run without submitter, results are not collected,"
-    "so result() method will not work"
-)
 def test_annotated_func():
     @to_task
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out1", float)]):
@@ -64,10 +60,6 @@ def test_annotated_func():
     ]
 
 
-@pytest.mark.xfail(
-    reason="when task run without submitter, results are not collected,"
-    "so result() method will not work"
-)
 def test_halfannotated_func():
     @to_task
     def testfunc(a, b) -> (int, int):
@@ -135,7 +127,7 @@ def test_exception_func():
     assert pytest.raises(Exception, bad_funk)
 
 
-@pytest.mark.xfail(reason="errors with RDF, need to ask Satra")
+@pytest.mark.xfail(reason="errors from cloudpickle")
 def test_audit(tmpdir):
     @to_task
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out", float)]):
@@ -160,7 +152,6 @@ def test_audit(tmpdir):
     assert (tmpdir / funky.checksum / "messages.jsonld").exists()
 
 
-@pytest.mark.xfail(reason="problems with pickling? need to ask Satra")
 def test_shell_cmd(tmpdir):
     cmd = ["echo", "hail", "pydra"]
 
@@ -171,7 +162,7 @@ def test_shell_cmd(tmpdir):
     assert res.output.stdout == " ".join(cmd[1:]) + "\n"
 
     # separate command into exec + args
-    shelly = ShellCommandTask(executable=cmd[0], args=cmd[1:])
+    shelly = ShellCommandTask(name="test", executable=cmd[0], args=cmd[1:])
     assert shelly.inputs.executable == "echo"
     assert shelly.cmdline == " ".join(cmd)
     res = shelly._run()

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -18,6 +18,19 @@ def test_output():
     assert res.output.out == 5
 
 
+@pytest.mark.xfail(reason="cp.dumps(func) depends on the system/setup, TODO!!")
+def test_checksum():
+    @to_task
+    def funaddtwo(a):
+        return a + 2
+
+    nn = funaddtwo(a=3)
+    assert (
+        nn.checksum
+        == "FunctionTask_abb4e7cc03b13d0e73884b87d142ed5deae6a312275187a9d8df54407317d7d3"
+    )
+
+
 def test_annotated_func():
     @to_task
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out1", float)]):

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -41,13 +41,12 @@ def test_wf_1(plugin):
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
     wf.plugin = plugin
-    odir = wf.output_dir
+
     with Submitter(plugin=plugin) as sub:
         sub(wf)
 
     results = wf.result()
     assert 4 == results.output.out
-    assert wf.output_dir == odir
     assert wf.output_dir.exists()
 
 
@@ -59,14 +58,12 @@ def test_wf_1_call_subm(plugin):
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         wf(submitter=sub)
 
     results = wf.result()
     assert 4 == results.output.out
-    assert wf.output_dir == odir
     assert wf.output_dir.exists()
 
 
@@ -78,13 +75,11 @@ def test_wf_1_call_plug(plugin):
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
     wf.plugin = plugin
-    odir = wf.output_dir
 
     wf(plugin=plugin)
 
     results = wf.result()
     assert 4 == results.output.out
-    assert wf.output_dir == odir
     assert wf.output_dir.exists()
 
 
@@ -113,13 +108,11 @@ def test_wf_2(plugin):
     wf.inputs.x = 2
     wf.inputs.y = 3
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
 
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
     results = wf.result()
     assert 8 == results.output.out
 
@@ -138,16 +131,13 @@ def test_wf_2a(plugin):
     wf.inputs.x = 2
     wf.inputs.y = 3
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
-    # assert wf.output_dir.exists()
+
     results = wf.result()
     assert 8 == results.output.out
-
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -165,16 +155,14 @@ def test_wf_2b(plugin):
     wf.inputs.x = 2
     wf.inputs.y = 3
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
-    # assert wf.output_dir.exists()
+
     results = wf.result()
     assert 8 == results.output.out
 
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -187,8 +175,6 @@ def test_wf_st_1(plugin):
     wf.inputs.x = [1, 2]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert wf.output_dir  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -198,8 +184,8 @@ def test_wf_st_1(plugin):
     assert results[0].output.out == 3
     assert results[1].output.out == 4
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -223,7 +209,7 @@ def test_wf_st_1_call_subm(plugin):
     assert results[1].output.out == 4
     # checking all directories
     assert wf.output_dir
-    for _, odir in wf.output_dir.items():
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -246,7 +232,7 @@ def test_wf_st_1_call_plug(plugin):
     assert results[1].output.out == 4
     # checking all directories
     assert wf.output_dir
-    for _, odir in wf.output_dir.items():
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -258,7 +244,6 @@ def test_wf_ndst_1(plugin):
     wf.inputs.x = [1, 2]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -267,7 +252,6 @@ def test_wf_ndst_1(plugin):
     # expected: [({"test7.x": 1}, 3), ({"test7.x": 2}, 4)]
     assert results.output.out == [3, 4]
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -280,8 +264,6 @@ def test_wf_st_2(plugin):
     wf.inputs.x = [1, 2]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -291,8 +273,8 @@ def test_wf_st_2(plugin):
     assert results[0][0].output.out == 3
     assert results[0][1].output.out == 4
     # checking all directories
-    assert odir_init == wf.output_dir
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -304,7 +286,6 @@ def test_wf_ndst_2(plugin):
     wf.inputs.x = [1, 2]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -313,7 +294,6 @@ def test_wf_ndst_2(plugin):
     # expected: [[({"test7.x": 1}, 3), ({"test7.x": 2}, 4)]]
     assert results.output.out[0] == [3, 4]
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 # workflows with structures A -> B
@@ -330,8 +310,6 @@ def test_wf_st_3(plugin):
     wf.split(("x", "y"))
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -341,8 +319,8 @@ def test_wf_st_3(plugin):
     assert results[0].output.out == 13
     assert results[1].output.out == 26
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -356,7 +334,6 @@ def test_wf_ndst_3(plugin):
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -366,7 +343,6 @@ def test_wf_ndst_3(plugin):
     assert results.output.out == [13, 26]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -380,8 +356,6 @@ def test_wf_st_4(plugin):
     wf.combine("x")
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -393,8 +367,8 @@ def test_wf_st_4(plugin):
     assert results[0][0].output.out == 13
     assert results[0][1].output.out == 26
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -409,7 +383,6 @@ def test_wf_ndst_4(plugin):
     wf.plugin = plugin
     wf.inputs.a = [1, 2]
     wf.inputs.b = [11, 12]
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -421,7 +394,6 @@ def test_wf_ndst_4(plugin):
     assert results.output.out[0] == [13, 26]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -435,8 +407,6 @@ def test_wf_st_5(plugin):
     wf.combine("x")
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -447,8 +417,8 @@ def test_wf_st_5(plugin):
     assert results[1][0].output.out == 14
     assert results[1][1].output.out == 26
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -462,7 +432,6 @@ def test_wf_ndst_5(plugin):
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -472,7 +441,6 @@ def test_wf_ndst_5(plugin):
     assert results.output.out[1] == [14, 26]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 # workflows with structures A -> C, B -> C
@@ -491,8 +459,6 @@ def test_wf_st_6(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -503,8 +469,8 @@ def test_wf_st_6(plugin):
     assert results[1].output.out == 42
     assert results[5].output.out == 70
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -521,7 +487,6 @@ def test_wf_ndst_6(plugin):
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -531,7 +496,6 @@ def test_wf_ndst_6(plugin):
     assert results.output.out == [39, 42, 52, 56, 65, 70]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -547,8 +511,6 @@ def test_wf_st_7(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -562,8 +524,8 @@ def test_wf_st_7(plugin):
     assert results[1][1].output.out == 56
     assert results[1][2].output.out == 70
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -584,7 +546,6 @@ def test_wf_ndst_7(plugin):
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -595,7 +556,6 @@ def test_wf_ndst_7(plugin):
     assert results.output.out[1] == [42, 56, 70]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -611,8 +571,6 @@ def test_wf_st_8(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -626,8 +584,8 @@ def test_wf_st_8(plugin):
     assert results[2][0].output.out == 65
     assert results[2][1].output.out == 70
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -648,7 +606,6 @@ def test_wf_ndst_8(plugin):
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -660,7 +617,6 @@ def test_wf_ndst_8(plugin):
     assert results.output.out[2] == [65, 70]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -675,8 +631,6 @@ def test_wf_st_9(plugin):
     wf.split(["x", "y"], x=[1, 2, 3], y=[11, 12]).combine(["x", "y"])
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -690,8 +644,8 @@ def test_wf_st_9(plugin):
     assert results[0][4].output.out == 65
     assert results[0][5].output.out == 70
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -712,7 +666,6 @@ def test_wf_ndst_9(plugin):
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -723,7 +676,6 @@ def test_wf_ndst_9(plugin):
     assert results.output.out == [[39, 42, 52, 56, 65, 70]]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 # workflow that have some single values as the input
@@ -740,8 +692,6 @@ def test_wf_st_singl_1(plugin):
     wf.combine("x")
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -750,8 +700,8 @@ def test_wf_st_singl_1(plugin):
     assert results[0][0].output.out == 13
     assert results[0][1].output.out == 24
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -767,7 +717,6 @@ def test_wf_ndst_singl_1(plugin):
     wf.inputs.y = 11
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -776,7 +725,6 @@ def test_wf_ndst_singl_1(plugin):
     assert results.output.out[0] == [13, 24]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -793,8 +741,6 @@ def test_wf_st_singl_2(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -805,8 +751,8 @@ def test_wf_st_singl_2(plugin):
     assert results[1].output.out == 52
     assert results[2].output.out == 65
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -824,7 +770,6 @@ def test_wf_ndst_singl_2(plugin):
     wf.inputs.y = 11
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -834,7 +779,6 @@ def test_wf_ndst_singl_2(plugin):
     assert results.output.out == [39, 52, 65]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 # workflows with structures wf(A)
@@ -854,7 +798,6 @@ def test_wfasnd_1(plugin):
     wf.add(wfnd)
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -863,7 +806,6 @@ def test_wfasnd_1(plugin):
     assert results.output.out == 4
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -881,7 +823,6 @@ def test_wfasnd_wfinp_1(plugin):
     wf.inputs.x = 2
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -890,7 +831,6 @@ def test_wfasnd_wfinp_1(plugin):
     assert results.output.out == 4
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -909,7 +849,6 @@ def test_wfasnd_st_1(plugin):
     wf.add(wfnd)
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -918,7 +857,6 @@ def test_wfasnd_st_1(plugin):
     assert results.output.out == [4, 6]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -938,7 +876,6 @@ def test_wfasnd_ndst_1(plugin):
     wf.add(wfnd)
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -947,7 +884,6 @@ def test_wfasnd_ndst_1(plugin):
     assert results.output.out == [4, 6]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -966,8 +902,6 @@ def test_wfasnd_wfst_1(plugin):
     wf.inputs.x = [2, 4]
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -976,8 +910,8 @@ def test_wfasnd_wfst_1(plugin):
     assert results[0].output.out == 4
     assert results[1].output.out == 6
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -1002,7 +936,6 @@ def test_wfasnd_st_2(plugin):
     wf.add(add2(name="add2", x=wf.wfnd.lzout.out))
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -1011,7 +944,6 @@ def test_wfasnd_st_2(plugin):
     assert results.output.out == [4, 42]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -1032,8 +964,6 @@ def test_wfasnd_wfst_2(plugin):
     wf.inputs.y = [1, 10]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -1042,8 +972,8 @@ def test_wfasnd_wfst_2(plugin):
     assert results[0].output.out == 4
     assert results[1].output.out == 42
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
@@ -1068,7 +998,6 @@ def test_wfasnd_ndst_3(plugin):
 
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -1077,7 +1006,6 @@ def test_wfasnd_ndst_3(plugin):
     assert results.output.out == [4, 42]
     # checking the output directory
     assert wf.output_dir.exists()
-    assert wf.output_dir == odir
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -1099,8 +1027,6 @@ def test_wfasnd_wfst_3(plugin):
 
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
-    odir_init = wf.output_dir
-    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -1109,12 +1035,12 @@ def test_wfasnd_wfst_3(plugin):
     assert results[0].output.out == 4
     assert results[1].output.out == 42
     # checking all directories
-    assert wf.output_dir == odir_init
-    for _, odir in wf.output_dir.items():
+    assert wf.output_dir
+    for odir in wf.output_dir:
         assert odir.exists()
 
 
-# Testing caching for tasks without states
+# Testing caching
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -1274,11 +1200,13 @@ def test_wf_state_cachelocations(plugin, tmpdir):
     assert t2 < 0.1
 
     # checking all directories
-    for _, odir in wf1.output_dir.items():
+    assert wf1.output_dir
+    for odir in wf1.output_dir:
         assert odir.exists()
     # checking if the second wf didn't run again
     # checking all directories
-    for _, odir in wf2.output_dir.items():
+    assert wf2.output_dir
+    for odir in wf2.output_dir:
         assert not odir.exists()
 
 
@@ -1445,4 +1373,128 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
 
     # checking if both dir exists
     assert wf1.output_dir.exists()
+    assert wf2.output_dir.exists()
+
+
+@pytest.mark.parametrize("plugin", Plugins)
+def test_wf_ndstate_cachelocations(plugin, tmpdir):
+    """
+    Two wfs with identical inputs and slightly different graph (a node has different state);
+    the second wf has cache_locations and should recompute the results
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(
+        multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y).split(splitter=("x", "y"))
+    )
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out", wf1.add2.lzout.out)])
+    wf1.inputs.x = [2, 20]
+    wf1.inputs.y = [3, 4]
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert results1.output.out == [8, 82]
+
+    wf2 = Workflow(
+        name="wf",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+    )
+    wf2.add(
+        multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y).split(splitter=("x", "y"))
+    )
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out))
+    wf2.set_output([("out", wf2.add2.lzout.out)])
+    wf2.inputs.x = [2, 20]
+    wf2.inputs.y = [3, 4]
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert results2.output.out == [8, 82]
+
+    # checking execution time
+    assert t1 > 3
+    assert t2 < 0.1
+
+    # checking all directories
+    assert wf1.output_dir.exists()
+
+    # checking if the second wf didn't run again
+    # checking all directories
+    assert not wf2.output_dir.exists()
+
+
+@pytest.mark.parametrize("plugin", Plugins)
+def test_wf_ndstate_cachelocations_recompute(plugin, tmpdir):
+    """
+    Two wfs (with nodes with states) with provided cache_dir;
+    the second wf has cache_locations and should not recompute the results
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(
+        multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y).split(splitter=("x", "y"))
+    )
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out", wf1.add2.lzout.out)])
+    wf1.inputs.x = [2, 20]
+    wf1.inputs.y = [3, 4]
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert results1.output.out == [8, 82]
+
+    wf2 = Workflow(
+        name="wf",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+    )
+    wf2.add(
+        multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y).split(splitter=["x", "y"])
+    )
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out))
+    wf2.set_output([("out", wf2.add2.lzout.out)])
+    wf2.inputs.x = [2, 20]
+    wf2.inputs.y = [3, 4]
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert results2.output.out == [8, 10, 62, 82]
+
+    # checking execution time
+    assert t1 > 3
+    assert t2 > 3
+
+    # checking all directories
+    assert wf1.output_dir.exists()
+
+    # checking if the second wf didn't run again
+    # checking all directories
     assert wf2.output_dir.exists()

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -96,7 +96,6 @@ def test_wf_1_call_exception(plugin):
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
     wf.plugin = plugin
-    odir = wf.output_dir
 
     with Submitter(plugin=plugin) as sub:
         with pytest.raises(Exception) as e:
@@ -188,6 +187,8 @@ def test_wf_st_1(plugin):
     wf.inputs.x = [1, 2]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert wf.output_dir  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -197,6 +198,7 @@ def test_wf_st_1(plugin):
     assert results[0].output.out == 3
     assert results[1].output.out == 4
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -220,6 +222,7 @@ def test_wf_st_1_call_subm(plugin):
     assert results[0].output.out == 3
     assert results[1].output.out == 4
     # checking all directories
+    assert wf.output_dir
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -242,6 +245,7 @@ def test_wf_st_1_call_plug(plugin):
     assert results[0].output.out == 3
     assert results[1].output.out == 4
     # checking all directories
+    assert wf.output_dir
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -276,6 +280,8 @@ def test_wf_st_2(plugin):
     wf.inputs.x = [1, 2]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -285,6 +291,7 @@ def test_wf_st_2(plugin):
     assert results[0][0].output.out == 3
     assert results[0][1].output.out == 4
     # checking all directories
+    assert odir_init == wf.output_dir
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -323,6 +330,8 @@ def test_wf_st_3(plugin):
     wf.split(("x", "y"))
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -332,6 +341,7 @@ def test_wf_st_3(plugin):
     assert results[0].output.out == 13
     assert results[1].output.out == 26
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -370,6 +380,8 @@ def test_wf_st_4(plugin):
     wf.combine("x")
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -381,6 +393,7 @@ def test_wf_st_4(plugin):
     assert results[0][0].output.out == 13
     assert results[0][1].output.out == 26
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -422,6 +435,8 @@ def test_wf_st_5(plugin):
     wf.combine("x")
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -432,6 +447,7 @@ def test_wf_st_5(plugin):
     assert results[1][0].output.out == 14
     assert results[1][1].output.out == 26
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -475,6 +491,8 @@ def test_wf_st_6(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -485,6 +503,7 @@ def test_wf_st_6(plugin):
     assert results[1].output.out == 42
     assert results[5].output.out == 70
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -528,6 +547,8 @@ def test_wf_st_7(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -541,6 +562,7 @@ def test_wf_st_7(plugin):
     assert results[1][1].output.out == 56
     assert results[1][2].output.out == 70
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -589,6 +611,8 @@ def test_wf_st_8(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -602,6 +626,7 @@ def test_wf_st_8(plugin):
     assert results[2][0].output.out == 65
     assert results[2][1].output.out == 70
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -650,6 +675,8 @@ def test_wf_st_9(plugin):
     wf.split(["x", "y"], x=[1, 2, 3], y=[11, 12]).combine(["x", "y"])
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -663,6 +690,7 @@ def test_wf_st_9(plugin):
     assert results[0][4].output.out == 65
     assert results[0][5].output.out == 70
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -712,6 +740,8 @@ def test_wf_st_singl_1(plugin):
     wf.combine("x")
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -720,6 +750,7 @@ def test_wf_st_singl_1(plugin):
     assert results[0][0].output.out == 13
     assert results[0][1].output.out == 24
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -762,6 +793,8 @@ def test_wf_st_singl_2(plugin):
 
     wf.set_output([("out", wf.mult.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -772,6 +805,7 @@ def test_wf_st_singl_2(plugin):
     assert results[1].output.out == 52
     assert results[2].output.out == 65
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -932,6 +966,8 @@ def test_wfasnd_wfst_1(plugin):
     wf.inputs.x = [2, 4]
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -940,6 +976,7 @@ def test_wfasnd_wfst_1(plugin):
     assert results[0].output.out == 4
     assert results[1].output.out == 6
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -995,6 +1032,8 @@ def test_wfasnd_wfst_2(plugin):
     wf.inputs.y = [1, 10]
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -1003,6 +1042,7 @@ def test_wfasnd_wfst_2(plugin):
     assert results[0].output.out == 4
     assert results[1].output.out == 42
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 
@@ -1059,6 +1099,8 @@ def test_wfasnd_wfst_3(plugin):
 
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
+    odir_init = wf.output_dir
+    assert odir_init  # checking if the dictionary is not empty
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -1067,6 +1109,7 @@ def test_wfasnd_wfst_3(plugin):
     assert results[0].output.out == 4
     assert results[1].output.out == 42
     # checking all directories
+    assert wf.output_dir == odir_init
     for _, odir in wf.output_dir.items():
         assert odir.exists()
 


### PR DESCRIPTION
changes in `TaskBase.checksum` and `BaseSpec.hash`. 
My changes introduced in [this commit](https://github.com/nipype/pydra/commit/86467b7fa9335ec60bee051227188ffa73f798a6) that were fixing problem with no existing output_dir, didn't work for situations from `test_annotated_func` (test was xfailed..).

Main changes:
- all checksum can be calculated before running (also for state) 
- hash property is changed to a method that takes dictionary with state values as an optional argument (so can replace values for inputs that are part of the splitter)
- to calculate has of `_graph`, `nd.inputs.hash()` is calculated, so `TaskBase.checksum` diesn't have to deal with lazy inputs
