### PR TITLE
ENH: Add pydra.mark module with initial annotate and task decorators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,9 +85,9 @@ before_script:
 script:
   - |
     if [ "$CHECK_TYPE" = "test" ]; then
-       pytest -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
+        pytest -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
     elif [ "$CHECK_TYPE" = "style" ]; then
-        black pydra setup.py
+        black --check pydra setup.py
     fi
 
 after_script:

--- a/pydra/engine/audit.py
+++ b/pydra/engine/audit.py
@@ -6,9 +6,7 @@ from .helpers import ensure_list, gather_runtime_info
 
 
 class Audit:
-    def __init__(
-        self, audit_flags, messengers, messenger_args, develop=None
-    ):
+    def __init__(self, audit_flags, messengers, messenger_args, develop=None):
         self.audit_flags = audit_flags
         self.messengers = ensure_list(messengers)
         self.messenger_args = messenger_args

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -147,14 +147,6 @@ class FunctionTask(TaskBase):
         return self.output_
 
 
-def to_task(func_to_decorate):
-    def create_func(**original_kwargs):
-        function_task = FunctionTask(func=func_to_decorate, **original_kwargs)
-        return function_task
-
-    return create_func
-
-
 class ShellCommandTask(TaskBase):
     def __init__(
         self,

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -112,6 +112,12 @@ class FunctionTask(TaskBase):
                         fields=list(return_info.__annotations__.items()),
                         bases=(BaseSpec,),
                     )
+                elif isinstance(return_info, dict):
+                    output_spec = SpecInfo(
+                        name="Output",
+                        fields=list(return_info.items()),
+                        bases=(BaseSpec,),
+                    )
                 else:
                     if not isinstance(return_info, tuple):
                         return_info = (return_info,)

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -2,9 +2,9 @@ import os, shutil
 import numpy as np
 import pytest, pdb
 
+from ... import mark
 from ..core import TaskBase
 from ..submitter import Submitter
-from ..task import to_task
 
 Plugins = ["cf"]
 
@@ -22,7 +22,7 @@ def change_dir(request):
     request.addfinalizer(move2orig)
 
 
-@to_task
+@mark.task
 def fun_addtwo(a):
     import time
 
@@ -32,22 +32,22 @@ def fun_addtwo(a):
     return a + 2
 
 
-@to_task
+@mark.task
 def fun_addvar(a, b):
     return a + b
 
 
-@to_task
+@mark.task
 def fun_addvar4(a, b, c, d):
     return a + b + c + d
 
 
-@to_task
+@mark.task
 def moment(lst, n):
     return sum([i ** n for i in lst]) / len(lst)
 
 
-@to_task
+@mark.task
 def fun_div(a, b):
     return a / b
 

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -1,11 +1,11 @@
 from ..core import Workflow
-from ..task import to_task
 from ..submitter import Submitter
+from ... import mark
 
 import time
 
 
-@to_task
+@mark.task
 def sleep_add_one(x):
     time.sleep(1)
     return x + 1

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -4,12 +4,13 @@ import typing as ty
 import os
 import pytest
 
-from ..task import to_task, AuditFlag, ShellCommandTask, ContainerTask, DockerTask
+from ... import mark
+from ..task import AuditFlag, ShellCommandTask, ContainerTask, DockerTask
 from ...utils.messenger import PrintMessenger, FileMessenger, collect_messages
 
 
 def test_output():
-    @to_task
+    @mark.task
     def funaddtwo(a):
         return a + 2
 
@@ -20,7 +21,7 @@ def test_output():
 
 @pytest.mark.xfail(reason="cp.dumps(func) depends on the system/setup, TODO!!")
 def test_checksum():
-    @to_task
+    @mark.task
     def funaddtwo(a):
         return a + 2
 
@@ -32,7 +33,7 @@ def test_checksum():
 
 
 def test_annotated_func():
-    @to_task
+    @mark.task
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out1", float)]):
         return a + b
 
@@ -76,7 +77,7 @@ def test_annotated_func():
 def test_annotated_func_multreturn():
     """function has two elements in the return statement"""
 
