### PR TITLE
fixing issues with state input fields that are empty lists

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -427,6 +427,14 @@ class TaskBase:
             # TODO: only check for needed state result
             if self.result() and all(self.result()):
                 return True
+            # checking if self.result() is not an empty list only because
+            # the states_ind is an empty list (input field might be an empty list)
+            elif (
+                self.result() == []
+                and hasattr(self.state, "states_ind")
+                and self.state.states_ind == []
+            ):
+                return True
         else:
             if self.result():
                 return True

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -487,7 +487,7 @@ class LazyField:
             node = getattr(wf, self.name)
             result = node.result(state_index=state_index)
             if isinstance(result, list):
-                if isinstance(result[0], list):
+                if len(result) and isinstance(result[0], list):
                     results_new = []
                     for res_l in result:
                         if self.field == "all_":
@@ -534,6 +534,6 @@ class TaskHook:
 def path_to_string(value):
     if isinstance(value, Path):
         value = str(value)
-    elif isinstance(value, list) and isinstance(value[0], Path):
+    elif isinstance(value, list) and len(value) and isinstance(value[0], Path):
         value = [str(val) for val in value]
     return value

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -159,7 +159,7 @@ class FunctionTask(TaskBase):
         del inputs["_func"]
         self.output_ = None
         output = cp.loads(self.inputs._func)(**inputs)
-        if output:
+        if output is not None:
             output_names = [el[0] for el in self.output_spec.fields]
             self.output_ = {}
             if len(output_names) > 1:

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -269,6 +269,20 @@ def test_task_init_5c():
     assert nn.state.splitter_rpn_final == ["NA.a"]
 
 
+def test_task_init_6():
+    """ task with splitter, but the input is an empty list"""
+    nn = fun_addtwo(name="NA", a=[])
+    nn.split(splitter="a")
+    assert nn.inputs.a == []
+
+    assert nn.state.splitter == "NA.a"
+    assert nn.state.splitter_rpn == ["NA.a"]
+
+    nn.state.prepare_states(nn.inputs)
+    assert nn.state.states_ind == []
+    assert nn.state.states_val == []
+
+
 def test_task_error():
     func = fun_div(name="div", a=1, b=0)
     with pytest.raises(ZeroDivisionError):
@@ -608,6 +622,27 @@ def test_task_state_singl_1(plugin):
 
 
 @pytest.mark.parametrize("plugin", Plugins)
+def test_task_state_2(plugin):
+    """ task with the simplest splitter, the input is an empty list"""
+    nn = fun_addtwo(name="NA").split(splitter="a", a=[])
+
+    assert nn.state.splitter == "NA.a"
+    assert nn.state.splitter_rpn == ["NA.a"]
+    assert nn.inputs.a == []
+
+    with Submitter(plugin=plugin) as sub:
+        sub(nn)
+
+    # checking the results
+    results = nn.result()
+    expected = []
+    for i, res in enumerate(expected):
+        assert results[i].output.out == res[1]
+    # checking the output_dir
+    assert nn.output_dir == []
+
+
+@pytest.mark.parametrize("plugin", Plugins)
 def test_task_state_comb_1(plugin):
     """ task with the simplest splitter and combiner"""
     nn = fun_addtwo(name="NA").split(a=[3, 5], splitter="a").combine(combiner="a")
@@ -773,6 +808,27 @@ def test_task_state_comb_singl_1(plugin):
     assert nn.output_dir
     for odir in nn.output_dir:
         assert odir.exists()
+
+
+@pytest.mark.parametrize("plugin", Plugins)
+def test_task_state_comb_2(plugin):
+    """ task with the simplest splitter, the input is an empty list"""
+    nn = fun_addtwo(name="NA").split(splitter="a", a=[]).combine(combiner=["a"])
+
+    assert nn.state.splitter == "NA.a"
+    assert nn.state.splitter_rpn == ["NA.a"]
+    assert nn.inputs.a == []
+
+    with Submitter(plugin=plugin) as sub:
+        sub(nn)
+
+    # checking the results
+    results = nn.result()
+    expected = []
+    for i, res in enumerate(expected):
+        assert results[i].output.out == res[1]
+    # checking the output_dir
+    assert nn.output_dir == []
 
 
 @pytest.mark.parametrize("plugin", Plugins)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
pydra didn't work when task has a state, but the input is an empty list

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.