### PR TITLE
list as a single element of an input

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -11,11 +11,13 @@ import subprocess as sp
 from .specs import Runtime, File
 
 
-def ensure_list(obj):
+def ensure_list(obj, tuple2list=False):
     if obj is None:
         return []
     if isinstance(obj, list):
         return obj
+    elif tuple2list and isinstance(obj, tuple):
+        return list(obj)
     return [obj]
 
 

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -240,7 +240,7 @@ class ShellCommandTask(TaskBase):
                 if value is not True:
                     break
             else:
-                cmd_add += ensure_list(value)
+                cmd_add += ensure_list(value, tuple2list=True)
             if cmd_add is not None:
                 pos_args.append((pos, cmd_add))
         # sorting all elements of the command


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
addressing issue with tasks that requires list as a single input: had examples for the task only without state. For tasks with a state decided to use a tuple (not a list) to distinguish between a "single element" and multiple elements that should be split.

For shell task, `command_args` had to be modified so it passes multiple elements, not a tuple.


## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.