### PR TITLE
rf: clean up workflow execution

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -601,7 +601,8 @@ class Workflow(TaskBase):
         if not submitter:
             raise Exception("Submitter should already be set.")
         # at this point Workflow is stateless so this should be fine
-        await submitter.submit(self)
+        self.results_dict[None] = (None, self.checksum)
+        await submitter._run_workflow(self)
 
     def set_output(self, connections):
         if isinstance(connections, tuple) and len(connections) == 2:

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -93,7 +93,6 @@ class Submitter:
                     # tasks are submitted to worker for execution
                     futures.add(self.worker.run_el(job))
         else:
-            runnable.results_dict[None] = (None, runnable.checksum)
             if is_workflow(runnable):
                 await self._run_workflow(runnable)
             else:
@@ -127,7 +126,7 @@ class Submitter:
         graph_copy = wf.graph.copy()
         # keep track of pending futures
         task_futures = set()
-        while not wf.done_all_tasks:
+        while not wf.done_all_tasks or len(task_futures):
             tasks = get_runnable_tasks(graph_copy)
             if not tasks and not task_futures:
                 raise Exception("Nothing queued or todo - something went wrong")


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
Ensures `Submitter._run_workflow()` does not exit with pending futures.
RF workflow execution to go straight to _run_workflow

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.