### PR TITLE
[fix] passing wf.cache_locations and submitter.rerun

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -800,6 +800,8 @@ class Workflow(TaskBase):
                 return result
         # creating connections that were defined after adding tasks to the wf
         for task in self.graph.nodes:
+            if self.task_rerun:
+                task.task_rerun = self.task_rerun
             task.cache_locations = task._cache_locations + self.cache_locations
             self.create_connections(task)
         # TODO add signal handler for processes killed after lock acquisition

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -811,7 +811,7 @@ class Workflow(TaskBase):
             self.hooks.pre_run_task(self)
             try:
                 self.audit.monitor()
-                await self._run_task(submitter)
+                await self._run_task(submitter, rerun=rerun)
                 result.output = self._collect_outputs()
             except Exception as e:
                 record_error(self.output_dir, e)
@@ -825,11 +825,11 @@ class Workflow(TaskBase):
         self.hooks.post_run(self, result)
         return result
 
-    async def _run_task(self, submitter):
+    async def _run_task(self, submitter, rerun=False):
         if not submitter:
             raise Exception("Submitter should already be set.")
         # at this point Workflow is stateless so this should be fine
-        await submitter._run_workflow(self)
+        await submitter._run_workflow(self, rerun=rerun)
 
     def set_output(self, connections):
         """

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -795,6 +795,7 @@ class Workflow(TaskBase):
                 return result
         # creating connections that were defined after adding tasks to the wf
         for task in self.graph.nodes:
+            task.cache_locations = task._cache_locations + self.cache_locations
             self.create_connections(task)
         # TODO add signal handler for processes killed after lock acquisition
         self.hooks.pre_run(self)

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -75,6 +75,7 @@ class FunctionTask(TaskBase):
         messengers=None,
         name=None,
         output_spec: ty.Optional[BaseSpec] = None,
+        rerun=False,
         **kwargs,
     ):
         """
@@ -143,6 +144,7 @@ class FunctionTask(TaskBase):
             messenger_args=messenger_args,
             cache_dir=cache_dir,
             cache_locations=cache_locations,
+            rerun=rerun,
         )
         if output_spec is None:
             if "return" not in func.__annotations__:
@@ -242,6 +244,7 @@ class ShellCommandTask(TaskBase):
         messengers=None,
         name=None,
         output_spec: ty.Optional[SpecInfo] = None,
+        rerun=False,
         strip=False,
         **kwargs,
     ):
@@ -283,6 +286,7 @@ class ShellCommandTask(TaskBase):
             messengers=messengers,
             messenger_args=messenger_args,
             cache_dir=cache_dir,
+            rerun=rerun,
         )
         self.strip = strip
 
@@ -412,6 +416,7 @@ class ContainerTask(ShellCommandTask):
         messengers=None,
         output_cpath="/output_pydra",
         output_spec: ty.Optional[SpecInfo] = None,
+        rerun=False,
         strip=False,
         **kwargs,
     ):
@@ -452,6 +457,7 @@ class ContainerTask(ShellCommandTask):
             messenger_args=messenger_args,
             cache_dir=cache_dir,
             strip=strip,
+            rerun=rerun,
             **kwargs,
         )
 
@@ -523,6 +529,7 @@ class DockerTask(ContainerTask):
         messengers=None,
         output_cpath="/output_pydra",
         output_spec: ty.Optional[SpecInfo] = None,
+        rerun=False,
         strip=False,
         **kwargs,
     ):
@@ -565,6 +572,7 @@ class DockerTask(ContainerTask):
                 cache_dir=cache_dir,
                 strip=strip,
                 output_cpath=output_cpath,
+                rerun=rerun,
                 **kwargs,
             )
             self.inputs.container_xargs = ["--rm"]
@@ -619,6 +627,7 @@ class SingularityTask(ContainerTask):
         messenger_args=None,
         messengers=None,
         output_spec: ty.Optional[SpecInfo] = None,
+        rerun=False,
         strip=False,
         **kwargs,
     ):
@@ -658,6 +667,7 @@ class SingularityTask(ContainerTask):
                 messenger_args=messenger_args,
                 cache_dir=cache_dir,
                 strip=strip,
+                rerun=rerun,
                 **kwargs,
             )
             self.init = True

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -2104,8 +2104,6 @@ def test_wf_nostate_cachelocations_wftaskrerun_propagateFalse(plugin, tmpdir):
     # tasks should not be recomputed
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
     assert len(list(Path(cache_dir2).glob("F*"))) == 0
-    assert t1 > 3
-    assert t2 < 1
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -2213,14 +2211,10 @@ def test_wf_nostate_nodecachelocations(plugin, tmpdir):
     results2 = wf2.result()
     assert 12 == results2.output.out
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 < 0.5
-
     # checking if the second wf runs again, but runs only one task
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
-
+    # the second wf should rerun one task
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
@@ -2270,12 +2264,9 @@ def test_wf_nostate_nodecachelocations_upd(plugin, tmpdir):
     # checking if the second wf runs again, but runs only one task
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
-
+    # the second wf should have only one task run
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
-    # checking execution time
-    assert t1 > 3
-    assert t2 < 0.5
 
 
 @pytest.mark.parametrize("plugin", Plugins)