-    @to_task
+    @mark.task
     def testfunc(
         a: float
     ) -> ty.NamedTuple("Output", [("fractional", float), ("integer", int)]):
@@ -117,7 +118,7 @@ def test_annotated_func_multreturn_exception():
         but three element provided in the spec - should raise an error
     """
 
-    @to_task
+    @mark.task
     def testfunc(
         a: float
     ) -> ty.NamedTuple(
@@ -134,7 +135,7 @@ def test_annotated_func_multreturn_exception():
 
 
 def test_halfannotated_func():
-    @to_task
+    @mark.task
     def testfunc(a, b) -> int:
         return a + b
 
@@ -175,7 +176,7 @@ def test_halfannotated_func():
 
 
 def test_halfannotated_func_multreturn():
-    @to_task
+    @mark.task
     def testfunc(a, b) -> (int, int):
         return a + 1, b + 1
 
@@ -217,7 +218,7 @@ def test_halfannotated_func_multreturn():
 
 
 def test_notannotated_func():
-    @to_task
+    @mark.task
     def no_annots(c, d):
         return c + d
 
@@ -237,7 +238,7 @@ def test_notannotated_func_multreturn():
         all elements should be returned as a tuple ans set to "out"
     """
 
-    @to_task
+    @mark.task
     def no_annots(c, d):
         return c + d, c - d
 
@@ -253,7 +254,7 @@ def test_notannotated_func_multreturn():
 
 
 def test_exception_func():
-    @to_task
+    @mark.task
     def raise_exception(c, d):
         raise Exception()
 
@@ -262,7 +263,7 @@ def test_exception_func():
 
 
 def test_audit_prov(tmpdir):
-    @to_task
+    @mark.task
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out", float)]):
         return a + b
 
@@ -281,7 +282,7 @@ def test_audit_prov(tmpdir):
 
 
 def test_audit_all(tmpdir):
-    @to_task
+    @mark.task
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out", float)]):
         return a + b
 

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -3,31 +3,31 @@ import shutil
 import time
 
 from ..submitter import Submitter
-from ..task import to_task
 from ..core import Workflow
+from ... import mark
 
 
 Plugins = ["cf"]
 
 
-@to_task
+@mark.task
 def double(x):
     return x * 2
 
 
-@to_task
+@mark.task
 def multiply(x, y):
     return x * y
 
 
-@to_task
+@mark.task
 def add2(x):
     if x == 1 or x == 12:
         time.sleep(1)
     return x + 2
 
 
-@to_task
+@mark.task
 def add2_wait(x):
     time.sleep(3)
     return x + 2

--- a/pydra/mark/__init__.py
+++ b/pydra/mark/__init__.py
@@ -1,0 +1,1 @@
+from .functions import annotate, task

--- a/pydra/mark/functions.py
+++ b/pydra/mark/functions.py
@@ -1,0 +1,38 @@
+""" Decorators to apply to functions used in Pydra workflows """
+
+
+def annotate(annotation):
+    """ Update the annotation of a function
+
+    >>> import pydra
+    >>> @pydra.mark.annotate({'a': int, 'return': float})
+    ... def square(a):
+    ...     a ** 2.0
+    """
+    import inspect
+
+    def decorate(func):
+        sig = inspect.signature(func)
+        unknown = set(annotation) - set(sig.parameters) - {"return"}
+        if unknown:
+            raise TypeError(f"Cannot annotate unknown parameters: {tuple(unknown)}")
+        func.__annotations__.update(annotation)
+        return func
+
+    return decorate
+
+
+def task(func):
+    """ Promote a function to a Pydra Task
+
+    >>> import pydra
+    >>> @pydra.mark.task
+    ... def square(a: int) -> float:
+    ...     a ** 2.0
+    """
+    from ..engine.task import FunctionTask
+
+    def decorate(**kwargs):
+        return FunctionTask(func=func, **kwargs)
+
+    return decorate

--- a/pydra/mark/tests/test_functions.py
+++ b/pydra/mark/tests/test_functions.py
@@ -73,7 +73,7 @@ def test_annotated_task():
     def square(in_val: float):
         return in_val ** 2
 
