### PR TITLE
[ fix] adding wf._connection to the checksum (closes #253, closes #252)

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -927,18 +927,29 @@ class Workflow(TaskBase):
             TODO
 
         """
+        if self._connections is None:
+            self._connections = []
         if isinstance(connections, tuple) and len(connections) == 2:
-            self._connections = [connections]
+            new_connections = [connections]
         elif isinstance(connections, list) and all(
             [len(el) == 2 for el in connections]
         ):
-            self._connections = connections
+            new_connections = connections
         elif isinstance(connections, dict):
-            self._connections = list(connections.items())
+            new_connections = list(connections.items())
         else:
             raise Exception(
                 "Connections can be a 2-elements tuple, a list of these tuples, or dictionary"
             )
+        # checking if a new output name is already in the connections
+        connection_names = [name for name, _ in self._connections]
+        new_names = [name for name, _ in new_connections]
+        if set(connection_names).intersection(new_names):
+            raise Exception(
+                f"output name {set(connection_names).intersection(new_names)} is already set"
+            )
+
+        self._connections += new_connections
         fields = [(name, ty.Any) for name, _ in self._connections]
         self.output_spec = SpecInfo(name="Output", fields=fields, bases=(BaseSpec,))
         logger.info("Added %s to %s", self.output_spec, self)

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -219,34 +219,26 @@ class TaskBase:
 
     @property
     def checksum(self):
-        """Calculate a unique checksum of this task."""
-        # if checksum is called before run the _graph_checksums is not ready
-        if is_workflow(self) and self.inputs._graph_checksums is attr.NOTHING:
-            self.inputs._graph_checksums = [nd.checksum for nd in self.graph_sorted]
-
+        """ Calculates the unique checksum of the task.
+            Used to create specific directory name for task that are run;
+            and to create nodes checksums needed for graph checkums
+            (before the tasks have inputs etc.)
+        """
         input_hash = self.inputs.hash
-        if self.state is None and not is_workflow(self):
+        if self.state is None:
             self._checksum = create_checksum(self.__class__.__name__, input_hash)
         else:
-            hash_list = [input_hash]
-            if self.state:
-                # including splitter in the hash
-                splitter_hash = hash_function(self.state.splitter)
-                hash_list.append(splitter_hash)
-            if is_workflow(self):
-                con_hash = hash_function(self._connections)
-                hash_list.append(con_hash)
+            splitter_hash = hash_function(self.state.splitter)
             self._checksum = create_checksum(
-                self.__class__.__name__, hash_function(hash_list)
+                self.__class__.__name__, hash_function([input_hash, splitter_hash])
             )
         return self._checksum
 
     def checksum_states(self, state_index=None):
         """
-        Calculate a checksum for the specific state or all of the states.
-
+        Calculate a checksum for the specific state or all of the states of the task.
         Replaces lists in the inputs fields with a specific values for states.
-        Can be used only for tasks with a state.
+        Used to recreate names of the task directories,
 
         Parameters
         ----------
@@ -269,7 +261,7 @@ class TaskBase:
                 con_hash = hash_function(self._connections)
                 hash_list = [input_hash, con_hash]
                 checksum_ind = create_checksum(
-                    self.__class__.__name__, hash_function(hash_list)
+                    self.__class__.__name__, self._checksum_wf(input_hash)
                 )
             else:
                 checksum_ind = create_checksum(self.__class__.__name__, input_hash)
@@ -765,6 +757,41 @@ class Workflow(TaskBase):
     def graph_sorted(self):
         """Get a sorted graph representation of the workflow."""
         return self.graph.sorted_nodes
+
+    @property
+    def checksum(self):
+        """ Calculates the unique checksum of the task.
+            Used to create specific directory name for task that are run;
+            and to create nodes checksums needed for graph checkums
+            (before the tasks have inputs etc.)
+        """
+        # if checksum is called before run the _graph_checksums is not ready
+        if is_workflow(self) and self.inputs._graph_checksums is attr.NOTHING:
+            self.inputs._graph_checksums = [nd.checksum for nd in self.graph_sorted]
+
+        input_hash = self.inputs.hash
+        if not self.state:
+            self._checksum = create_checksum(
+                self.__class__.__name__, self._checksum_wf(input_hash)
+            )
+        else:
+            self._checksum = create_checksum(
+                self.__class__.__name__,
+                self._checksum_wf(input_hash, with_splitter=True),
+            )
+        return self._checksum
+
+    def _checksum_wf(self, input_hash, with_splitter=False):
+        """ creating hash value for workflows
+            includes connections and splitter if with_splitter is True
+        """
+        connection_hash = hash_function(self._connections)
+        hash_list = [input_hash, connection_hash]
+        if with_splitter and self.state:
+            # including splitter in the hash
+            splitter_hash = hash_function(self.state.splitter)
+            hash_list.append(splitter_hash)
+        return hash_function(hash_list)
 
     def add(self, task):
         """

--- a/pydra/engine/tests/test_boutiques.py
+++ b/pydra/engine/tests/test_boutiques.py
@@ -21,7 +21,7 @@ Infile = Path(__file__).resolve().parent / "data_tests" / "test.nii.gz"
 
 @no_win
 @need_bosh_docker
-@pytest.mark.flaky(reruns=2)  # need for travis
+@pytest.mark.flaky(reruns=3)  # need for travis
 @pytest.mark.parametrize(
     "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
 )
@@ -45,6 +45,7 @@ def test_boutiques_1(maskfile, plugin, results_function):
 
 @no_win
 @need_bosh_docker
+@pytest.mark.flaky(reruns=3)
 def test_boutiques_spec_1():
     """ testing spec: providing input/output fields names"""
     btask = BoshTask(
@@ -69,6 +70,7 @@ def test_boutiques_spec_1():
 
 @no_win
 @need_bosh_docker
+@pytest.mark.flaky(reruns=3)
 def test_boutiques_spec_2():
     """ testing spec: providing partial input/output fields names"""
     btask = BoshTask(
@@ -91,6 +93,7 @@ def test_boutiques_spec_2():
 
 @no_win
 @need_bosh_docker
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize(
     "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
 )
@@ -121,6 +124,7 @@ def test_boutiques_wf_1(maskfile, plugin):
 
 @no_win
 @need_bosh_docker
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize(
     "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
 )

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -2047,7 +2047,8 @@ def test_wf_nostate_cachelocations_a(plugin, tmpdir):
 
     # checking execution time (second one should be quick)
     assert t1 > 3
-    assert t2 < 0.5
+    # testing relative values (windows or slurm takes much longer to create wf itself)
+    assert t2 / t1 < 0.9
 
     # checking if both wf.output_dir are created
     assert wf1.output_dir.exists()
@@ -2104,7 +2105,8 @@ def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
 
     # checking execution time (the second wf should be fast, nodes do not have to rerun)
     assert t1 > 3
-    assert t2 < 0.5
+    # testing relative values (windows or slurm takes much longer to create wf itself)
+    assert t2 / t1 < 0.9
 
     # both wf output_dirs should be created
     assert wf1.output_dir.exists()
@@ -2158,7 +2160,8 @@ def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
 
     # checking execution time (the second wf should be fast, nodes do not have to rerun)
     assert t1 > 3
-    assert t2 < 0.5
+    # testing relative values (windows or slurm takes much longer to create wf itself)
+    assert t2 / t1 < 0.9
 
     # both wf output_dirs should be created
     assert wf1.output_dir.exists()

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1999,7 +1999,7 @@ def test_wf_nostate_cachelocations(plugin, tmpdir):
 
 def test_wf_nostate_cachelocations_a(plugin, tmpdir):
     """
-    almost the same as previous thest, but workflows names differ;
+    the same as previous test, but workflows names differ;
     the task should not be run and it should be fast,
     but the wf itself is triggered and the new output dir is created
     """
@@ -2054,8 +2054,10 @@ def test_wf_nostate_cachelocations_a(plugin, tmpdir):
 
 def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
     """
-    Two identical wfs with provided cache_dir;
-    the second wf has cache_locations and should not recompute the results
+    the same as previous test, but wf output names differ,
+    the tasks should not be run and it should be fast,
+    but the wf itself is triggered and the new output dir is created
+    (the second wf has updated name in its Output)
     """
     cache_dir1 = tmpdir.mkdir("test_wf_cache3")
     cache_dir2 = tmpdir.mkdir("test_wf_cache4")
@@ -2097,19 +2099,18 @@ def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out2
 
-    # checking execution time
+    # checking execution time (the second wf should be fast, nodes do not have to rerun)
     assert t1 > 3
     assert t2 < 0.5
 
-    # checking if the second wf didn't run again
+    # both wf output_dirs should be created
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
 
 
 def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
     """
-    Two identical wfs with provided cache_dir;
-    the second wf has cache_locations and should not recompute the results
+    the same as previous test, but wf names and output names differ,
     """
     cache_dir1 = tmpdir.mkdir("test_wf_cache3")
     cache_dir2 = tmpdir.mkdir("test_wf_cache4")
@@ -2151,11 +2152,11 @@ def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out2
 
-    # checking execution time
+    # checking execution time (the second wf should be fast, nodes do not have to rerun)
     assert t1 > 3
     assert t2 < 0.5
 
-    # checking if the second wf didn't run again
+    # both wf output_dirs should be created
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
 

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -2025,7 +2025,6 @@ def test_wf_nostate_cachedir_relativepath(tmpdir, plugin):
     shutil.rmtree(cache_dir)
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir;
@@ -2080,7 +2079,6 @@ def test_wf_nostate_cachelocations(plugin, tmpdir):
     assert not wf2.output_dir.exists()
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations_a(plugin, tmpdir):
     """
     the same as previous test, but workflows names differ;
@@ -2195,7 +2193,6 @@ def test_wf_nostate_cachelocations_b(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
     """
     the same as previous test, but wf output names differ,
@@ -2253,7 +2250,6 @@ def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
     """
     the same as previous test, but wf names and output names differ,
@@ -2639,7 +2635,6 @@ def test_wf_nostate_nodecachelocations_upd(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_state_cachelocations(plugin, tmpdir):
     """
     Two identical wfs (with states) with provided cache_dir;
@@ -2769,7 +2764,6 @@ def test_wf_state_cachelocations_forcererun(plugin, tmpdir):
         assert odir.exists()
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_state_cachelocations_updateinp(plugin, tmpdir):
     """
     Two identical wfs (with states) with provided cache_dir;
@@ -3001,7 +2995,6 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_ndstate_cachelocations(plugin, tmpdir):
     """
     Two wfs with identical inputs and node states;
@@ -3124,7 +3117,6 @@ def test_wf_ndstate_cachelocations_forcererun(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
-@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_ndstate_cachelocations_updatespl(plugin, tmpdir):
     """
     Two wfs with identical inputs and node state (that is set after adding the node!);

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1943,6 +1943,7 @@ def test_wf_nostate_cachedir_relativepath(tmpdir, plugin):
     shutil.rmtree(cache_dir)
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir;
@@ -1997,6 +1998,7 @@ def test_wf_nostate_cachelocations(plugin, tmpdir):
     assert not wf2.output_dir.exists()
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations_a(plugin, tmpdir):
     """
     the same as previous test, but workflows names differ;
@@ -2052,6 +2054,7 @@ def test_wf_nostate_cachelocations_a(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
     """
     the same as previous test, but wf output names differ,
@@ -2108,6 +2111,7 @@ def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
     """
     the same as previous test, but wf names and output names differ,
@@ -2492,6 +2496,7 @@ def test_wf_nostate_nodecachelocations_upd(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_state_cachelocations(plugin, tmpdir):
     """
     Two identical wfs (with states) with provided cache_dir;
@@ -2621,6 +2626,7 @@ def test_wf_state_cachelocations_forcererun(plugin, tmpdir):
         assert odir.exists()
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_state_cachelocations_updateinp(plugin, tmpdir):
     """
     Two identical wfs (with states) with provided cache_dir;
@@ -2852,6 +2858,7 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_ndstate_cachelocations(plugin, tmpdir):
     """
     Two wfs with identical inputs and node states;
@@ -2974,6 +2981,7 @@ def test_wf_ndstate_cachelocations_forcererun(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
+@pytest.mark.flaky(reruns=2)  # windows test sometimes gives longer time t2
 def test_wf_ndstate_cachelocations_updatespl(plugin, tmpdir):
     """
     Two wfs with identical inputs and node state (that is set after adding the node!);

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -12,6 +12,7 @@ from .utils import (
     ten,
     identity,
     list_output,
+    fun_addsubvar,
     fun_addvar3,
     add2_sub2_res,
     fun_addvar_none,
@@ -289,6 +290,87 @@ def test_wf_4a(plugin):
     assert wf.output_dir.exists()
     results = wf.result()
     assert 5 == results.output.out
+
+
+def test_wf_5(plugin):
+    """ wf with two outputs connected to the task outputs
+        one set_output
+    """
+    wf = Workflow(name="wf_5", input_spec=["x", "y"], x=3, y=2)
+    wf.add(fun_addsubvar(name="addsub", a=wf.lzin.x, b=wf.lzin.y))
+    wf.set_output([("out_sum", wf.addsub.lzout.sum), ("out_sub", wf.addsub.lzout.sub)])
+
+    with Submitter(plugin=plugin) as sub:
+        sub(wf)
+
+    results = wf.result()
+    assert 5 == results.output.out_sum
+    assert 1 == results.output.out_sub
+
+
+def test_wf_5a(plugin):
+    """ wf with two outputs connected to the task outputs,
+        set_output set twice
+    """
+    wf = Workflow(name="wf_5", input_spec=["x", "y"], x=3, y=2)
+    wf.add(fun_addsubvar(name="addsub", a=wf.lzin.x, b=wf.lzin.y))
+    wf.set_output([("out_sum", wf.addsub.lzout.sum)])
+    wf.set_output([("out_sub", wf.addsub.lzout.sub)])
+
+    with Submitter(plugin=plugin) as sub:
+        sub(wf)
+
+    results = wf.result()
+    assert 5 == results.output.out_sum
+    assert 1 == results.output.out_sub
+
+
+def test_wf_5b_exception():
+    """  set_output used twice with the same name - exception should be raised """
+    wf = Workflow(name="wf_5", input_spec=["x", "y"], x=3, y=2)
+    wf.add(fun_addsubvar(name="addsub", a=wf.lzin.x, b=wf.lzin.y))
+    wf.set_output([("out", wf.addsub.lzout.sum)])
+
+    with pytest.raises(Exception) as excinfo:
+        wf.set_output([("out", wf.addsub.lzout.sub)])
+    assert "is already set" in str(excinfo.value)
+
+
+def test_wf_6(plugin):
+    """ wf with two tasks and two outputs connected to both tasks,
+        one set_output
+    """
+    wf = Workflow(name="wf_6", input_spec=["x", "y"], x=2, y=3)
+    wf.add(multiply(name="mult", x=wf.lzin.x, y=wf.lzin.y))
+    wf.add(add2(name="add2", x=wf.mult.lzout.out))
+    wf.set_output([("out1", wf.mult.lzout.out), ("out2", wf.add2.lzout.out)])
+
+    with Submitter(plugin=plugin) as sub:
+        sub(wf)
+
+    assert wf.output_dir.exists()
+    results = wf.result()
+    assert 6 == results.output.out1
+    assert 8 == results.output.out2
+
+
+def test_wf_6a(plugin):
+    """ wf with two tasks and two outputs connected to both tasks,
+        set_output used twice
+    """
+    wf = Workflow(name="wf_6", input_spec=["x", "y"], x=2, y=3)
+    wf.add(multiply(name="mult", x=wf.lzin.x, y=wf.lzin.y))
+    wf.add(add2(name="add2", x=wf.mult.lzout.out))
+    wf.set_output([("out1", wf.mult.lzout.out)])
+    wf.set_output([("out2", wf.add2.lzout.out)])
+
+    with Submitter(plugin=plugin) as sub:
+        sub(wf)
+
+    assert wf.output_dir.exists()
+    results = wf.result()
+    assert 6 == results.output.out1
+    assert 8 == results.output.out2
 
 
 def test_wf_st_1(plugin):
@@ -2051,6 +2133,64 @@ def test_wf_nostate_cachelocations_a(plugin, tmpdir):
     assert t2 / t1 < 0.9
 
     # checking if both wf.output_dir are created
+    assert wf1.output_dir.exists()
+    assert wf2.output_dir.exists()
+
+
+def test_wf_nostate_cachelocations_b(plugin, tmpdir):
+    """
+    the same as previous test, but the 2nd workflows has two outputs
+    (connected to the same task output);
+    the task should not be run and it should be fast,
+    but the wf itself is triggered and the new output dir is created
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y))
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out", wf1.add2.lzout.out)])
+    wf1.inputs.x = 2
+    wf1.inputs.y = 3
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert 8 == results1.output.out
+
+    wf2 = Workflow(
+        name="wf",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+    )
+    wf2.add(multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y))
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out))
+    wf2.set_output([("out", wf2.add2.lzout.out)])
+    # additional output
+    wf2.set_output([("out_pr", wf2.add2.lzout.out)])
+    wf2.inputs.x = 2
+    wf2.inputs.y = 3
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert 8 == results2.output.out == results2.output.out_pr
+
+    # checking execution time
+    assert t1 > 3
+    assert t2 / t1 < 0.9
+
+    # checking if the second wf didn't run again
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
 

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1997,6 +1997,169 @@ def test_wf_nostate_cachelocations(plugin, tmpdir):
     assert not wf2.output_dir.exists()
 
 
