### PR TITLE
[wip] to_task decorator with arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_script:
 script:
   - |
     if [ "$CHECK_TYPE" = "test" ]; then
-        py.test -vs -n auto --cov pydra/engine/tests/test_task.py --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
+        py.test -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
     elif [ "$CHECK_TYPE" = "style" ]; then
         black pydra setup.py
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_script:
 script:
   - |
     if [ "$CHECK_TYPE" = "test" ]; then
-        py.test -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
+        py.test -vs -n auto --cov pydra/engine/tests/test_task.py --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
     elif [ "$CHECK_TYPE" = "style" ]; then
         black pydra setup.py
     fi

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -9,7 +9,7 @@ from ...utils.messenger import PrintMessenger, FileMessenger, collect_messages
 
 
 def test_output():
-    @to_task
+    @to_task()
     def funaddtwo(a):
         return a + 2
 
@@ -20,7 +20,7 @@ def test_output():
 
 @pytest.mark.xfail(reason="cp.dumps(func) depends on the system/setup, TODO!!")
 def test_checksum():
-    @to_task
+    @to_task()
     def funaddtwo(a):
         return a + 2
 
@@ -32,7 +32,7 @@ def test_checksum():
 
 
 def test_annotated_func():
-    @to_task
+    @to_task()
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out1", float)]):
         return a + b
 
@@ -76,7 +76,7 @@ def test_annotated_func():
 def test_annotated_func_multreturn():
     """function has two elements in the return statement"""
 
-    @to_task
+    @to_task()
     def testfunc(
         a: float
     ) -> ty.NamedTuple("Output", [("fractional", float), ("integer", int)]):
@@ -117,7 +117,7 @@ def test_annotated_func_multreturn_exception():
         but three element provided in the spec - should raise an error
     """
 
-    @to_task
+    @to_task()
     def testfunc(
         a: float
     ) -> ty.NamedTuple(
@@ -134,7 +134,7 @@ def test_annotated_func_multreturn_exception():
 
 
 def test_halfannotated_func():
-    @to_task
+    @to_task()
     def testfunc(a, b) -> int:
         return a + b
 
@@ -175,7 +175,7 @@ def test_halfannotated_func():
 
 
 def test_halfannotated_func_multreturn():
-    @to_task
+    @to_task()
     def testfunc(a, b) -> (int, int):
         return a + 1, b + 1
 
@@ -217,7 +217,7 @@ def test_halfannotated_func_multreturn():
 
 
 def test_notannotated_func():
-    @to_task
+    @to_task()
     def no_annots(c, d):
         return c + d
 
@@ -237,7 +237,7 @@ def test_notannotated_func_multreturn():
         all elements should be returned as a tuple ans set to "out"
     """
 
-    @to_task
+    @to_task()
     def no_annots(c, d):
         return c + d, c - d
 
@@ -252,8 +252,58 @@ def test_notannotated_func_multreturn():
     assert result.output.out == (20.2, 13.8)
 
 
+def test_decorator_halfannotated_func():
+    @to_task(outputs_annotation="my_output")
+    def no_annots(c, d):
+        return c + d
+
+    natask = no_annots(c=17, d=3.2)
+    assert hasattr(natask.inputs, "c")
+    assert hasattr(natask.inputs, "d")
+    assert hasattr(natask.inputs, "_func")
+
+    result = natask._run()
+    assert hasattr(result, "output")
+    assert hasattr(result.output, "my_output")
+    assert result.output.my_output == 20.2
+
+
+def test_decorator_halfannotated_func_multreturn():
+    @to_task(outputs_annotation=["sum", "sub"])
+    def no_annots(c, d):
+        return c + d, c - d
+
+    natask = no_annots(c=17, d=3.2)
+    assert hasattr(natask.inputs, "c")
+    assert hasattr(natask.inputs, "d")
+    assert hasattr(natask.inputs, "_func")
+
+    result = natask._run()
+    assert hasattr(result, "output")
+    assert hasattr(result.output, "sum")
+    assert result.output.sum == 20.2
+    assert hasattr(result.output, "sub")
+    assert result.output.sub == 13.8
+
+
+def test_decorator_annotated_func():
+    @to_task(outputs_annotation=("my_output", float))
+    def no_annots(c, d):
+        return c + d
+
+    natask = no_annots(c=17, d=3.2)
+    assert hasattr(natask.inputs, "c")
+    assert hasattr(natask.inputs, "d")
+    assert hasattr(natask.inputs, "_func")
+
+    result = natask._run()
+    assert hasattr(result, "output")
+    assert hasattr(result.output, "my_output")
+    assert result.output.my_output == 20.2
+
+
 def test_exception_func():
-    @to_task
+    @to_task()
     def raise_exception(c, d):
         raise Exception()
 
@@ -262,7 +312,7 @@ def test_exception_func():
 
 
 def test_audit_prov(tmpdir):
-    @to_task
+    @to_task()
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out", float)]):
         return a + b
 
@@ -282,7 +332,7 @@ def test_audit_prov(tmpdir):
 
 @pytest.mark.xfail(reason="errors from cloudpickle")
 def test_audit_all(tmpdir):
-    @to_task
+    @to_task()
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out", float)]):
         return a + b
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
testing `to_task` decorator with arguments for providing output spec (instead of annotating the function).

we should think if you want to have a separate decorator for it, right now `@to_task` would have to be changed to `@to_task()` in all our tests 

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.