### PR TITLE
RF: Replace pickle with cloudpickle for input/output specs

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -6,7 +6,6 @@ import logging
 import os
 from pathlib import Path
 import typing as ty
-import pickle as pk
 from copy import deepcopy
 
 import cloudpickle as cp
@@ -134,14 +133,14 @@ class TaskBase:
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state["input_spec"] = pk.dumps(state["input_spec"])
-        state["output_spec"] = pk.dumps(state["output_spec"])
+        state["input_spec"] = cp.dumps(state["input_spec"])
+        state["output_spec"] = cp.dumps(state["output_spec"])
         state["inputs"] = dc.asdict(state["inputs"])
         return state
 
     def __setstate__(self, state):
-        state["input_spec"] = pk.loads(state["input_spec"])
-        state["output_spec"] = pk.loads(state["output_spec"])
+        state["input_spec"] = cp.loads(state["input_spec"])
+        state["output_spec"] = cp.loads(state["output_spec"])
         state["inputs"] = make_klass(state["input_spec"])(**state["inputs"])
         self.__dict__.update(state)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 [options]
 python_requires = >= 3.7
 install_requires =
-    cloudpickle
+    cloudpickle >= 0.8.0
     filelock
 test_requires =
     pytest >= 4.4.0


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Replace pickle with cloudpickle for input/output specs.

As noted in https://github.com/nipype/pydra/pull/96#issuecomment-516008605, the problem with cloudpickling specs should have been resolved by cloudpipe/cloudpickle#245. This hit version 0.8.0, so I'm updating the minimum required version, as well.

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.