### PR TITLE
updates for splitter and combiner

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -358,7 +358,7 @@ class TaskBase:
 
     def combine(self, combiner, overwrite=False):
         if not isinstance(combiner, (str, list)):
-            raise Exception("combiner has to be a string or list")
+            raise Exception("combiner has to be a string or a list")
         combiner = hlpst.add_name_combiner(ensure_list(combiner), self.name)
         if (
             self.state

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -341,19 +341,35 @@ class TaskBase:
         output = output_klass(**{f.name: None for f in dc.fields(output_klass)})
         return dc.replace(output, **run_output)
 
-    def split(self, splitter, **kwargs):
+    def split(self, splitter, overwrite=False, **kwargs):
+        splitter = hlpst.add_name_splitter(splitter, self.name)
+        # if user want to update the splitter, overwrite has to be True
+        if self.state and not overwrite and self.state.splitter != splitter:
+            raise Exception(
+                "splitter has been already set, "
+                "if you want to overwrite it - use overwrite=True"
+            )
         if kwargs:
             self.inputs = dc.replace(self.inputs, **kwargs)
-            # dj:??, check if I need it
             self.state_inputs = kwargs
-        splitter = hlpst.add_name_splitter(splitter, self.name)
-        if self.state:
-            raise Exception("splitter has been already set")
-        else:
+        if not self.state or splitter != self.state.splitter:
             self.set_state(splitter)
         return self
 
-    def combine(self, combiner):
+    def combine(self, combiner, overwrite=False):
+        if not isinstance(combiner, (str, list)):
+            raise Exception("combiner has to be a string or list")
+        combiner = hlpst.add_name_combiner(ensure_list(combiner), self.name)
+        if (
+            self.state
+            and self.state.combiner
+            and combiner != self.state.combiner
+            and not overwrite
+        ):
+            raise Exception(
+                "combiner has been already set, "
+                "if you want to overwrite it - use overwrite=True"
+            )
         if not self.state:
             self.split(splitter=None)
             # a task can have a combiner without a splitter
@@ -361,8 +377,6 @@ class TaskBase:
             # self.fut_combiner will be used later as a combiner
             self.fut_combiner = combiner
             return self
-        elif self.state.combiner:
-            raise Exception("combiner has been already set")
         else:  # self.state and not self.state.combiner
             self.combiner = combiner
             self.set_state(splitter=self.state.splitter, combiner=self.combiner)

--- a/pydra/engine/state.py
+++ b/pydra/engine/state.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 from . import helpers_state as hlpst
+from .helpers import ensure_list
 from .specs import BaseSpec
 
 
@@ -81,6 +82,8 @@ class State:
 
     @splitter.setter
     def splitter(self, splitter):
+        if splitter and not isinstance(splitter, (str, tuple, list)):
+            raise Exception("splitter has to be string, tuple or list")
         if splitter:
             self._splitter = hlpst.add_name_splitter(splitter, self.name)
             self.splitter_rpn = hlpst.splitter2rpn(
@@ -122,11 +125,9 @@ class State:
         if combiner:
             if not self.splitter:
                 raise Exception("splitter has to be set before setting combiner")
-            if type(combiner) is str:
-                combiner = [combiner]
-            elif type(combiner) is not list:
+            if not isinstance(combiner, (str, list)):
                 raise Exception("combiner should be a string or a list")
-            self._combiner = hlpst.add_name_combiner(combiner, self.name)
+            self._combiner = hlpst.add_name_combiner(ensure_list(combiner), self.name)
             if set(self._combiner) - set(self.splitter_rpn):
                 raise Exception("all combiners should be in the splitter")
             # combiners from the current fields: i.e. {self.name}.input

--- a/pydra/engine/state.py
+++ b/pydra/engine/state.py
@@ -83,7 +83,7 @@ class State:
     @splitter.setter
     def splitter(self, splitter):
         if splitter and not isinstance(splitter, (str, tuple, list)):
-            raise Exception("splitter has to be string, tuple or list")
+            raise Exception("splitter has to be a string, a tuple or a list")
         if splitter:
             self._splitter = hlpst.add_name_splitter(splitter, self.name)
             self.splitter_rpn = hlpst.splitter2rpn(
@@ -126,10 +126,10 @@ class State:
             if not self.splitter:
                 raise Exception("splitter has to be set before setting combiner")
             if not isinstance(combiner, (str, list)):
-                raise Exception("combiner should be a string or a list")
+                raise Exception("combiner has to be a string or a list")
             self._combiner = hlpst.add_name_combiner(ensure_list(combiner), self.name)
             if set(self._combiner) - set(self.splitter_rpn):
-                raise Exception("all combiners should be in the splitter")
+                raise Exception("all combiners have to be in the splitter")
             # combiners from the current fields: i.e. {self.name}.input
             self._right_combiner = [
                 comb for comb in self._combiner if self.name in comb

--- a/pydra/engine/tests/test_state.py
+++ b/pydra/engine/tests/test_state.py
@@ -90,6 +90,24 @@ def test_state_1(
     assert st.inputs_ind == states_ind
 
 
+def test_state_2_err():
+    with pytest.raises(Exception) as exinfo:
+        st = State("NA", splitter={"a"})
+    assert "splitter has to be a string, a tuple or a list" == str(exinfo.value)
+
+
+def test_state_3_err():
+    with pytest.raises(Exception) as exinfo:
+        st = State("NA", splitter=["a", "b"], combiner=("a", "b"))
+    assert "combiner has to be a string or a list" == str(exinfo.value)
+
+
+def test_state_4_err():
+    with pytest.raises(Exception) as exinfo:
+        st = State("NA", splitter="a", combiner=["a", "b"])
+    assert "all combiners have to be in the splitter" == str(exinfo.value)
+
+
 def test_state_connect_1():
     """ two 'connected' states: testing groups, prepare_states and prepare_inputs
         no explicit splitter for the second state


### PR DESCRIPTION
… new splitter is the same as old splitter before raising exception (when overwrite=False)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- adding `overwrite` to `split` and `combine` methods to allow updates of `splitter` and `combiner`
- if `overwrite=False` the exception should still be raised, but checking if the new splitter/combiner is different from the old one
- fixing the issue in `split` and `combine` - the exception was raised too late

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.