### PR TITLE
ENH: Reserve pydra.tasks as a namespace package

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,4 +13,5 @@ Subpackages
 
    api/pydra.engine
    api/pydra.mark
+   api/pydra.tasks
    api/pydra.utils

--- a/pydra/tasks/__init__.py
+++ b/pydra/tasks/__init__.py
@@ -1,3 +1,10 @@
+""" Pydra tasks
+
+The ``pydra.tasks`` namespace is reserved for collections of Tasks, to be managed and
+packaged separately.
+To create a task package, please fork the `pydra-tasks-template
+<https://github.com/nipype/pydra-tasks-template>`__.
+"""
 try:
     __import__("pkg_resources").declare_namespace(__name__)
 except ImportError:

--- a/pydra/tasks/__init__.py
+++ b/pydra/tasks/__init__.py
@@ -1,0 +1,4 @@
+try:
+    __import__("pkg_resources").declare_namespace(__name__)
+except ImportError:
+    pass  # must not have setuptools


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
This creates the `pydra.tasks` namespace and leaves it empty. Contributing packages should include `pydra/tasks/X` **without** putting `__init__.py` in `pydra/` or `pydra/tasks/`.

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [x] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
