### PR TITLE
using hash_file for lists and tuples (closes #178)

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -113,7 +113,7 @@ def hash_file(afile, chunk_len=8192, crypto=sha256, raise_notfound=True):
     from .helpers import hash_function
 
     # adding option for tasks with splitter over list of files
-    if isinstance(afile, list):
+    if isinstance(afile, (list, tuple)):
         return hash_function([hash_file(el) for el in afile])
 
     if afile is None or isinstance(afile, LazyField) or isinstance(afile, list):

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -50,6 +50,8 @@ class BaseSpec:
                 continue
             if field.type == File and "container_path" not in field.metadata:
                 inp_dict[field.name] = hash_file(getattr(self, field.name))
+            elif field.type == ty.List[File] or field.type == ty.Tuple[File]:
+                inp_dict[field.name] = hash_file(getattr(self, field.name))
             elif isinstance(getattr(self, field.name), tuple):
                 inp_dict[field.name] = list(getattr(self, field.name))
             else:

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -391,7 +391,7 @@ class ShellCommandTask(TaskBase):
             args = self.command_args
         if args:
             # removing emty strings
-            args = [el for el in args if el not in ["", " "]]
+            args = [str(el) for el in args if el not in ["", " "]]
             keys = ["return_code", "stdout", "stderr"]
             values = execute(args, strip=self.strip)
             self.output_ = dict(zip(keys, values))

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -953,6 +953,48 @@ def test_shell_cmd_inputspec_7a(plugin, results_function):
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
 @pytest.mark.parametrize("plugin", Plugins)
+def test_shell_cmd_inputspec_8(plugin, results_function, tmpdir):
+    """ using input_spec, providing list of files as an input """
+
+    file_1 = tmpdir.join("file_1.txt")
+    file_2 = tmpdir.join("file_2.txt")
+    with open(file_1, "w") as f:
+        f.write("hello ")
+    with open(file_2, "w") as f:
+        f.write("from boston")
+
+    cmd_exec = "cat"
+    files_list = [file_1, file_2]
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "files",
+                attr.ib(
+                    type=ty.List[File],
+                    metadata={
+                        "position": 1,
+                        "help_string": "list of files",
+                        "mandatory": True,
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly", executable=cmd_exec, files=files_list, input_spec=my_input_spec
+    )
+
+    assert shelly.inputs.executable == cmd_exec
+    res = results_function(shelly, plugin)
+    assert res.output.stdout == "hello from boston"
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_copyfile_1(plugin, results_function, tmpdir):
     """ shelltask changes a file in place,
         adding copyfile=True to the file-input from input_spec


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
calling `hash_file` if type is ty.List[File] or ty.Tuple[File], `hash_file` can handle lists/tuples

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.