### PR TITLE
fixing inner splitters in workflow's tasks

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -586,12 +586,21 @@ class Workflow(TaskBase):
                         )
         # if task has connections state has to be recalculated
         if other_states:
+            if task.state:
+                old_splitter = task.state.splitter
+            else:
+                old_splitter = None
             if hasattr(task, "fut_combiner"):
                 task.state = state.State(
-                    task.name, other_states=other_states, combiner=task.fut_combiner
+                    task.name,
+                    splitter=old_splitter,
+                    other_states=other_states,
+                    combiner=task.fut_combiner,
                 )
             else:
-                task.state = state.State(task.name, other_states=other_states)
+                task.state = state.State(
+                    task.name, splitter=old_splitter, other_states=other_states
+                )
 
     async def _run(self, submitter=None, **kwargs):
         # self.inputs = dc.replace(self.inputs, **kwargs) don't need it?

--- a/pydra/engine/helpers_state.py
+++ b/pydra/engine/helpers_state.py
@@ -33,31 +33,31 @@ def _ordering(
         # checking if the splitter dont contain splitter from previous nodes, i.e. has str "_NA", etc.
         if type(el[0]) is str and el[0].startswith("_"):
             node_nm = el[0][1:]
-            if node_nm not in other_states:
+            if node_nm not in other_states and state_fields:
                 raise Exception(
                     "can't ask for splitter from {}, other nodes that are connected: ".format(
                         node_nm, other_states.keys()
                     )
                 )
-            splitter_mod = add_name_splitter(
-                splitter=other_states[node_nm][0].splitter_final, name=node_nm
-            )
-            if state_fields:
+            elif state_fields:
+                splitter_mod = add_name_splitter(
+                    splitter=other_states[node_nm][0].splitter_final, name=node_nm
+                )
                 el = (splitter_mod, el[1])
             if other_states[node_nm][0].other_states:
                 other_states.update(other_states[node_nm][0].other_states)
         if type(el[1]) is str and el[1].startswith("_"):
             node_nm = el[1][1:]
-            if node_nm not in other_states:
+            if node_nm not in other_states and state_fields:
                 raise Exception(
                     "can't ask for splitter from {}, other nodes that are connected: ".format(
                         node_nm, other_states.keys()
                     )
                 )
-            splitter_mod = add_name_splitter(
-                splitter=other_states[node_nm][0].splitter_final, name=node_nm
-            )
-            if state_fields:
+            elif state_fields:
+                splitter_mod = add_name_splitter(
+                    splitter=other_states[node_nm][0].splitter_final, name=node_nm
+                )
                 el = (el[0], splitter_mod)
             if other_states[node_nm][0].other_states:
                 other_states.update(other_states[node_nm][0].other_states)
@@ -71,34 +71,34 @@ def _ordering(
     elif type(el) is list:
         if type(el[0]) is str and el[0].startswith("_"):
             node_nm = el[0][1:]
-            if node_nm not in other_states:
+            if node_nm not in other_states and state_fields:
                 raise Exception(
                     "can't ask for splitter from {}, other nodes that are connected: ".format(
                         node_nm, other_states.keys()
                     )
                 )
-            splitter_mod = add_name_splitter(
-                splitter=other_states[node_nm][0].splitter_final, name=node_nm
-            )
-            if state_fields:
+            elif state_fields:
+                splitter_mod = add_name_splitter(
+                    splitter=other_states[node_nm][0].splitter_final, name=node_nm
+                )
                 el[0] = splitter_mod
-            if other_states[node_nm][0].other_states:
-                other_states.update(other_states[node_nm][0].other_states)
+                if other_states[node_nm][0].other_states:
+                    other_states.update(other_states[node_nm][0].other_states)
         if type(el[1]) is str and el[1].startswith("_"):
             node_nm = el[1][1:]
-            if node_nm not in other_states:
+            if node_nm not in other_states and state_fields:
                 raise Exception(
                     "can't ask for splitter from {}, other nodes that are connected: ".format(
                         node_nm, other_states.keys()
                     )
                 )
-            splitter_mod = add_name_splitter(
-                splitter=other_states[node_nm][0].splitter_final, name=node_nm
-            )
-            if state_fields:
+            elif state_fields:
+                splitter_mod = add_name_splitter(
+                    splitter=other_states[node_nm][0].splitter_final, name=node_nm
+                )
                 el[1] = splitter_mod
-            if other_states[node_nm][0].other_states:
-                other_states.update(other_states[node_nm][0].other_states)
+                if other_states[node_nm][0].other_states:
+                    other_states.update(other_states[node_nm][0].other_states)
         _iterate_list(
             el,
             "*",
@@ -109,19 +109,19 @@ def _ordering(
     elif type(el) is str:
         if el.startswith("_"):
             node_nm = el[1:]
-            if node_nm not in other_states:
+            if node_nm not in other_states and state_fields:
                 raise Exception(
                     "can't ask for splitter from {}, other nodes that are connected: ".format(
                         node_nm, other_states.keys()
                     )
                 )
-            splitter_mod = add_name_splitter(
-                splitter=other_states[node_nm][0].splitter_final, name=node_nm
-            )
-            if state_fields:
+            elif state_fields:
+                splitter_mod = add_name_splitter(
+                    splitter=other_states[node_nm][0].splitter_final, name=node_nm
+                )
                 el = splitter_mod
-            if other_states[node_nm][0].other_states:
-                other_states.update(other_states[node_nm][0].other_states)
+                if other_states[node_nm][0].other_states:
+                    other_states.update(other_states[node_nm][0].other_states)
         if type(el) is str:
             output_splitter.append(el)
         elif type(el) is tuple:
@@ -687,16 +687,20 @@ def map_splits(split_iter, inputs):
 # Functions for merging and completing splitters in states.
 
 
-def connect_splitters(splitter, other_states):
+def connect_splitters(splitter, other_states, state_fields=False):
     if splitter:
         # if splitter is string, have to check if this is Left or Right part (Left is required)
         if isinstance(splitter, str):
             # so this is the Left part
             if splitter.startswith("_"):
-                left_part = _complete_left(left=splitter, other_states=other_states)
+                left_part = _complete_left(
+                    left=splitter, other_states=other_states, state_fields=state_fields
+                )
                 right_part = None
             else:  # this is Right part
-                left_part = _complete_left(other_states=other_states)
+                left_part = _complete_left(
+                    other_states=other_states, state_fields=state_fields
+                )
                 right_part = splitter
         # if splitter is tuple, it has to be either Left or Right part, you can't have (Left, Right)
         elif isinstance(splitter, tuple):
@@ -712,16 +716,24 @@ def connect_splitters(splitter, other_states):
         elif isinstance(splitter, list):
             lr_flag = _left_right_check(splitter, other_states=other_states)
             if lr_flag == "Left":
-                left_part = _complete_left(left=splitter, other_states=other_states)
+                left_part = _complete_left(
+                    left=splitter, other_states=other_states, state_fields=state_fields
+                )
                 right_part = None
             elif lr_flag == "Right":
-                left_part = _complete_left(other_states=other_states)
+                left_part = _complete_left(
+                    other_states=other_states, state_fields=state_fields
+                )
                 right_part = splitter
             elif (
                 _left_right_check(splitter[0], other_states=other_states) == "Left"
                 and _left_right_check(splitter[1], other_states=other_states) == "Right"
             ):
-                left_part = _complete_left(left=splitter[0], other_states=other_states)
+                left_part = _complete_left(
+                    left=splitter[0],
+                    other_states=other_states,
+                    state_fields=state_fields,
+                )
                 right_part = splitter[1]
             else:
                 raise Exception("splitter doesn't have separated Left and Right parts")
@@ -732,7 +744,7 @@ def connect_splitters(splitter, other_states):
             )
     else:
         # if there is no splitter, I create the Left part
-        left_part = _complete_left(other_states=other_states)
+        left_part = _complete_left(other_states=other_states, state_fields=state_fields)
         right_part = None
     if right_part:
         splitter = [deepcopy(left_part), deepcopy(right_part)]
@@ -741,10 +753,12 @@ def connect_splitters(splitter, other_states):
     return splitter, left_part, right_part
 
 
-def _complete_left(other_states, left=None):
+def _complete_left(other_states, left=None, state_fields=False):
     """completing Left part: adding all splitters from previous nodes"""
     if left:
-        rpn_left = splitter2rpn(left, other_states=other_states, state_fields=False)
+        rpn_left = splitter2rpn(
+            left, other_states=other_states, state_fields=state_fields
+        )
         for name, (st, inp) in list(other_states.items())[::-1]:
             if "_{}".format(name) not in rpn_left and st.splitter_final:
                 left = ["_{}".format(name), left]

--- a/pydra/engine/tests/test_helpers_state.py
+++ b/pydra/engine/tests/test_helpers_state.py
@@ -657,4 +657,4 @@ def test_connect_splitters(
 )
 def test_connect_splitters_exception(splitter, other_states):
     with pytest.raises(Exception):
-        hlpst.connect_splitters(splitter, other_states)
+        hlpst.connect_splitters(splitter, other_states, state_fields=True)

--- a/pydra/engine/tests/test_state.py
+++ b/pydra/engine/tests/test_state.py
@@ -148,7 +148,7 @@ def test_state_connect_1a():
 
 def test_state_connect_1b_exception():
     """can't provide explicitly NA.a (should be _NA)"""
-    st1 = State(name="NA", splitter="a")
+    st1 = State(name="NA", splitter="a", other_states={})
     with pytest.raises(Exception) as excinfo:
         st2 = State(name="NB", splitter="NA.a")
     assert "consider using _NA" in str(excinfo.value)

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -21,6 +21,11 @@ def fun_addvar(a, b):
 
 
 @mark.task
+def fun_addvar3(a, b, c):
+    return a + b + c
+
+
+@mark.task
 def fun_addvar4(a, b, c, d):
     return a + b + c + d
 
@@ -61,6 +66,11 @@ def identity(x):
 def add2_wait(x):
     time.sleep(3)
     return x + 2
+
+
+@mark.task
+def list_output(x):
+    return [x, 2 * x, 3 * x]
 
 
 def gen_basic_wf(name="basic-wf"):


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
fixing inner splitters in workflow's tasks:
- fixing `create_connections`, so the Right part of splitter (its own splitter) is also passed to the new state that takes also into account the Left part 
- changing `State` class, so it doesn't try to calculate the final `splitter_rpn` and states if connections are needed (i.e. Left part from previous states is provided), but not provided. It should be provided by `Workflow.create_connections` before running the workflow
-  changing `splitter2rpn`, so it doesn't return error if splitters from previous states (that are part of the Left part) are not provided and State is aware of the missing connections (i.e. `State.missing_connections = True`)

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.