@@ -2639,9 +2630,9 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
 
-    # checking execution time (second task shouldn't be recompute, t2 should be small)
-    assert t1 > 3
-    assert t2 < 1
+    # the second wf should have only one task run
+    assert len(list(Path(cache_dir1).glob("F*"))) == 2
+    assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
 @pytest.mark.parametrize("plugin", Plugins)

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -2358,7 +2358,8 @@ def test_wf_nostate_cachelocations_updated(plugin, tmpdir):
 def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     """
     Two wfs with the same inputs but slightly different graph;
-    the second wf should recompute the results
+    the second wf should recompute the results,
+    but the second node should use the results from the first wf (has the same input)
     """
     cache_dir1 = tmpdir.mkdir("test_wf_cache3")
     cache_dir2 = tmpdir.mkdir("test_wf_cache4")
@@ -2401,13 +2402,13 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 > 3
-
     # checking if both dir exists
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
+
+    # checking execution time (second task shouldn't be recompute, t2 should be small)
+    assert t1 > 3
+    assert t2 < 0.5
 
 
 @pytest.mark.parametrize("plugin", Plugins)

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1989,6 +1989,126 @@ def test_wf_nostate_cachelocations_forcererun(plugin, tmpdir):
 
 
 @pytest.mark.parametrize("plugin", Plugins)
+def test_wf_nostate_cachelocations_wftaskrerun(plugin, tmpdir):
+    """
+    Two identical wfs with provided cache_dir;
+    the second wf has cache_locations and rerun=True,
+    so the workflow is rerun, but it doesn't propagate to nodes,
+    so none of the node has to be recalculated
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y))
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out", wf1.add2.lzout.out)])
+    wf1.inputs.x = 2
+    wf1.inputs.y = 3
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert 8 == results1.output.out
+
+    wf2 = Workflow(
+        name="wf",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+        rerun=True,
+    )
+    wf2.add(multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y))
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out))
+    wf2.set_output([("out", wf2.add2.lzout.out)])
+    wf2.inputs.x = 2
+    wf2.inputs.y = 3
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert 8 == results2.output.out
+
+    # checking if the second wf runs again
+    assert wf1.output_dir.exists()
+    assert wf2.output_dir.exists()
+
+    # even if the second wf is recomputed the nodes are not, so it's fast
+    assert len(list(Path(cache_dir1).glob("F*"))) == 2
+    assert len(list(Path(cache_dir2).glob("F*"))) == 0
+    assert t1 > 3
+    assert t2 < 1
+
+
+@pytest.mark.parametrize("plugin", Plugins)
+def test_wf_nostate_cachelocations_taskrerun(plugin, tmpdir):
+    """
+    Two identical wfs with provided cache_dir;
+    the second wf has cache_locations and rerun=True
+    and one of the task also has rerun=True;
+    so the workflow is rerun, and one of the node also has to be rerun,
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y))
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out", wf1.add2.lzout.out)])
+    wf1.inputs.x = 2
+    wf1.inputs.y = 3
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert 8 == results1.output.out
+
+    wf2 = Workflow(
+        name="wf",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+        rerun=True,
+    )
+    wf2.add(multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y))
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out, rerun=True))
+    wf2.set_output([("out", wf2.add2.lzout.out)])
+    wf2.inputs.x = 2
+    wf2.inputs.y = 3
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert 8 == results2.output.out
+
+    # checking if the second wf runs again
+    assert wf1.output_dir.exists()
+    assert wf2.output_dir.exists()
+
+    # the second task also has to be recomputed this time
+    assert len(list(Path(cache_dir1).glob("F*"))) == 2
+    assert len(list(Path(cache_dir2).glob("F*"))) == 1
+    assert t1 > 3
+    assert t2 > 3
+
+
+@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_nodecachelocations(plugin, tmpdir):
     """
     Two wfs with different input, but the second node has the same input;
@@ -2408,7 +2528,7 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
 
     # checking execution time (second task shouldn't be recompute, t2 should be small)
     assert t1 > 3
-    assert t2 < 0.5
+    assert t2 < 1
 
 
 @pytest.mark.parametrize("plugin", Plugins)

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -88,6 +88,11 @@ def identity(x):
 
 
 @mark.task
+def ten(x):
+    return 10
+
+
+@mark.task
 def add2_wait(x):
     time.sleep(3)
     return x + 2


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- tasks from a workflow didn't see the `cache_locations` from the workflow, now `wf.cache_locations` is added to each task
- `rerun` from `Submitter.__call__` is passed everywhere, so everything is rerun
- adding `task_rerun` to `Task` attribute; 
- for `Workflow` there is one more flag `propagate_rerun`: if set to `False`, the wf is triggered, but tasks are not automatically rerun (only if they have `task_rerun=True`) 

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.