### PR TITLE
FIX+ENH: Slurm execution + option to set maximum job limit

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -475,7 +475,6 @@ class Workflow(TaskBase):
 
         self.graph = DiGraph()
         self.name2obj = {}
-        self._submitted = False
 
         # store output connections
         self._connections = None
@@ -596,8 +595,6 @@ class Workflow(TaskBase):
         if not submitter:
             raise Exception("Submitter should already be set.")
         # at this point Workflow is stateless so this should be fine
-        if submitter.worker._distributed:
-            self._submitted = True
         await submitter.submit(self)
 
     def set_output(self, connections):

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -91,7 +91,7 @@ class Submitter:
                 )
                 if is_workflow(runnable):
                     # job has no state anymore
-                    futures.add(asyncio.create_task(self.submit_workflow(job)))
+                    futures.add(self.submit_workflow(job))
                 else:
                     # tasks are submitted to worker for execution
                     futures.add(self.worker.run_el(job))
@@ -146,8 +146,8 @@ class Submitter:
                 else:
                     for fut in await self.submit(task):
                         task_futures.add(fut)
-
             task_futures = await self.worker.fetch_finished(task_futures)
+
         return wf
 
     def __enter__(self):

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -53,7 +53,7 @@ def add2_wait(x):
     return x + 2
 
 
-def gen_basic_wf():
+def gen_basic_wf(name="basic-wf"):
     """
     Generates `Workflow` of two tasks
 
@@ -65,9 +65,9 @@ def gen_basic_wf():
     -----------
     out : int (9)
     """
-    wf = Workflow(name="basic-wf", input_spec=["x"])
+    wf = Workflow(name=name, input_spec=["x"])
     wf.inputs.x = 5
-    wf.add(fun_addtwo(name="task1", a=wf.lzin.x))
+    wf.add(fun_addtwo(name="task1", a=wf.lzin.x, b=0))
     wf.add(fun_addvar(name="task2", a=wf.task1.lzout.out, b=2))
     wf.set_output([("out", wf.task2.lzout.out)])
     return wf

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -96,7 +96,7 @@ class DistributedWorker(Worker):
             Finished or cancelled tasks
         """
         done, unqueued = set(), set()
-        job_slots = self.max_jobs - self._jobs if self.max_jobs else float('inf')
+        job_slots = self.max_jobs - self._jobs if self.max_jobs else float("inf")
         if len(futures) > job_slots:
             # convert to list to simplify indexing
             futures = list(futures)
@@ -110,6 +110,7 @@ class DistributedWorker(Worker):
         except ValueError:
             # nothing pending!
             pending = set()
+        breakpoint()
         self._jobs -= len(done)
         logger.debug(f"Tasks finished: {len(done)}")
         # ensure pending + unqueued tasks persist
@@ -167,10 +168,12 @@ class ConcurrentFuturesWorker(Worker):
 class SlurmWorker(DistributedWorker):
     _cmd = "sbatch"
     _sacct_re = re.compile(
-            "(?P<jobid>\\d*) +(?P<status>\\w*)\\+? +" "(?P<exit_code>\\d+):\\d+"
-        )
+        "(?P<jobid>\\d*) +(?P<status>\\w*)\\+? +" "(?P<exit_code>\\d+):\\d+"
+    )
 
-    def __init__(self, loop=None, max_jobs=None, poll_delay=1, sbatch_args=None, **kwargs):
+    def __init__(
+        self, loop=None, max_jobs=None, poll_delay=1, sbatch_args=None, **kwargs
+    ):
         """Initialize Slurm Worker
 
         Parameters

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -25,17 +25,18 @@ class Worker:
         pass
 
     async def fetch_finished(self, futures):
-        """Awaits asyncio ``Tasks`` until one is finished
+        """
+        Awaits asyncio `Tasks` until one is finished.
 
         Parameters
         ----------
-        futures : set of ``Futures``
-            Pending tasks
+        futures : set of asyncio awaitables
+            Task execution coroutines or asyncio `Tasks`
 
         Returns
         -------
-        done : set
-            Finished or cancelled tasks
+        pending : set
+            Pending asyncio `Task`s
         """
         done = set()
         try:
@@ -79,18 +80,18 @@ class DistributedWorker(Worker):
 
     async def fetch_finished(self, futures):
         """
-        Awaits asyncio ``Tasks`` until one is finished.
+        Awaits asyncio `Task`s until one is finished.
         Limits number of submissions based on max_jobs attr.
 
         Parameters
         ----------
-        futures : set of ``Futures``
-            Pending tasks
+        futures : set of asyncio awaitables
+            Task execution coroutines or asyncio `Task`s
 
         Returns
         -------
-        done : set
-            Finished or cancelled tasks
+        pending : set
+            Pending asyncio `Task`s
         """
         done, unqueued = set(), set()
         job_slots = self.max_jobs - self._jobs if self.max_jobs else float("inf")


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
Revisits #64 and changes method of executing tasks with a `slurm` submitter.
- Avoids queuing workflows as standalone slurm jobs, unless its plugin differs from the submitter.
- Adds `max_jobs` attribute to limit the number of concurrent jobs.

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [x] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.