-    res = square(in_val=2.0)._run()
+    res = square(in_val=2.0)()
     assert res.output.out == 4.0
 
 
@@ -83,5 +83,27 @@ def test_return_annotated_task():
     def square(in_val):
         return in_val ** 2
 
-    res = square(in_val=2.0)._run()
+    res = square(in_val=2.0)()
     assert res.output.squared == 4.0
+
+
+def test_return_annotated_task_multiple_output():
+    @task
+    @annotate({"in_val": float, "return": {"squared": float, "cubed": float}})
+    def square(in_val):
+        return in_val ** 2, in_val ** 3
+
+    res = square(in_val=2.0)()
+    assert res.output.squared == 4.0
+    assert res.output.cubed == 8.0
+
+
+def test_return_halfannotated_task_multiple_output():
+    @task
+    @annotate({"in_val": float, "return": (float, float)})
+    def square(in_val):
+        return in_val ** 2, in_val ** 3
+
+    res = square(in_val=2.0)()
+    assert res.output.out1 == 4.0
+    assert res.output.out2 == 8.0

--- a/pydra/mark/tests/test_functions.py
+++ b/pydra/mark/tests/test_functions.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import random
+
+from ..functions import task, annotate
+from ...engine.task import FunctionTask
+
+
+def test_task_equivalence():
+    def add_two(a):
+        return a + 2
+
+    canonical = FunctionTask(add_two, a=3)
+
+    decorated1 = task(add_two)(a=3)
+
+    @task
+    def addtwo(a):
+        return a + 2
+
+    decorated2 = addtwo(a=3)
+
+    assert canonical.checksum == decorated1.checksum
+
+    c_res = canonical._run()
+    d1_res = decorated1._run()
+    d2_res = decorated2._run()
+
+    assert c_res.output.hash == d1_res.output.hash
+    assert c_res.output.hash == d2_res.output.hash
+
+
+def test_annotation_equivalence():
+    def direct(a: int) -> int:
+        return a + 2
+
+    @annotate({"return": int})
+    def partial(a: int):
+        return a + 2
+
+    @annotate({"a": int, "return": int})
+    def indirect(a):
+        return a + 2
+
+    assert direct.__annotations__ == partial.__annotations__
+    assert direct.__annotations__ == indirect.__annotations__
+
+    # Run functions to ensure behavior is unaffected
+    a = random.randint(0, (1 << 32) - 3)
+    assert direct(a) == partial(a)
+    assert direct(a) == indirect(a)
+
+
+def test_annotation_override():
+    @annotate({"a": float, "return": float})
+    def annotated(a: int) -> int:
+        return a + 2
+
+    assert annotated.__annotations__ == {"a": float, "return": float}
+
+
+def test_invalid_annotation():
+    with pytest.raises(TypeError):
+
+        @annotate({"b": int})
+        def addtwo(a):
+            return a + 2

--- a/pydra/mark/tests/test_functions.py
+++ b/pydra/mark/tests/test_functions.py
@@ -66,3 +66,22 @@ def test_invalid_annotation():
         @annotate({"b": int})
         def addtwo(a):
             return a + 2
+
+
+def test_annotated_task():
+    @task
+    def square(in_val: float):
+        return in_val ** 2
+
+    res = square(in_val=2.0)._run()
+    assert res.output.out == 4.0
+
+
+def test_return_annotated_task():
+    @task
+    @annotate({"in_val": float, "return": {"squared": float}})
+    def square(in_val):
+        return in_val ** 2
+
+    res = square(in_val=2.0)._run()
+    assert res.output.squared == 4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ tests =
     %(test)s
 dev = 
     %(test)s
+    black
     pre-commit
 all =
     %(dev)s


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
As suggested in https://github.com/nipype/pydra/pull/95#issuecomment-514299672, we can use a `pytest.mark`-inspired namespace to provide a library of useful decorators that can keep the functionality of each decorator tightly focused.

This replaces the `pydra.engine.task.to_task` decorator with `pydra.mark.task`, which feels a little more declarative, IMO.

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [x] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.