### PR TITLE
fix:combine fixes#120

### DIFF
--- a/pydra/engine/state.py
+++ b/pydra/engine/state.py
@@ -13,10 +13,10 @@ class State:
         self.combiner = combiner
         if not self.other_states:
             self.other_states = {}
-        self.inner_inputs = {
-            "{}.{}".format(self.name, inp): st
-            for name, (st, inp) in self.other_states.items()
-        }
+        self.inner_inputs = {}
+        for name, (st, inp) in self.other_states.items():
+            if f"_{st.name}" in self.splitter_rpn_nost:
+                self.inner_inputs[f"{self.name}.{inp}"] = st
         self.set_input_groups()
         self.set_splitter_final()
         self.states_val = []

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -149,9 +149,6 @@ class FunctionTask(TaskBase):
         else:  # if only one element in the fields, everything should be returned together
             self.output_ = output
 
-    def _list_outputs(self):
-        return self.output_
-
 
 class ShellCommandTask(TaskBase):
     def __init__(
@@ -207,9 +204,6 @@ class ShellCommandTask(TaskBase):
         args = self.command_args
         if args:
             self.output_ = execute(args)
-
-    def _list_outputs(self):
-        return list(self.output_)
 
 
 class ContainerTask(ShellCommandTask):

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -231,6 +231,31 @@ def test_notannotated_func():
     assert result.output.out == 20.2
 
 
+def test_notannotated_func_returnlist():
+    @mark.task
+    def no_annots(c, d):
+        return [c, d]
+
+    natask = no_annots(c=17, d=3.2)
+    result = natask._run()
+    assert hasattr(result.output, "out")
+    assert result.output.out == [17, 3.2]
+
+
+def test_halfannotated_func_multrun_returnlist():
+    @mark.task
+    def no_annots(c, d) -> (list, float):
+        return [c, d], c + d
+
+    natask = no_annots(c=17, d=3.2)
+    result = natask._run()
+
+    assert hasattr(result.output, "out1")
+    assert hasattr(result.output, "out2")
+    assert result.output.out1 == [17, 3.2]
+    assert result.output.out2 == 20.2
+
+
 def test_notannotated_func_multreturn():
     """ no annotation and multiple values are returned
         all elements should be returned as a tuple ans set to "out"

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1909,10 +1909,19 @@ def test_workflow_combine1(tmpdir):
     wf1.add(power(name="power", a=wf1.lzin.a, b=wf1.lzin.b).split(["a", "b"]))
     wf1.add(identity(name="identity1", x=wf1.power.lzout.out).combine("power.a"))
     wf1.add(identity(name="identity2", x=wf1.identity1.lzout.out).combine("power.b"))
-    wf1.set_output({"out": wf1.identity2.lzout.out})
+    wf1.set_output(
+        {
+            "out_pow": wf1.power.lzout.out,
+            "out_iden1": wf1.identity1.lzout.out,
+            "out_iden2": wf1.identity2.lzout.out,
+        }
+    )
     wf1.cache_dir = tmpdir
     result = wf1(plugin="cf")
-    assert result.output.out == [[1, 4], [1, 8]]
+
+    assert result.output.out_pow == [1, 1, 4, 8]
+    assert result.output.out_iden1 == [[1, 4], [1, 8]]
+    assert result.output.out_iden2 == [[[1, 4], [1, 8]]]
 
 
 def test_workflow_combine2(tmpdir):
@@ -1924,7 +1933,6 @@ def test_workflow_combine2(tmpdir):
     wf1.set_output({"out_pow": wf1.power.lzout.out, "out_iden": wf1.identity.lzout.out})
     wf1.cache_dir = tmpdir
     result = wf1(plugin="cf")
-    wf1.identity.result()
 
     assert result.output.out_pow == [[1, 4], [1, 8]]
     assert result.output.out_iden == [[[1, 4], [1, 8]]]

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1907,22 +1907,24 @@ def test_cache_propagation3(tmpdir, create_tasks):
 def test_workflow_combine1(tmpdir):
     wf1 = Workflow(name="wf1", input_spec=["a", "b"], a=[1, 2], b=[2, 3])
     wf1.add(power(name="power", a=wf1.lzin.a, b=wf1.lzin.b).split(["a", "b"]))
-    wf1.add(
-        identity(name="identity1", x=wf1.power.lzout.out).combine("power.a"))
-    wf1.add(identity(name="identity2", x=wf1.identity1.lzout.out).combine(
-        "power.b"))
-    wf1.set_output({'out': wf1.identity2.lzout.out})
+    wf1.add(identity(name="identity1", x=wf1.power.lzout.out).combine("power.a"))
+    wf1.add(identity(name="identity2", x=wf1.identity1.lzout.out).combine("power.b"))
+    wf1.set_output({"out": wf1.identity2.lzout.out})
     wf1.cache_dir = tmpdir
-    result = wf1(plugin='cf')
-    assert result.output.out == [[1, 1], [4, 8]]
+    result = wf1(plugin="cf")
+    assert result.output.out == [[1, 4], [1, 8]]
 
 
 def test_workflow_combine2(tmpdir):
     wf1 = Workflow(name="wf1", input_spec=["a", "b"], a=[1, 2], b=[2, 3])
-    wf1.add(power(name="power", a=wf1.lzin.a, b=wf1.lzin.b).split(["a", "b"]).combine("a"))
-    wf1.add(identity(name="identity", x=wf1.power.lzout.out).combine(
-        "power.b"))
-    wf1.set_output({'out': wf1.identity.lzout.out})
+    wf1.add(
+        power(name="power", a=wf1.lzin.a, b=wf1.lzin.b).split(["a", "b"]).combine("a")
+    )
+    wf1.add(identity(name="identity", x=wf1.power.lzout.out).combine("power.b"))
+    wf1.set_output({"out_pow": wf1.power.lzout.out, "out_iden": wf1.identity.lzout.out})
     wf1.cache_dir = tmpdir
-    result = wf1(plugin='cf')
-    assert result.output.out == [[1, 1], [4, 8]]
+    result = wf1(plugin="cf")
+    wf1.identity.result()
+
+    assert result.output.out_pow == [[1, 4], [1, 8]]
+    assert result.output.out_iden == [[[1, 4], [1, 8]]]

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -3,7 +3,7 @@ import shutil
 import time
 import platform
 
-from .utils import add2, add2_wait, multiply
+from .utils import add2, add2_wait, multiply, power, identity
 from ..submitter import Submitter
 from ..core import Workflow
 from ... import mark
@@ -1902,3 +1902,27 @@ def test_cache_propagation3(tmpdir, create_tasks):
     wf.cache_dir = (tmpdir / "shared").strpath
     wf(plugin="cf")
     assert wf.cache_dir == t1.cache_dir == t2.cache_dir
+
+
+def test_workflow_combine1(tmpdir):
+    wf1 = Workflow(name="wf1", input_spec=["a", "b"], a=[1, 2], b=[2, 3])
+    wf1.add(power(name="power", a=wf1.lzin.a, b=wf1.lzin.b).split(["a", "b"]))
+    wf1.add(
+        identity(name="identity1", x=wf1.power.lzout.out).combine("power.a"))
+    wf1.add(identity(name="identity2", x=wf1.identity1.lzout.out).combine(
+        "power.b"))
+    wf1.set_output({'out': wf1.identity2.lzout.out})
+    wf1.cache_dir = tmpdir
+    result = wf1(plugin='cf')
+    assert result.output.out == [[1, 1], [4, 8]]
+
+
+def test_workflow_combine2(tmpdir):
+    wf1 = Workflow(name="wf1", input_spec=["a", "b"], a=[1, 2], b=[2, 3])
+    wf1.add(power(name="power", a=wf1.lzin.a, b=wf1.lzin.b).split(["a", "b"]).combine("a"))
+    wf1.add(identity(name="identity", x=wf1.power.lzout.out).combine(
+        "power.b"))
+    wf1.set_output({'out': wf1.identity.lzout.out})
+    wf1.cache_dir = tmpdir
+    result = wf1(plugin='cf')
+    assert result.output.out == [[1, 1], [4, 8]]

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -48,6 +48,16 @@ def add2(x):
 
 
 @mark.task
+def power(a, b):
+    return a ** b
+
+
+@mark.task
+def identity(x):
+    return x
+
+
+@mark.task
 def add2_wait(x):
     time.sleep(3)
     return x + 2


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
fixing tests for workflows with "delayed" combiners. There were two independent problems:
- output that was a list was not saved properly (only the first element)
- `State.inner_inputs` was not set properly for some workflows (elements of the dictionary were overwritten)
- fixing output of the tests (not combined properly)

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.