### PR TITLE
[ENH] set `n_proc` to max available by default in `ConcurrentFuturesWorker`

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -513,3 +513,31 @@ def output_from_inputfields(output_spec, inputs):
                 (field_name, attr.ib(type=File, metadata={"value": value}))
             )
     return output_spec
+
+
+def get_available_cpus():
+    """
+    Return the number of CPUs available to the current process or, if that is not
+    available, the total number of CPUs on the system.
+
+    Returns
+    -------
+    n_proc : :obj:`int`
+        The number of available CPUs.
+    """
+    # Will not work on some systems or if psutil is not installed.
+    # See https://psutil.readthedocs.io/en/latest/#psutil.Process.cpu_affinity
+    try:
+        import psutil
+
+        return len(psutil.Process().cpu_affinity())
+    except (AttributeError, ImportError, NotImplementedError):
+        pass
+
+    # Not available on all systems, including macOS.
+    # See https://docs.python.org/3/library/os.html#os.sched_getaffinity
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+
+    # Last resort
+    return os.cpu_count()

--- a/pydra/engine/tests/test_helpers.py
+++ b/pydra/engine/tests/test_helpers.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import platform
 
 import pytest
 import cloudpickle as cp
@@ -170,10 +171,14 @@ def test_get_available_cpus():
         import psutil
 
         has_psutil = True
-        assert get_available_cpus() == len(psutil.Process().cpu_affinity())
     except ImportError:
         has_psutil = False
+
     if hasattr(os, "sched_getaffinity"):
         assert get_available_cpus() == len(os.sched_getaffinity(0))
-    elif not has_psutil:
+
+    if has_psutil and platform.system().lower() != "darwin":
+        assert get_available_cpus() == len(psutil.Process().cpu_affinity())
+
+    if platform.system().lower() == "darwin":
         assert get_available_cpus() == os.cpu_count()

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import concurrent.futures as cf
 
-from .helpers import create_pyscript, read_and_display_async, save
+from .helpers import create_pyscript, get_available_cpus, read_and_display_async, save
 
 import logging
 
@@ -164,7 +164,7 @@ class ConcurrentFuturesWorker(Worker):
     def __init__(self, n_procs=None):
         """Initialize Worker."""
         super(ConcurrentFuturesWorker, self).__init__()
-        self.n_procs = n_procs
+        self.n_procs = get_available_cpus() if n_procs is None else n_procs
         # added cpu_count to verify, remove once confident and let PPE handle
         self.pool = cf.ProcessPoolExecutor(self.n_procs)
         # self.loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->

Adds a method `pydra.helpers.get_available_cpus` that returns the number of CPUs available to the current process or, if that is not available, the number of CPUs on the system. Tests included.

Closes #177 

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [x] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.