### PR TITLE
[ci] checking that the input doesn't change when the node/wf is run

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -71,6 +71,28 @@ class BaseSpec:
         for field, value in temp_values.items():
             setattr(self, field, value)
 
+    def compare(self, other, check_all=False):
+        """ comparing two inputs, if they have the same fields and if the values are the same,
+            if check_all=False private fields (start with _) are ignored
+        """
+        if check_all:
+            names = {el.name for el in attr_fields(self)}
+            names_other = {el.name for el in attr_fields(other)}
+        else:
+            names = {el.name for el in attr_fields(self) if not el.name.startswith("_")}
+            names_other = {
+                el.name for el in attr_fields(other) if not el.name.startswith("_")
+            }
+
+        if names != names_other:
+            return False
+
+        for nm in names:
+            if getattr(self, nm) != getattr(other, nm):
+                return False
+
+        return True
+
     def check_metadata(self):
         """Check contained metadata."""
 

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import numpy as np
 import pytest
+from copy import deepcopy
 
 from .utils import fun_addtwo, fun_addvar, moment, fun_div
 
@@ -308,6 +309,7 @@ def test_task_nostate_1(plugin):
     assert np.allclose(nn.inputs.a, [3])
     assert nn.state is None
 
+    nn_inputs_before = deepcopy(nn.inputs)
     with Submitter(plugin=plugin) as sub:
         sub(nn)
 
@@ -316,6 +318,8 @@ def test_task_nostate_1(plugin):
     assert results.output.out == 5
     # checking the output_dir
     assert nn.output_dir.exists()
+    # checking that the input hasn't changed
+    assert nn.inputs.compare(nn_inputs_before)
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -631,6 +635,7 @@ def test_task_state_2(plugin, splitter, state_splitter, state_rpn, expected):
     assert nn.state.splitter_final == state_splitter
     assert nn.state.splitter_rpn_final == state_rpn
 
+    nn_inputs_before = deepcopy(nn.inputs)
     with Submitter(plugin=plugin) as sub:
         sub(nn)
 
@@ -642,6 +647,8 @@ def test_task_state_2(plugin, splitter, state_splitter, state_rpn, expected):
     assert nn.output_dir
     for odir in nn.output_dir:
         assert odir.exists()
+    # checking that the input hasn't changed
+    assert nn.inputs.compare(nn_inputs_before)
 
 
 @pytest.mark.parametrize("plugin", Plugins)

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1,7 +1,7 @@
 import pytest
 import shutil, os
 import time
-import platform
+from copy import deepcopy
 
 from .utils import (
     add2,
@@ -15,7 +15,6 @@ from .utils import (
 )
 from ..submitter import Submitter
 from ..core import Workflow
-from ... import mark
 
 
 if bool(shutil.which("sbatch")):
@@ -121,12 +120,15 @@ def test_wf_2(plugin):
     wf.inputs.y = 3
     wf.plugin = plugin
 
+    wf_inputs_before = deepcopy(wf.inputs)
     with Submitter(plugin=plugin) as sub:
         sub(wf)
 
     assert wf.output_dir.exists()
     results = wf.result()
     assert 8 == results.output.out
+    # checking that the input hasn't changed
+    assert wf.inputs.compare(wf_inputs_before)
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -539,6 +541,7 @@ def test_wf_st_4(plugin):
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.plugin = plugin
 
+    wf_inputs_before = deepcopy(wf.inputs)
     with Submitter(plugin=plugin) as sub:
         sub(wf)
 
@@ -552,6 +555,8 @@ def test_wf_st_4(plugin):
     assert wf.output_dir
     for odir in wf.output_dir:
         assert odir.exists()
+    # checking that the input hasn't changed
+    assert wf.inputs.compare(wf_inputs_before)
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -1141,6 +1146,7 @@ def test_wf_ndstinner_3(plugin):
     wf.set_output([("out_list", wf.list.lzout.out), ("out", wf.mult.lzout.out)])
     wf.plugin = plugin
 
+    wf_inputs_before = deepcopy(wf.inputs)
     with Submitter(plugin=plugin) as sub:
         sub(wf)
 
@@ -1152,6 +1158,8 @@ def test_wf_ndstinner_3(plugin):
     assert results.output.out == [10, 100, 20, 200, 30, 300]
 
     assert wf.output_dir.exists()
+    # checking that the input hasn't changed
+    assert wf.inputs.compare(wf_inputs_before)
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -1331,6 +1339,7 @@ def test_wfasnd_wfinp_1(plugin):
     wf.plugin = plugin
 
     checksum_before = wf.checksum
+    wf_inputs_before = deepcopy(wf.inputs)
     with Submitter(plugin=plugin) as sub:
         sub(wf)
 
@@ -1339,6 +1348,8 @@ def test_wfasnd_wfinp_1(plugin):
     assert results.output.out == 4
     # checking the output directory
     assert wf.output_dir.exists()
+    # checking that the input hasn't changed
+    assert wf.inputs.compare(wf_inputs_before)
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -1633,6 +1644,8 @@ def test_wfasnd_ndst_3(plugin):
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
 
+    wf_inputs_before = deepcopy(wf.inputs)
+
     with Submitter(plugin=plugin) as sub:
         sub(wf)
     # assert wf.output_dir.exists()
@@ -1640,6 +1653,8 @@ def test_wfasnd_ndst_3(plugin):
     assert results.output.out == [4, 42]
     # checking the output directory
     assert wf.output_dir.exists()
+    # checking that the input hasn't changed
+    assert wf.inputs.compare(wf_inputs_before)
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -1662,8 +1677,11 @@ def test_wfasnd_wfst_3(plugin):
     wf.set_output([("out", wf.wfnd.lzout.out)])
     wf.plugin = plugin
 
+    wf_inputs_before = deepcopy(wf.inputs)
+
     with Submitter(plugin=plugin) as sub:
         sub(wf)
+
     # assert wf.output_dir.exists()
     results = wf.result()
     assert results[0].output.out == 4
@@ -1672,6 +1690,8 @@ def test_wfasnd_wfst_3(plugin):
     assert wf.output_dir
     for odir in wf.output_dir:
         assert odir.exists()
+    # checking that the input hasn't changed
+    assert wf.inputs.compare(wf_inputs_before)
 
 
 # Testing caching


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
addresses one point from #179

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.