+def test_wf_nostate_cachelocations_a(plugin, tmpdir):
+    """
+    almost the same as previous thest, but workflows names differ;
+    the task should not be run and it should be fast,
+    but the wf itself is triggered and the new output dir is created
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf1", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y))
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out", wf1.add2.lzout.out)])
+    wf1.inputs.x = 2
+    wf1.inputs.y = 3
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert 8 == results1.output.out
+
+    wf2 = Workflow(
+        name="wf2",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+    )
+    wf2.add(multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y))
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out))
+    wf2.set_output([("out", wf2.add2.lzout.out)])
+    wf2.inputs.x = 2
+    wf2.inputs.y = 3
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert 8 == results2.output.out
+
+    # checking execution time (second one should be quick)
+    assert t1 > 3
+    assert t2 < 0.5
+
+    # checking if both wf.output_dir are created
+    assert wf1.output_dir.exists()
+    assert wf2.output_dir.exists()
+
+
+def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
+    """
+    Two identical wfs with provided cache_dir;
+    the second wf has cache_locations and should not recompute the results
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y))
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out1", wf1.add2.lzout.out)])
+    wf1.inputs.x = 2
+    wf1.inputs.y = 3
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert 8 == results1.output.out1
+
+    wf2 = Workflow(
+        name="wf",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+    )
+    wf2.add(multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y))
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out))
+    wf2.set_output([("out2", wf2.add2.lzout.out)])
+    wf2.inputs.x = 2
+    wf2.inputs.y = 3
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert 8 == results2.output.out2
+
+    # checking execution time
+    assert t1 > 3
+    assert t2 < 0.5
+
+    # checking if the second wf didn't run again
+    assert wf1.output_dir.exists()
+    assert wf2.output_dir.exists()
+
+
+def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
+    """
+    Two identical wfs with provided cache_dir;
+    the second wf has cache_locations and should not recompute the results
+    """
+    cache_dir1 = tmpdir.mkdir("test_wf_cache3")
+    cache_dir2 = tmpdir.mkdir("test_wf_cache4")
+
+    wf1 = Workflow(name="wf1", input_spec=["x", "y"], cache_dir=cache_dir1)
+    wf1.add(multiply(name="mult", x=wf1.lzin.x, y=wf1.lzin.y))
+    wf1.add(add2_wait(name="add2", x=wf1.mult.lzout.out))
+    wf1.set_output([("out1", wf1.add2.lzout.out)])
+    wf1.inputs.x = 2
+    wf1.inputs.y = 3
+    wf1.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf1)
+    t1 = time.time() - t0
+
+    results1 = wf1.result()
+    assert 8 == results1.output.out1
+
+    wf2 = Workflow(
+        name="wf2",
+        input_spec=["x", "y"],
+        cache_dir=cache_dir2,
+        cache_locations=cache_dir1,
+    )
+    wf2.add(multiply(name="mult", x=wf2.lzin.x, y=wf2.lzin.y))
+    wf2.add(add2_wait(name="add2", x=wf2.mult.lzout.out))
+    wf2.set_output([("out2", wf2.add2.lzout.out)])
+    wf2.inputs.x = 2
+    wf2.inputs.y = 3
+    wf2.plugin = plugin
+
+    t0 = time.time()
+    with Submitter(plugin=plugin) as sub:
+        sub(wf2)
+    t2 = time.time() - t0
+
+    results2 = wf2.result()
+    assert 8 == results2.output.out2
+
+    # checking execution time
+    assert t1 > 3
+    assert t2 < 0.5
+
+    # checking if the second wf didn't run again
+    assert wf1.output_dir.exists()
+    assert wf2.output_dir.exists()
+
+
 def test_wf_nostate_cachelocations_forcererun(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir;

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -52,6 +52,12 @@ def fun_addvar(a, b):
 
 
 @mark.task
+@mark.annotate({"return": {"sum": float, "sub": float}})
+def fun_addsubvar(a, b):
+    return a + b, a - b
+
+
+@mark.task
 def fun_addvar_none(a, b):
     if b is None:
         return a


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
connection were not included in the checksum, so when workflow had the same input and different values in `set_output`, the cached values were loaded.

updated `set_output`, so it can be run twice in order to update workflow's output


## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
