### PR TITLE
FIX: test equality of sorted list of hash values

### DIFF
--- a/pydra/engine/tests/test_helpers.py
+++ b/pydra/engine/tests/test_helpers.py
@@ -135,7 +135,9 @@ def test_hash_value_dir(tmpdir):
     with open(file_2, "w") as f:
         f.write("hi")
 
-    assert hash_value(tmpdir, tp=Directory) == hash_value([file_1, file_2], tp=File)
+    assert sorted(hash_value(tmpdir, tp=Directory)) == sorted(
+        hash_value([file_1, file_2], tp=File)
+    )
     assert hash_value(tmpdir, tp=Directory) == helpers_file.hash_dir(tmpdir)
 
 

--- a/pydra/engine/tests/test_helpers.py
+++ b/pydra/engine/tests/test_helpers.py
@@ -171,7 +171,9 @@ def test_hash_value_nested(tmpdir):
     assert orig_hash == test_sha.hexdigest()
     assert orig_hash == hash_value(tmpdir, tp=Directory)
 
-    nohidden_hash = helpers_file.hash_dir(tmpdir, ignore_hidden_dirs=True, ignore_hidden_files=True)
+    nohidden_hash = helpers_file.hash_dir(
+        tmpdir, ignore_hidden_dirs=True, ignore_hidden_files=True
+    )
     nohiddendirs_hash = helpers_file.hash_dir(tmpdir, ignore_hidden_dirs=True)
     nohiddenfiles_hash = helpers_file.hash_dir(tmpdir, ignore_hidden_files=True)
 


### PR DESCRIPTION

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->

The `helpers.hash_value` function does not guarantee order when giving the hashes of files in a directory, so this commit takes that into account by sorting the output of the `hash_value` calls before comparing.

This test was previously failing on my machine:

```
Linux dash 4.19.0-8-amd64 #1 SMP Debian 4.19.98-1 (2020-01-26) x86_64 GNU/Linux
python 3.8.2, pytest 5.4.1
ext4 filesystem
```

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
