### PR TITLE
[fix] fixing cmdline (closes #141)

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -247,9 +247,9 @@ class TaskBase:
             TODO
 
         """
+        self.state.prepare_states(self.inputs)
+        self.state.prepare_inputs()
         if state_index is not None:
-            if self.state is None:
-                raise Exception("can't use state_index if no splitter is used")
             inputs_copy = deepcopy(self.inputs)
             for key, ind in self.state.inputs_ind[state_index].items():
                 setattr(
@@ -510,6 +510,9 @@ class TaskBase:
     @property
     def done(self):
         """Check whether the tasks has been finalized and all outputs are stored."""
+        # if any of the field is lazy, there is no need to check results
+        if is_lazy(self.inputs):
+            return False
         if self.state:
             # TODO: only check for needed state result
             if self.result() and all(self.result()):
@@ -866,3 +869,11 @@ def is_task(obj):
 def is_workflow(obj):
     """Check whether an object is a :class:`Workflow` instance."""
     return isinstance(obj, Workflow)
+
+
+def is_lazy(obj):
+    """Check whether an object has any field that is a Lazy Field"""
+    for f in attr_fields(obj):
+        if isinstance(getattr(obj, f.name), LazyField):
+            return True
+    return False

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -122,8 +122,7 @@ def test_shell_cmd_3(plugin):
 
     # all args given as executable
     shelly = ShellCommandTask(name="shelly", executable=cmd).split("executable")
-    # TODO: doesnt make sense for tasks with splitter
-    #    assert shelly.cmdline == " ".join(cmd)
+    assert shelly.cmdline == ["pwd", "whoami"]
     res = shelly(plugin=plugin)
     assert res[0].output.stdout == f"{str(shelly.output_dir[0])}\n"
     if "USER" in os.environ:
@@ -147,8 +146,7 @@ def test_shell_cmd_4(plugin):
     )
     assert shelly.inputs.executable == "echo"
     assert shelly.inputs.args == ["nipype", "pydra"]
-    # this doesnt work, cmdline gives echo nipype pydra
-    # assert shelly.cmdline == "echo pydra"
+    assert shelly.cmdline == ["echo nipype", "echo pydra"]
     res = shelly(plugin=plugin)
 
     assert res[0].output.stdout == "nipype\n"
@@ -173,8 +171,7 @@ def test_shell_cmd_5(plugin):
     )
     assert shelly.inputs.executable == "echo"
     assert shelly.inputs.args == ["nipype", "pydra"]
-    # this doesnt work, cmdline gives echo nipype pydra
-    # assert shelly.cmdline == "echo pydra"
+    assert shelly.cmdline == ["echo nipype", "echo pydra"]
     res = shelly(plugin=plugin)
 
     assert res[0][0].output.stdout == "nipype\n"
@@ -194,8 +191,12 @@ def test_shell_cmd_6(plugin):
     )
     assert shelly.inputs.executable == ["echo", ["echo", "-n"]]
     assert shelly.inputs.args == ["nipype", "pydra"]
-    # this doesnt work, cmdline gives echo nipype pydra
-    # assert shelly.cmdline == "echo pydra"
+    assert shelly.cmdline == [
+        "echo nipype",
+        "echo pydra",
+        "echo -n nipype",
+        "echo -n pydra",
+    ]
     res = shelly(plugin=plugin)
 
     assert res[0].output.stdout == "nipype\n"
@@ -234,8 +235,7 @@ def test_shell_cmd_7(plugin):
     )
     assert shelly.inputs.executable == ["echo", ["echo", "-n"]]
     assert shelly.inputs.args == ["nipype", "pydra"]
-    # this doesnt work, cmdline gives echo nipype pydra
-    # assert shelly.cmdline == "echo pydra"
+
     res = shelly(plugin=plugin)
 
     assert res[0][0].output.stdout == "nipype\n"
@@ -2251,9 +2251,7 @@ def test_fsl():
 
     # TODO: not sure why this has to be string
     in_file = Path(os.path.dirname(os.path.abspath(__file__))) / "data" / "foo.nii"
-    out_file = (
-        Path(os.path.dirname(os.path.abspath(__file__))) / "data" / "foo_brain.nii"
-    )
+
     # separate command into exec + args
     shelly = ShellCommandTask(
         name="bet_task", executable="bet", in_file=in_file, input_spec=bet_input_spec

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -351,7 +351,7 @@ def test_shell_cmd(tmpdir):
 
 
 def test_container_cmds(tmpdir):
-    containy = ContainerTask(name="containy", executable="pwd")
+    containy = DockerTask(name="containy", executable="pwd")
     with pytest.raises(AttributeError):
         containy.cmdline
     containy.inputs.container = "docker"


### PR DESCRIPTION


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- fixing `cmdline`, `command_args` and `container_args` so they work if the task has a state (return a list if state) 
- adding `is_lazy` to be able to check if inputs has lazy fields - prevents to run `results()`, and `checksum_states` if inputs is not ready

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.