### PR TITLE
[fix] allowing annotated function to return none (closes #256)

### DIFF
--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -200,17 +200,20 @@ class FunctionTask(TaskBase):
         self.output_ = None
         output = cp.loads(self.inputs._func)(**inputs)
         output_names = [el[0] for el in self.output_spec.fields]
-        self.output_ = {}
-        if len(output_names) > 1:
-            if len(output_names) == len(output):
-                self.output_ = dict(zip(output_names, output))
+        if output is None:
+            self.output_ = dict((nm, None) for nm in output_names)
+        else:
+            if len(output_names) == 1:
+                # if only one element in the fields, everything should be returned together
+                self.output_ = {output_names[0]: output}
             else:
-                raise Exception(
-                    f"expected {len(self.output_spec.fields)} elements, "
-                    f"but {len(output)} were returned"
-                )
-        else:  # if only one element in the fields, everything should be returned together
-            self.output_[output_names[0]] = output
+                if isinstance(output, tuple) and len(output_names) == len(output):
+                    self.output_ = dict(zip(output_names, output))
+                else:
+                    raise Exception(
+                        f"expected {len(self.output_spec.fields)} elements, "
+                        f"but {output} were returned"
+                    )
 
 
 class ShellCommandTask(TaskBase):

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -199,19 +199,18 @@ class FunctionTask(TaskBase):
         del inputs["_func"]
         self.output_ = None
         output = cp.loads(self.inputs._func)(**inputs)
-        if output is not None:
-            output_names = [el[0] for el in self.output_spec.fields]
-            self.output_ = {}
-            if len(output_names) > 1:
-                if len(output_names) == len(output):
-                    self.output_ = dict(zip(output_names, output))
-                else:
-                    raise Exception(
-                        f"expected {len(self.output_spec.fields)} elements, "
-                        f"but {len(output)} were returned"
-                    )
-            else:  # if only one element in the fields, everything should be returned together
-                self.output_[output_names[0]] = output
+        output_names = [el[0] for el in self.output_spec.fields]
+        self.output_ = {}
+        if len(output_names) > 1:
+            if len(output_names) == len(output):
+                self.output_ = dict(zip(output_names, output))
+            else:
+                raise Exception(
+                    f"expected {len(self.output_spec.fields)} elements, "
+                    f"but {len(output)} were returned"
+                )
+        else:  # if only one element in the fields, everything should be returned together
+            self.output_[output_names[0]] = output
 
 
 class ShellCommandTask(TaskBase):

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -309,6 +309,18 @@ def test_exception_func():
     assert pytest.raises(Exception, bad_funk)
 
 
+def test_result_none():
+    """ checking if None is properly returned as the result"""
+
+    @mark.task
+    def fun_none(x):
+        return None
+
+    task = fun_none(name="none", x=3)
+    res = task()
+    assert res.output.out is None
+
+
 def test_audit_prov(tmpdir):
     @mark.task
     def testfunc(a: int, b: float = 0.1) -> ty.NamedTuple("Output", [("out", float)]):

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -309,7 +309,7 @@ def test_exception_func():
     assert pytest.raises(Exception, bad_funk)
 
 
-def test_result_none():
+def test_result_none_1():
     """ checking if None is properly returned as the result"""
 
     @mark.task
@@ -319,6 +319,19 @@ def test_result_none():
     task = fun_none(name="none", x=3)
     res = task()
     assert res.output.out is None
+
+
+def test_result_none_2():
+    """ checking if None is properly set for all outputs """
+
+    @mark.task
+    def fun_none(x) -> (ty.Any, ty.Any):
+        return None
+
+    task = fun_none(name="none", x=3)
+    res = task()
+    assert res.output.out1 is None
+    assert res.output.out2 is None
 
 
 def test_audit_prov(tmpdir):


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
functions that returns `None` led to errors


## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
