### PR TITLE
[ci] changing tests with time execution

### DIFF
--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -196,6 +196,7 @@ def test_slurm_wf_state(tmpdir):
 
 
 @pytest.mark.skipif(not slurm_available, reason="slurm not installed")
+@pytest.mark.flaky(reruns=3)
 def test_slurm_max_jobs(tmpdir):
     wf = Workflow("new_wf", input_spec=["x", "y"], cache_dir=tmpdir)
     wf.inputs.x = 5

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -2074,7 +2074,7 @@ def test_wf_nostate_cachelocations(plugin, tmpdir):
     # for win and dask/slurm the time for dir creation etc. might take much longer
     if not sys.platform.startswith("win") and plugin == "cf":
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
     # checking if the second wf didn't run again
     assert wf1.output_dir.exists()
@@ -2132,7 +2132,7 @@ def test_wf_nostate_cachelocations_a(plugin, tmpdir):
         # checking execution time (second one should be quick)
         assert t1 > 2
         # testing relative values (windows or slurm takes much longer to create wf itself)
-        assert t2 < 0.5
+        assert t2 < 1
 
     # checking if both wf.output_dir are created
     assert wf1.output_dir.exists()
@@ -2192,7 +2192,7 @@ def test_wf_nostate_cachelocations_b(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking execution time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
     # checking if the second wf didn't run again
     assert wf1.output_dir.exists()
@@ -2251,7 +2251,7 @@ def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
         # checking execution time (the second wf should be fast, nodes do not have to rerun)
         assert t1 > 2
         # testing relative values (windows or slurm takes much longer to create wf itself)
-        assert t2 < 0.5
+        assert t2 < 1
 
     # both wf output_dirs should be created
     assert wf1.output_dir.exists()
@@ -2307,7 +2307,7 @@ def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
         # checking execution time (the second wf should be fast, nodes do not have to rerun)
         assert t1 > 2
         # testing relative values (windows or slurm takes much longer to create wf itself)
-        assert t2 < 0.5
+        assert t2 < 1
 
     # both wf output_dirs should be created
     assert wf1.output_dir.exists()
@@ -2489,7 +2489,7 @@ def test_wf_nostate_cachelocations_wftaskrerun_propagateFalse(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking the time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
     # tasks should not be recomputed
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
@@ -2704,7 +2704,7 @@ def test_wf_state_cachelocations(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking the execution time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
     # checking all directories
     assert wf1.output_dir
@@ -2840,7 +2840,7 @@ def test_wf_state_cachelocations_updateinp(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking the execution time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
     # checking all directories
     assert wf1.output_dir
@@ -3068,7 +3068,7 @@ def test_wf_ndstate_cachelocations(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking the execution time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
     # checking all directories
     assert wf1.output_dir.exists()
@@ -3194,7 +3194,7 @@ def test_wf_ndstate_cachelocations_updatespl(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking the execution time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
     # checking all directories
     assert wf1.output_dir.exists()
@@ -3310,7 +3310,7 @@ def test_wf_nostate_runtwice_usecache(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking the execution time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
 
 def test_wf_state_runtwice_usecache(plugin, tmpdir):
@@ -3359,7 +3359,7 @@ def test_wf_state_runtwice_usecache(plugin, tmpdir):
     if not sys.platform.startswith("win") and plugin == "cf":
         # checking the execution time
         assert t1 > 2
-        assert t2 < 0.5
+        assert t2 < 1
 
 
 @pytest.fixture

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -1,5 +1,5 @@
 import pytest
-import shutil, os
+import shutil, os, sys
 import time
 import attr
 from pathlib import Path
@@ -2070,9 +2070,11 @@ def test_wf_nostate_cachelocations(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 < 0.5
+    # checking execution time (for unix and cf)
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        assert t1 > 2
+        assert t2 < 0.5
 
     # checking if the second wf didn't run again
     assert wf1.output_dir.exists()
@@ -2125,10 +2127,12 @@ def test_wf_nostate_cachelocations_a(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out
 
-    # checking execution time (second one should be quick)
-    assert t1 > 3
-    # testing relative values (windows or slurm takes much longer to create wf itself)
-    assert t2 / t1 < 0.9
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking execution time (second one should be quick)
+        assert t1 > 2
+        # testing relative values (windows or slurm takes much longer to create wf itself)
+        assert t2 < 0.5
 
     # checking if both wf.output_dir are created
     assert wf1.output_dir.exists()
@@ -2184,9 +2188,11 @@ def test_wf_nostate_cachelocations_b(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out == results2.output.out_pr
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 / t1 < 0.9
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking execution time
+        assert t1 > 2
+        assert t2 < 0.5
 
     # checking if the second wf didn't run again
     assert wf1.output_dir.exists()
@@ -2240,10 +2246,12 @@ def test_wf_nostate_cachelocations_setoutputchange(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out2
 
-    # checking execution time (the second wf should be fast, nodes do not have to rerun)
-    assert t1 > 3
-    # testing relative values (windows or slurm takes much longer to create wf itself)
-    assert t2 / t1 < 0.9
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking execution time (the second wf should be fast, nodes do not have to rerun)
+        assert t1 > 2
+        # testing relative values (windows or slurm takes much longer to create wf itself)
+        assert t2 < 0.5
 
     # both wf output_dirs should be created
     assert wf1.output_dir.exists()
@@ -2294,10 +2302,12 @@ def test_wf_nostate_cachelocations_setoutputchange_a(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out2
 
-    # checking execution time (the second wf should be fast, nodes do not have to rerun)
-    assert t1 > 3
-    # testing relative values (windows or slurm takes much longer to create wf itself)
-    assert t2 / t1 < 0.9
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking execution time (the second wf should be fast, nodes do not have to rerun)
+        assert t1 > 2
+        # testing relative values (windows or slurm takes much longer to create wf itself)
+        assert t2 < 0.5
 
     # both wf output_dirs should be created
     assert wf1.output_dir.exists()
@@ -2350,9 +2360,11 @@ def test_wf_nostate_cachelocations_forcererun(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 > 3
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking execution time
+        assert t1 > 2
+        assert t2 > 2
 
     # checking if the second wf didn't run again
     assert wf1.output_dir.exists()
@@ -2413,8 +2425,11 @@ def test_wf_nostate_cachelocations_wftaskrerun_propagateTrue(plugin, tmpdir):
     # everything has to be recomputed
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
     assert len(list(Path(cache_dir2).glob("F*"))) == 2
-    assert t1 > 3
-    assert t2 > 3
+
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        assert t1 > 2
+        assert t2 > 2
 
 
 def test_wf_nostate_cachelocations_wftaskrerun_propagateFalse(plugin, tmpdir):
@@ -2470,6 +2485,12 @@ def test_wf_nostate_cachelocations_wftaskrerun_propagateFalse(plugin, tmpdir):
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
 
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the time
+        assert t1 > 2
+        assert t2 > 2
+
     # tasks should not be recomputed
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
     assert len(list(Path(cache_dir2).glob("F*"))) == 0
@@ -2524,14 +2545,17 @@ def test_wf_nostate_cachelocations_taskrerun_wfrerun_propagateFalse(plugin, tmpd
     results2 = wf2.result()
     assert 8 == results2.output.out
 
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
     # checking if the second wf doesn't runs again
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
     # the second task should be recomputed
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
-    assert t1 > 3
-    assert t2 > 3
 
 
 def test_wf_nostate_nodecachelocations(plugin, tmpdir):
@@ -2578,6 +2602,11 @@ def test_wf_nostate_nodecachelocations(plugin, tmpdir):
     results2 = wf2.result()
     assert 12 == results2.output.out
 
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
     # checking if the second wf runs again, but runs only one task
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
@@ -2627,6 +2656,11 @@ def test_wf_nostate_nodecachelocations_upd(plugin, tmpdir):
     results2 = wf2.result()
     assert 12 == results2.output.out
 
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
     # checking if the second wf runs again, but runs only one task
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
@@ -2684,9 +2718,11 @@ def test_wf_state_cachelocations(plugin, tmpdir):
     assert results2[0].output.out == 8
     assert results2[1].output.out == 82
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 < 0.5
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 < 0.5
 
     # checking all directories
     assert wf1.output_dir
@@ -2749,9 +2785,11 @@ def test_wf_state_cachelocations_forcererun(plugin, tmpdir):
     assert results2[0].output.out == 8
     assert results2[1].output.out == 82
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 > 3
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
 
     # checking all directories
     assert wf1.output_dir
@@ -2816,9 +2854,11 @@ def test_wf_state_cachelocations_updateinp(plugin, tmpdir):
     assert results2[0].output.out == 8
     assert results2[1].output.out == 82
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 < 0.5
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 < 0.5
 
     # checking all directories
     assert wf1.output_dir
@@ -2930,9 +2970,11 @@ def test_wf_nostate_cachelocations_updated(plugin, tmpdir):
     results2 = wf2.result()
     assert 8 == results2.output.out
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 > 3
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
 
     # checking if both wf run
     assert wf1.output_dir.exists()
@@ -2990,6 +3032,12 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     assert wf1.output_dir.exists()
     assert wf2.output_dir.exists()
 
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
+
     # the second wf should have only one task run
     assert len(list(Path(cache_dir1).glob("F*"))) == 2
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
@@ -3044,9 +3092,11 @@ def test_wf_ndstate_cachelocations(plugin, tmpdir):
     results2 = wf2.result()
     assert results2.output.out == [8, 82]
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 < 0.5
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 < 0.5
 
     # checking all directories
     assert wf1.output_dir.exists()
@@ -3106,9 +3156,11 @@ def test_wf_ndstate_cachelocations_forcererun(plugin, tmpdir):
     results2 = wf2.result()
     assert results2.output.out == [8, 82]
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 > 3
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
 
     # checking all directories
     assert wf1.output_dir.exists()
@@ -3166,9 +3218,11 @@ def test_wf_ndstate_cachelocations_updatespl(plugin, tmpdir):
     results2 = wf2.result()
     assert results2.output.out == [8, 82]
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 < 0.5
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 < 0.5
 
     # checking all directories
     assert wf1.output_dir.exists()
@@ -3227,9 +3281,11 @@ def test_wf_ndstate_cachelocations_recompute(plugin, tmpdir):
     results2 = wf2.result()
     assert results2.output.out == [8, 10, 62, 82]
 
-    # checking execution time
-    assert t1 > 3
-    assert t2 > 3
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 > 2
 
     # checking all directories
     assert wf1.output_dir.exists()
@@ -3254,8 +3310,10 @@ def test_wf_nostate_runtwice_usecache(plugin, tmpdir):
     wf1.inputs.y = 3
     wf1.plugin = plugin
 
+    t0 = time.time()
     with Submitter(plugin=plugin) as sub:
         sub(wf1)
+    t1 = time.time() - t0
 
     results1 = wf1.result()
     assert 8 == results1.output.out
@@ -3266,13 +3324,21 @@ def test_wf_nostate_runtwice_usecache(plugin, tmpdir):
     cache_dir_content = os.listdir(wf1.cache_dir)
 
     # running workflow the second time
+    t0 = time.time()
     with Submitter(plugin=plugin) as sub:
         sub(wf1)
+    t2 = time.time() - t0
 
     results1 = wf1.result()
     assert 8 == results1.output.out
-    # checking if no new directory is not created
+    # checking if no new directory is created
     assert cache_dir_content == os.listdir(wf1.cache_dir)
+
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 < 0.5
 
 
 def test_wf_state_runtwice_usecache(plugin, tmpdir):
@@ -3291,8 +3357,10 @@ def test_wf_state_runtwice_usecache(plugin, tmpdir):
     wf1.inputs.y = [3, 30]
     wf1.plugin = plugin
 
+    t0 = time.time()
     with Submitter(plugin=plugin) as sub:
         sub(wf1)
+    t1 = time.time() - t0
 
     results1 = wf1.result()
     assert 8 == results1[0].output.out
@@ -3305,14 +3373,21 @@ def test_wf_state_runtwice_usecache(plugin, tmpdir):
     cache_dir_content = os.listdir(wf1.cache_dir)
 
     # running workflow the second time
+    t0 = time.time()
     with Submitter(plugin=plugin) as sub:
         sub(wf1)
+    t2 = time.time() - t0
 
     results1 = wf1.result()
     assert 8 == results1[0].output.out
     assert 602 == results1[1].output.out
-    # checking if no new directory is not created
+    # checking if no new directory is created
     assert cache_dir_content == os.listdir(wf1.cache_dir)
+    # for win and dask/slurm the time for dir creation etc. might take much longer
+    if sys.platform.startswith("win") and plugin == "cf":
+        # checking the execution time
+        assert t1 > 2
+        assert t2 < 0.5
 
 
 @pytest.fixture

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -128,7 +128,7 @@ def ten(x):
 
 @mark.task
 def add2_wait(x):
-    time.sleep(3)
+    time.sleep(2)
     return x + 2
 
 


### PR DESCRIPTION
… (windows and slurm/dask can spend a lot of time to create directory etc. and how to set a good check)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
 changing tests, so the execution time is only checked for unix and plugin=cf (windows and slurm/dask can spend a lot of time to create directory etc. and how to set a good check)

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [ ] I acknowledge that this contribution will be available under the Apache 2 license.
