### PR TITLE
extending command_args to include more flexible argstr, and sep

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -598,3 +598,41 @@ def load_task(task_pkl, ind=None):
         task.inputs = attr.evolve(task.inputs, **inputs_dict)
         task.state = None
     return task
+
+
+def position_adjustment(pos_args):
+    """
+    sorting elements with the first element - position,
+    the negative positions should go to the end of the list
+    everything that has no position (i.e. it's None),
+    should go between elements with positive positions an with negative pos.
+    Returns a list of sorted args.
+    """
+    # sorting all elements of the command
+    try:
+        pos_args.sort()
+    except TypeError:  # if some positions are None
+        pos_args_none = []
+        pos_args_int = []
+        for el in pos_args:
+            if el[0] is None:
+                pos_args_none.append(el)
+            else:
+                pos_args_int.append(el)
+            pos_args_int.sort()
+        last_el = pos_args_int[-1][0]
+        for el_none in pos_args_none:
+            last_el += 1
+            pos_args_int.append((last_el, el_none[1]))
+        pos_args = pos_args_int
+
+    # if args available, they should be moved at the of the list
+    while pos_args[0][0] < 0:
+        pos_args.append(pos_args.pop(0))
+
+    # dropping the position index
+    cmd_args = []
+    for el in pos_args:
+        cmd_args += el[1]
+
+    return cmd_args

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -2,7 +2,6 @@
 import attr
 import subprocess as sp
 from hashlib import sha256
-import re
 import os
 import os.path as op
 import re
@@ -11,6 +10,7 @@ import posixpath
 from builtins import str, bytes, open
 import logging
 from pathlib import Path
+import typing as ty
 
 related_filetype_sets = [(".hdr", ".img", ".mat"), (".nii", ".mat"), (".BRIK", ".HEAD")]
 """List of neuroimaging file types that are to be interpreted together."""
@@ -513,22 +513,33 @@ def template_update(inputs, map_copyfiles=None):
 
     from .specs import attr_fields
 
-    fields = attr_fields(inputs)
-    # TODO: Create a dependency graph first and then traverse it
-    for fld in fields:
-        if getattr(inputs, fld.name) is not attr.NOTHING:
-            continue
-        if fld.metadata.get("output_file_template"):
-            if fld.type is str:
-                template = fld.metadata["output_file_template"]
-                value = template.format(**dict_)
-                value = removing_nothing(value)
-                dict_[fld.name] = value
-            else:
-                raise Exception(
-                    f"output_file_template metadata for "
-                    "{fld.name} should be a string"
-                )
+    fields_templ = [
+        fld for fld in attr_fields(inputs) if fld.metadata.get("output_file_template")
+    ]
+    for fld in fields_templ:
+        if fld.type not in [str, ty.Union[str, bool]]:
+            raise Exception(
+                f"fields with output_file_template"
+                "has to be a string or Union[str, bool]"
+            )
+        inp_val_set = getattr(inputs, fld.name)
+        if inp_val_set is not attr.NOTHING and not isinstance(inp_val_set, (str, bool)):
+            raise Exception(f"{fld.name} has to be str or bool, but {inp_val_set} set")
+        if isinstance(inp_val_set, bool) and fld.type is str:
+            raise Exception(
+                f"type of {fld.name} is str, consider using Union[str, bool]"
+            )
+
+        if isinstance(inp_val_set, str):
+            dict_[fld.name] = inp_val_set
+        elif inp_val_set is False:
+            # if False, the field should not be used, so setting attr.NOTHING
+            dict_[fld.name] = attr.NOTHING
+        else:  # True or attr.NOTHING
+            template = fld.metadata["output_file_template"]
+            value = template.format(**dict_)
+            value = removing_nothing(value)
+            dict_[fld.name] = value
     return {k: v for k, v in dict_.items() if getattr(inputs, k) is not v}
 
 
@@ -541,7 +552,13 @@ def removing_nothing(template_str):
     for fld in fields_str.split():
         if "NOTHING" in fld:
             template_str = template_str.replace(fld, "")
-    return template_str.replace("[ ", "[").replace(" ]", "]").strip()
+    return (
+        template_str.replace("[ ", "[")
+        .replace(" ]", "]")
+        .replace(",]", "]")
+        .replace("[,", "[")
+        .strip()
+    )
 
 
 def is_local_file(f):

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -519,8 +519,14 @@ def template_update(inputs, map_copyfiles=None):
             continue
         if fld.metadata.get("output_file_template"):
             if fld.type is str:
-                value = fld.metadata["output_file_template"].format(**dict_)
-                dict_[fld.name] = str(value)
+                templates_list = ensure_list(fld.metadata["output_file_template"])
+                values_list = []
+                for template in templates_list:
+                    value = template.format(**dict_)
+                    if "NOTHING" in value:
+                        continue
+                    values_list.append(value)
+                dict_[fld.name] = " ".join(values_list)
             else:
                 raise Exception(
                     f"output_file_template metadata for "

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -522,8 +522,7 @@ def template_update(inputs, map_copyfiles=None):
             if fld.type is str:
                 template = fld.metadata["output_file_template"]
                 value = template.format(**dict_)
-                if "NOTHING" in value:
-                    value = _removing_nothing(value)
+                value = removing_nothing(value)
                 dict_[fld.name] = value
             else:
                 raise Exception(
@@ -533,8 +532,10 @@ def template_update(inputs, map_copyfiles=None):
     return {k: v for k, v in dict_.items() if getattr(inputs, k) is not v}
 
 
-def _removing_nothing(template_str):
+def removing_nothing(template_str):
     """ removing all fields that had NOTHING"""
+    if "NOTHING" not in template_str:
+        return template_str
     regex = re.compile("[^a-zA-Z_\-]")
     fields_str = regex.sub(" ", template_str)
     for fld in fields_str.split():

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -231,9 +231,10 @@ class ShellSpec(BaseSpec):
             # checking if the help string is provided (required field)
             if "help_string" not in mdata:
                 raise AttributeError(f"{fld.name} doesn't have help_string field")
-
             # assuming that fields with output_file_template shouldn't have default
-            if not fld.default == attr.NOTHING and mdata.get("output_file_template"):
+            if fld.default not in [attr.NOTHING, True, False] and mdata.get(
+                "output_file_template"
+            ):
                 raise AttributeError(
                     "default value should not be set together with output_file_template"
                 )

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -223,22 +223,22 @@ class ShellSpec(BaseSpec):
             mdata = fld.metadata
             # checking keys from metadata
             if set(mdata.keys()) - supported_keys:
-                raise Exception(
+                raise AttributeError(
                     f"only these keys are supported {supported_keys}, but "
                     f"{set(mdata.keys()) - supported_keys} provided"
                 )
             # checking if the help string is provided (required field)
             if "help_string" not in mdata:
-                raise Exception(f"{fld.name} doesn't have help_string field")
+                raise AttributeError(f"{fld.name} doesn't have help_string field")
 
             # assuming that fields with output_file_template shouldn't have default
             if not fld.default == attr.NOTHING and mdata.get("output_file_template"):
-                raise Exception(
+                raise AttributeError(
                     "default value should not be set together with output_file_template"
                 )
             # not allowing for default if the field is mandatory
             if not fld.default == attr.NOTHING and mdata.get("mandatory"):
-                raise Exception(
+                raise AttributeError(
                     "default value should not be set when the field is mandatory"
                 )
             # setting default if value not provided and default is available
@@ -261,7 +261,9 @@ class ShellSpec(BaseSpec):
             # checking if the mandatory field is provided
             if getattr(self, fld.name) is attr.NOTHING:
                 if mdata.get("mandatory"):
-                    raise Exception(f"{fld.name} is mandatory, but no value provided")
+                    raise AttributeError(
+                        f"{fld.name} is mandatory, but no value provided"
+                    )
                 else:
                     continue
             names.append(fld.name)
@@ -269,7 +271,7 @@ class ShellSpec(BaseSpec):
             # checking if fields meet the xor and requires are
             if "xor" in mdata:
                 if [el for el in mdata["xor"] if el in names]:
-                    raise Exception(
+                    raise AttributeError(
                         f"{fld.name} is mutually exclusive with {mdata['xor']}"
                     )
 
@@ -284,7 +286,7 @@ class ShellSpec(BaseSpec):
         for nm, required in require_to_check.items():
             required_notfound = [el for el in required if el not in names]
             if required_notfound:
-                raise Exception(f"{nm} requires {required_notfound}")
+                raise AttributeError(f"{nm} requires {required_notfound}")
 
             # TODO: types might be checked here
         self._type_checking()
@@ -292,7 +294,7 @@ class ShellSpec(BaseSpec):
     def _file_check(self, field):
         file = Path(getattr(self, field.name))
         if not file.exists():
-            raise Exception(f"the file from the {field.name} input does not exist")
+            raise AttributeError(f"the file from the {field.name} input does not exist")
 
     def _type_checking(self):
         """Use fld.type to check the types TODO.
@@ -328,7 +330,9 @@ class ShellOutSpec(BaseSpec):
                     if (
                         fld.default is None or fld.default == attr.NOTHING
                     ) and not fld.metadata:  # TODO: is it right?
-                        raise Exception("File has to have default value or metadata")
+                        raise AttributeError(
+                            "File has to have default value or metadata"
+                        )
                     elif not fld.default == attr.NOTHING:
                         additional_out[fld.name] = self._field_defaultvalue(
                             fld, output_dir
@@ -344,7 +348,7 @@ class ShellOutSpec(BaseSpec):
     def _field_defaultvalue(self, fld, output_dir):
         """Collect output file if the default value specified."""
         if not isinstance(fld.default, (str, Path)):
-            raise Exception(
+            raise AttributeError(
                 f"{fld.name} is a File, so default value "
                 f"should be a string or a Path, "
                 f"{fld.default} provided"
@@ -359,7 +363,7 @@ class ShellOutSpec(BaseSpec):
             if default.exists():
                 return default
             else:
-                raise Exception(f"file {default} does not exist")
+                raise AttributeError(f"file {default} does not exist")
         else:
             all_files = list(Path(default.parent).expanduser().glob(default.name))
             if len(all_files) > 1:
@@ -367,7 +371,7 @@ class ShellOutSpec(BaseSpec):
             elif len(all_files) == 1:
                 return all_files[0]
             else:
-                raise Exception(f"no file matches {default.name}")
+                raise AttributeError(f"no file matches {default.name}")
 
     def _field_metadata(self, fld, inputs, output_dir):
         """Collect output file if metadata specified."""

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -199,6 +199,7 @@ class ShellSpec(BaseSpec):
             "requires",
             "separate_ext",
             "xor",
+            "sep",
         }
         # special inputs, don't have to follow rules for standard inputs
         special_input = ["_func", "_graph_checksums"]

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -207,6 +207,7 @@ class ShellSpec(BaseSpec):
             "copyfile",
             "help_string",
             "mandatory",
+            "readonly",
             "output_field_name",
             "output_file_template",
             "position",

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -461,6 +461,8 @@ class ShellCommandTask(TaskBase):
         """
         if is_lazy(self.inputs):
             raise Exception("can't return cmdline, self.inputs has LazyFields")
+        # checking the inputs fields before returning the command line
+        self.inputs.check_fields_input_spec()
         orig_inputs = attr.asdict(self.inputs)
         modified_inputs = template_update(self.inputs)
         if modified_inputs is not None:

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -448,9 +448,14 @@ class ShellCommandTask(TaskBase):
                 if argstr.endswith("..."):
                     argstr = argstr.replace("...", "")
                     if "sep" in field.metadata:
-                        cmd_el_str = field.metadata["sep"].join(
-                            [argstr.format(**{field.name: val}) for val in value]
-                        )
+                        if "{" + field.name + "}" in argstr:
+                            cmd_el_str = field.metadata["sep"].join(
+                                [argstr.format(**{field.name: val}) for val in value]
+                            )
+                        else:
+                            cmd_el_str = field.metadata["sep"].join(
+                                [f"{argstr} {val}" for val in value]
+                            )
                     else:
                         raise Exception("should we have ... without sep??")
 
@@ -460,7 +465,10 @@ class ShellCommandTask(TaskBase):
                             [str(val) for val in value]
                         )
                     else:
-                        cmd_el_str = argstr.format(**{field.name: value})
+                        if "{" + field.name + "}" in argstr:
+                            cmd_el_str = argstr.format(**{field.name: value})
+                        else:
+                            cmd_el_str = f"{argstr} {value}"
                 cmd_add += cmd_el_str.split(" ")
             # TODO: argstr in nipype1 is always required, should change
             else:

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -315,7 +315,15 @@ class ShellCommandTask(TaskBase):
         """Get command line arguments for a single state"""
         pos_args = []  # list for (position, command arg)
         for f in attr_fields(self.inputs):
-            if f.name == "executable":
+            # these inputs will eb used in container_args
+            if isinstance(self, ContainerTask) and f.name in [
+                "container",
+                "image",
+                "container_xargs",
+                "bindings",
+            ]:
+                continue
+            elif f.name == "executable":
                 pos = 0  # executable should be the first el. of the command
             elif f.name == "args":
                 pos = -1  # assuming that args is the last el. of the command

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -445,13 +445,17 @@ class ShellCommandTask(TaskBase):
                 if isinstance(value, list):
                     cmd_el_str = sep.join([str(val) for val in value])
                     value = cmd_el_str
-                if True:
-                    if "{" + field.name + "}" in argstr:
-                        cmd_el_str = argstr.format(**{field.name: value})
-                    else:
+
+                if "{" + field.name + "}" in argstr:
+                    cmd_el_str = argstr.format(**{field.name: value})
+                else:
+                    if value:
                         cmd_el_str = f"{argstr} {value}"
+                    else:
+                        cmd_el_str = ""
             cmd_el_str = cmd_el_str.strip().replace("  ", " ")
-            cmd_add += cmd_el_str.split(" ")
+            if cmd_el_str:
+                cmd_add += cmd_el_str.split(" ")
         return pos, cmd_add
 
     @property

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -403,16 +403,19 @@ class ShellCommandTask(TaskBase):
         the specific field.
         """
         argstr = field.metadata.get("argstr", None)
-        if argstr is None and "output_file_template" not in field.metadata:
-            raise Exception(f"{field.name} doesn't have argstr field in the metadata")
-
+        if argstr is None:
+            if "output_file_template" in field.metadata:
+                # assuming that input that has output_file_template and no arstr
+                # are not used in the command
+                return None
+            else:
+                raise Exception(
+                    f"{field.name} doesn't have argstr field in the metadata"
+                )
         pos = field.metadata.get("position", None)
         if pos is None:
-            if "output_file_template" in field.metadata:
-                # assuming that input that has output_file_template and no position
-                # are not used in the command
-                # for others, pos will be calculated at the end
-                return None
+            # position will be set at the end
+            pass
         elif not isinstance(pos, int):
             raise Exception(f"position should be an integer, but {pos} given")
         elif pos == 0:

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -347,16 +347,19 @@ class ShellCommandTask(TaskBase):
                 value = str(cpath)
             if f.type is bool:
                 if "argstr" in f.metadata:
-                    cmd_add.append(f.metadata["argstr"])
-                if value is not True:
-                    break
+                    if value is True:
+                        cmd_add.append(f.metadata["argstr"])
+                    else:
+                        break
+                else:
+                    raise Exception("if f.type is bool argst should be provided")
             else:
                 if "argstr" in f.metadata:
                     argstr = f.metadata["argstr"]
 
                     if argstr.endswith("..."):
                         argstr = argstr.replace("...", "")
-                        if "sep" in f.metadata and isinstance(value, list):
+                        if "sep" in f.metadata:
                             cmd_el_str = f.metadata["sep"].join(
                                 [argstr.format(**{f.name: val}) for val in value]
                             )
@@ -371,6 +374,7 @@ class ShellCommandTask(TaskBase):
                         else:
                             cmd_el_str = argstr.format(**{f.name: value})
                     cmd_add += cmd_el_str.split(" ")
+                # TODO: argstr in nipype1 is always required, should change
                 else:
                     if "sep" in f.metadata and isinstance(value, list):
                         cmd_el_str = f.metadata["sep"].join([str(val) for val in value])

--- a/pydra/engine/tests/test_dockertask.py
+++ b/pydra/engine/tests/test_dockertask.py
@@ -677,6 +677,7 @@ def test_docker_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -718,7 +719,7 @@ def test_docker_inputspec_1a(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename,
-                    metadata={"position": 1, "help_string": "input file"},
+                    metadata={"position": 1, "argstr": "", "help_string": "input file"},
                 ),
             )
         ],
@@ -757,7 +758,12 @@ def test_docker_inputspec_2(plugin, tmpdir):
             (
                 "file1",
                 attr.ib(
-                    type=File, metadata={"position": 1, "help_string": "input file 1"}
+                    type=File,
+                    metadata={
+                        "position": 1,
+                        "argstr": "",
+                        "help_string": "input file 1",
+                    },
                 ),
             ),
             (
@@ -765,7 +771,11 @@ def test_docker_inputspec_2(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename_2,
-                    metadata={"position": 2, "help_string": "input file 2"},
+                    metadata={
+                        "position": 2,
+                        "argstr": "",
+                        "help_string": "input file 2",
+                    },
                 ),
             ),
         ],
@@ -809,13 +819,22 @@ def test_docker_inputspec_2a_except(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename_1,
-                    metadata={"position": 1, "help_string": "input file 1"},
+                    metadata={
+                        "position": 1,
+                        "argstr": "",
+                        "help_string": "input file 1",
+                    },
                 ),
             ),
             (
                 "file2",
                 attr.ib(
-                    type=File, metadata={"position": 2, "help_string": "input file 2"}
+                    type=File,
+                    metadata={
+                        "position": 2,
+                        "argstr": "",
+                        "help_string": "input file 2",
+                    },
                 ),
             ),
         ],
@@ -861,13 +880,22 @@ def test_docker_inputspec_2a(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename_1,
-                    metadata={"position": 1, "help_string": "input file 1"},
+                    metadata={
+                        "position": 1,
+                        "argstr": "",
+                        "help_string": "input file 1",
+                    },
                 ),
             ),
             (
                 "file2",
                 attr.ib(
-                    type=File, metadata={"position": 2, "help_string": "input file 2"}
+                    type=File,
+                    metadata={
+                        "position": 2,
+                        "argstr": "",
+                        "help_string": "input file 2",
+                    },
                 ),
             ),
         ],
@@ -906,6 +934,7 @@ def test_docker_inputspec_3(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                         "container_path": True,
                     },
@@ -951,6 +980,7 @@ def test_docker_inputspec_3a(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -995,6 +1025,7 @@ def test_docker_cmd_inputspec_copyfile_1(plugin, tmpdir):
                     type=File,
                     metadata={
                         "position": 1,
+                        "argstr": "",
                         "help_string": "orig file",
                         "mandatory": True,
                         "copyfile": True,
@@ -1061,6 +1092,7 @@ def test_docker_inputspec_state_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -1110,6 +1142,7 @@ def test_docker_inputspec_state_1b(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -1152,6 +1185,7 @@ def test_docker_wf_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -1207,6 +1241,7 @@ def test_docker_wf_state_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -1264,6 +1299,7 @@ def test_docker_wf_ndst_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),

--- a/pydra/engine/tests/test_helpers.py
+++ b/pydra/engine/tests/test_helpers.py
@@ -8,7 +8,14 @@ import pytest
 import cloudpickle as cp
 
 from .utils import multiply, raise_xeq1
-from ..helpers import hash_value, hash_function, get_available_cpus, save, load_and_run
+from ..helpers import (
+    hash_value,
+    hash_function,
+    get_available_cpus,
+    save,
+    load_and_run,
+    position_adjustment,
+)
 from .. import helpers_file
 from ..specs import File, Directory
 from ..core import Workflow
@@ -284,3 +291,18 @@ def test_load_and_run_wf(tmpdir):
     result_1 = cp.loads(resultfile_1.read_bytes())
     assert result_0.output.out == 10
     assert result_1.output.out == 20
+
+
+@pytest.mark.parametrize(
+    "pos_args",
+    [
+        [(2, "b"), (1, "a"), (3, "c")],
+        [(-2, "b"), (1, "a"), (-1, "c")],
+        [(None, "b"), (1, "a"), (-1, "c")],
+        [(-3, "b"), (None, "a"), (-1, "c")],
+        [(None, "b"), (1, "a"), (None, "c")],
+    ],
+)
+def test_position_adjustment(pos_args):
+    final_args = position_adjustment(pos_args)
+    assert final_args == ["a", "b", "c"]

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -2275,7 +2275,7 @@ def no_fsl():
         return True
 
 
-# @pytest.mark.skipif(no_fsl(), reason="fsl is not installed")
+@pytest.mark.skipif(no_fsl(), reason="fsl is not installed")
 def test_fsl():
     """  mandatory field added to fields, value provided """
 

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -306,7 +306,10 @@ def test_shell_cmd_inputspec_2(plugin, results_function):
         fields=[
             (
                 "opt_hello",
-                attr.ib(type=str, metadata={"position": 3, "help_string": "todo"}),
+                attr.ib(
+                    type=str,
+                    metadata={"position": 3, "help_string": "todo", "argstr": ""},
+                ),
             ),
             (
                 "opt_n",
@@ -347,7 +350,12 @@ def test_shell_cmd_inputspec_3(plugin, results_function):
                 "text",
                 attr.ib(
                     type=str,
-                    metadata={"position": 1, "help_string": "text", "mandatory": True},
+                    metadata={
+                        "position": 1,
+                        "help_string": "text",
+                        "mandatory": True,
+                        "argstr": "",
+                    },
                 ),
             )
         ],
@@ -374,7 +382,11 @@ def test_shell_cmd_inputspec_3a(plugin, results_function):
     my_input_spec = SpecInfo(
         name="Input",
         fields=[
-            ("text", str, {"position": 1, "help_string": "text", "mandatory": True})
+            (
+                "text",
+                str,
+                {"position": 1, "help_string": "text", "mandatory": True, "argstr": ""},
+            )
         ],
         bases=(ShellSpec,),
     )
@@ -401,7 +413,12 @@ def test_shell_cmd_inputspec_3b(plugin, results_function):
                 "text",
                 attr.ib(
                     type=str,
-                    metadata={"position": 1, "help_string": "text", "mandatory": True},
+                    metadata={
+                        "position": 1,
+                        "help_string": "text",
+                        "mandatory": True,
+                        "argstr": "",
+                    },
                 ),
             )
         ],
@@ -429,7 +446,12 @@ def test_shell_cmd_inputspec_3c_exception(plugin):
                 "text",
                 attr.ib(
                     type=str,
-                    metadata={"position": 1, "help_string": "text", "mandatory": True},
+                    metadata={
+                        "position": 1,
+                        "help_string": "text",
+                        "mandatory": True,
+                        "argstr": "",
+                    },
                 ),
             )
         ],
@@ -456,7 +478,12 @@ def test_shell_cmd_inputspec_3c(plugin, results_function):
                 attr.ib(
                     type=str,
                     default=None,
-                    metadata={"position": 1, "help_string": "text", "mandatory": False},
+                    metadata={
+                        "position": 1,
+                        "help_string": "text",
+                        "mandatory": False,
+                        "argstr": "",
+                    },
                 ),
             )
         ],
@@ -485,7 +512,7 @@ def test_shell_cmd_inputspec_4(plugin, results_function):
                 attr.ib(
                     type=str,
                     default="Hello",
-                    metadata={"position": 1, "help_string": "text"},
+                    metadata={"position": 1, "help_string": "text", "argstr": ""},
                 ),
             )
         ],
@@ -512,7 +539,9 @@ def test_shell_cmd_inputspec_4a(plugin, results_function):
     cmd_exec = "echo"
     my_input_spec = SpecInfo(
         name="Input",
-        fields=[("text", str, "Hello", {"position": 1, "help_string": "text"})],
+        fields=[
+            ("text", str, "Hello", {"position": 1, "help_string": "text", "argstr": ""})
+        ],
         bases=(ShellSpec,),
     )
 
@@ -540,7 +569,7 @@ def test_shell_cmd_inputspec_4b(plugin, results_function):
                 attr.ib(
                     type=str,
                     default="Hi",
-                    metadata={"position": 1, "help_string": "text"},
+                    metadata={"position": 1, "help_string": "text", "argstr": ""},
                 ),
             )
         ],
@@ -570,7 +599,12 @@ def test_shell_cmd_inputspec_4c_exception(plugin):
                 attr.ib(
                     type=str,
                     default="Hello",
-                    metadata={"position": 1, "help_string": "text", "mandatory": True},
+                    metadata={
+                        "position": 1,
+                        "help_string": "text",
+                        "mandatory": True,
+                        "argstr": "",
+                    },
                 ),
             )
         ],
@@ -603,6 +637,7 @@ def test_shell_cmd_inputspec_4d_exception(plugin):
                         "position": 1,
                         "help_string": "text",
                         "output_file_template": "exception",
+                        "argstr": "",
                     },
                 ),
             )
@@ -934,7 +969,10 @@ def test_shell_cmd_inputspec_7b(plugin, results_function):
         fields=[
             (
                 "newfile",
-                attr.ib(type=str, metadata={"position": 1, "help_string": "new file"}),
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "new file", "argstr": ""},
+                ),
             ),
             (
                 "out1",
@@ -975,7 +1013,10 @@ def test_shell_cmd_inputspec_8(plugin, results_function, tmpdir):
         fields=[
             (
                 "newfile",
-                attr.ib(type=str, metadata={"position": 2, "help_string": "new file"}),
+                attr.ib(
+                    type=str,
+                    metadata={"position": 2, "help_string": "new file", "argstr": ""},
+                ),
             ),
             (
                 "time",
@@ -1028,7 +1069,10 @@ def test_shell_cmd_inputspec_8a(plugin, results_function, tmpdir):
         fields=[
             (
                 "newfile",
-                attr.ib(type=str, metadata={"position": 2, "help_string": "new file"}),
+                attr.ib(
+                    type=str,
+                    metadata={"position": 2, "help_string": "new file", "argstr": ""},
+                ),
             ),
             (
                 "time",
@@ -1091,6 +1135,8 @@ def test_shell_cmd_inputspec_9(plugin, results_function, tmpdir):
                     type=ty.List[File],
                     metadata={
                         "position": 1,
+                        "argstr": "...",
+                        "sep": " ",
                         "help_string": "list of files",
                         "mandatory": True,
                     },
@@ -1130,6 +1176,7 @@ def test_shell_cmd_inputspec_copyfile_1(plugin, results_function, tmpdir):
                     type=File,
                     metadata={
                         "position": 1,
+                        "argstr": "",
                         "help_string": "orig file",
                         "mandatory": True,
                         "copyfile": True,
@@ -1187,6 +1234,7 @@ def test_shell_cmd_inputspec_copyfile_1a(plugin, results_function, tmpdir):
                     type=File,
                     metadata={
                         "position": 1,
+                        "argstr": "",
                         "help_string": "orig file",
                         "mandatory": True,
                         "copyfile": False,
@@ -1259,6 +1307,7 @@ def test_shell_cmd_inputspec_copyfile_1b(plugin, results_function, tmpdir):
                     type=File,
                     metadata={
                         "position": 1,
+                        "argstr": "",
                         "help_string": "orig file",
                         "mandatory": True,
                     },
@@ -1303,7 +1352,12 @@ def test_shell_cmd_inputspec_state_1(plugin, results_function):
                 "text",
                 attr.ib(
                     type=str,
-                    metadata={"position": 1, "help_string": "text", "mandatory": True},
+                    metadata={
+                        "position": 1,
+                        "help_string": "text",
+                        "mandatory": True,
+                        "argstr": "",
+                    },
                 ),
             )
         ],
@@ -1332,7 +1386,11 @@ def test_shell_cmd_inputspec_state_1a(plugin, results_function):
     my_input_spec = SpecInfo(
         name="Input",
         fields=[
-            ("text", str, {"position": 1, "help_string": "text", "mandatory": True})
+            (
+                "text",
+                str,
+                {"position": 1, "help_string": "text", "mandatory": True, "argstr": ""},
+            )
         ],
         bases=(ShellSpec,),
     )
@@ -1404,7 +1462,12 @@ def test_shell_cmd_inputspec_state_3(plugin, results_function, tmpdir):
                 "file",
                 attr.ib(
                     type=File,
-                    metadata={"position": 1, "help_string": "files", "mandatory": True},
+                    metadata={
+                        "position": 1,
+                        "help_string": "files",
+                        "mandatory": True,
+                        "argstr": "",
+                    },
                 ),
             )
         ],
@@ -1447,6 +1510,7 @@ def test_shell_cmd_inputspec_copyfile_state_1(plugin, results_function, tmpdir):
                     type=File,
                     metadata={
                         "position": 1,
+                        "argstr": "",
                         "help_string": "orig file",
                         "mandatory": True,
                         "copyfile": True,
@@ -1613,7 +1677,12 @@ def test_wf_shell_cmd_3(plugin):
             (
                 "orig_file",
                 attr.ib(
-                    type=File, metadata={"position": 1, "help_string": "output file"}
+                    type=File,
+                    metadata={
+                        "position": 1,
+                        "help_string": "output file",
+                        "argstr": "",
+                    },
                 ),
             ),
             (
@@ -1622,6 +1691,7 @@ def test_wf_shell_cmd_3(plugin):
                     type=str,
                     metadata={
                         "position": 2,
+                        "argstr": "",
                         "output_file_template": "{orig_file}_copy",
                         "help_string": "output file",
                     },
@@ -1701,7 +1771,12 @@ def test_wf_shell_cmd_3a(plugin):
             (
                 "orig_file",
                 attr.ib(
-                    type=str, metadata={"position": 1, "help_string": "output file"}
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "output file",
+                        "argstr": "",
+                    },
                 ),
             ),
             (
@@ -1710,6 +1785,7 @@ def test_wf_shell_cmd_3a(plugin):
                     type=str,
                     metadata={
                         "position": 2,
+                        "argstr": "",
                         "output_file_template": "{orig_file}_cp",
                         "help_string": "output file",
                     },
@@ -1789,7 +1865,12 @@ def test_wf_shell_cmd_state_1(plugin):
             (
                 "orig_file",
                 attr.ib(
-                    type=str, metadata={"position": 1, "help_string": "output file"}
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "output file",
+                        "argstr": "",
+                    },
                 ),
             ),
             (
@@ -1798,6 +1879,7 @@ def test_wf_shell_cmd_state_1(plugin):
                     type=str,
                     metadata={
                         "position": 2,
+                        "argstr": "",
                         "output_file_template": "{orig_file}_copy",
                         "help_string": "output file",
                     },
@@ -1878,7 +1960,12 @@ def test_wf_shell_cmd_ndst_1(plugin):
             (
                 "orig_file",
                 attr.ib(
-                    type=str, metadata={"position": 1, "help_string": "output file"}
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "output file",
+                        "argstr": "",
+                    },
                 ),
             ),
             (
@@ -1887,6 +1974,7 @@ def test_wf_shell_cmd_ndst_1(plugin):
                     type=str,
                     metadata={
                         "position": 2,
+                        "argstr": "",
                         "output_file_template": "{orig_file}_copy",
                         "help_string": "output file",
                     },
@@ -2217,6 +2305,7 @@ def test_fsl():
                         "help_string": "input file to skull strip",
                         "position": 1,
                         "mandatory": True,
+                        "argstr": "",
                     },
                 ),
             ),
@@ -2227,6 +2316,7 @@ def test_fsl():
                     metadata={
                         "help_string": "name of output skull stripped image",
                         "position": 2,
+                        "argstr": "",
                         "output_file_template": "{in_file}_brain",
                     },
                 ),

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -2,7 +2,7 @@
 
 import attr
 import typing as ty
-import os, sys, shutil
+import os, sys
 import pytest
 from pathlib import Path
 

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -922,7 +922,154 @@ def test_shell_cmd_inputspec_7a(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_inputspec_7b(plugin, results_function):
+    """
+        providing new file and output name using input_spec,
+        using name_tamplate in metadata
+    """
+    cmd = "touch"
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "newfile",
+                attr.ib(type=str, metadata={"position": 1, "help_string": "new file"}),
+            ),
+            (
+                "out1",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "output_file_template": "{newfile}",
+                        "help_string": "output file",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        newfile="newfile_tmp.txt",
+        input_spec=my_input_spec,
+    )
+
+    res = results_function(shelly, plugin)
+    assert res.output.stdout == ""
+    assert res.output.out1.exists()
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
 def test_shell_cmd_inputspec_8(plugin, results_function, tmpdir):
+    """
+        providing new file and output name using input_spec,
+        adding additional string input field with argstr
+    """
+    cmd = "touch"
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "newfile",
+                attr.ib(type=str, metadata={"position": 2, "help_string": "new file"}),
+            ),
+            (
+                "time",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "argstr": "-t",
+                        "help_string": "time of modif.",
+                    },
+                ),
+            ),
+            (
+                "out1",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "output_file_template": "{newfile}",
+                        "help_string": "output file",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        newfile="newfile_tmp.txt",
+        time="02121010",
+        input_spec=my_input_spec,
+    )
+
+    res = results_function(shelly, plugin)
+    assert res.output.stdout == ""
+    assert res.output.out1.exists()
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_inputspec_8a(plugin, results_function, tmpdir):
+    """
+        providing new file and output name using input_spec,
+        adding additional string input field with argstr (argstr uses string formatting)
+    """
+    cmd = "touch"
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "newfile",
+                attr.ib(type=str, metadata={"position": 2, "help_string": "new file"}),
+            ),
+            (
+                "time",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "argstr": "-t {time}",
+                        "help_string": "time of modif.",
+                    },
+                ),
+            ),
+            (
+                "out1",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "output_file_template": "{newfile}",
+                        "help_string": "output file",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        newfile="newfile_tmp.txt",
+        time="02121010",
+        input_spec=my_input_spec,
+    )
+
+    res = results_function(shelly, plugin)
+    assert res.output.stdout == ""
+    assert res.output.out1.exists()
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_inputspec_9(plugin, results_function, tmpdir):
     """ using input_spec, providing list of files as an input """
 
     file_1 = tmpdir.join("file_1.txt")

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -2040,7 +2040,7 @@ def no_fsl():
         return True
 
 
-@pytest.mark.skipif(no_fsl(), reason="fsl is not installed")
+# @pytest.mark.skipif(no_fsl(), reason="fsl is not installed")
 def test_fsl():
     """  mandatory field added to fields, value provided """
 

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -573,12 +573,12 @@ def test_shell_cmd_inputs_template_1():
     shelly = ShellCommandTask(
         executable="executable", input_spec=my_input_spec, inpA="inpA"
     )
-    # outA has position, so is a part of the command line
+    # outA has argstr in the metadata fields, so it's a part of the command line
     assert shelly.cmdline == "executable inpA -o inpA_out"
 
 
 def test_shell_cmd_inputs_template_1a():
-    """ additional inputs, one uses output_file_template (without position)"""
+    """ additional inputs, one uses output_file_template (without argstr)"""
     my_input_spec = SpecInfo(
         name="Input",
         fields=[
@@ -600,7 +600,6 @@ def test_shell_cmd_inputs_template_1a():
                     type=str,
                     metadata={
                         "help_string": "outA",
-                        "argstr": "-o",
                         "output_file_template": "{inpA}_out",
                     },
                 ),
@@ -612,7 +611,7 @@ def test_shell_cmd_inputs_template_1a():
     shelly = ShellCommandTask(
         executable="executable", input_spec=my_input_spec, inpA="inpA"
     )
-    # outA has no position, so is not a part of the command line
+    # outA has no argstr in metadata, so it's not a part of the command line
     assert shelly.cmdline == "executable inpA"
 
 
@@ -645,7 +644,7 @@ def test_shell_cmd_inputs_template_2():
     )
 
     shelly = ShellCommandTask(executable="executable", input_spec=my_input_spec)
-    # outA has position, so is a part of the command line
+    # outA has argstr in the metadata fields, so it's a part of the command line
     assert shelly.cmdline == "executable"
 
 

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1125,7 +1125,7 @@ def test_shell_cmd_inputs_di(tmpdir):
     )
     assert (
         shelly.cmdline
-        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -h -o [{my_input_file}_out {my_input_file}_noise]"
+        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -h -o [{my_input_file}_out, {my_input_file}_noise]"
     )
 
     assert shelly.output_names == [

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -511,7 +511,7 @@ def test_shell_cmd_inputs_format_2():
 
 
 def test_shell_cmd_inputs_mandatory_1():
-    """ additional inputs with argstr that has string formatting and ..."""
+    """ additional inputs with mandatory=True"""
     my_input_spec = SpecInfo(
         name="Input",
         fields=[
@@ -535,6 +535,217 @@ def test_shell_cmd_inputs_mandatory_1():
     with pytest.raises(Exception) as e:
         shelly.cmdline
     assert "mandatory" in str(e.value)
+
+
+def test_shell_cmd_inputs_template_1():
+    """ additional inputs, one uses output_file_template (and position)"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "argstr": "",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+            (
+                "outA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 2,
+                        "help_string": "outA",
+                        "argstr": "-o",
+                        "output_file_template": "{inpA}_out",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", input_spec=my_input_spec, inpA="inpA"
+    )
+    # outA has position, so is a part of the command line
+    assert shelly.cmdline == "executable inpA -o inpA_out"
+
+
+def test_shell_cmd_inputs_template_1a():
+    """ additional inputs, one uses output_file_template (without position)"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "argstr": "",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+            (
+                "outA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "help_string": "outA",
+                        "argstr": "-o",
+                        "output_file_template": "{inpA}_out",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", input_spec=my_input_spec, inpA="inpA"
+    )
+    # outA has no position, so is not a part of the command line
+    assert shelly.cmdline == "executable inpA"
+
+
+def test_shell_cmd_inputs_template_2():
+    """ additional inputs, one uses output_file_template (and position)"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpB",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpB", "argstr": ""},
+                ),
+            ),
+            (
+                "outB",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 2,
+                        "help_string": "outB",
+                        "argstr": "-o",
+                        "output_file_template": "{inpB}_out",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(executable="executable", input_spec=my_input_spec)
+    # outA has position, so is a part of the command line
+    assert shelly.cmdline == "executable"
+
+
+def test_shell_cmd_inputs_template_3():
+    """ additional inputs, one uses output_file_template with a list"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "argstr": "",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+            (
+                "inpB",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 2,
+                        "help_string": "inpB",
+                        "argstr": "",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+            (
+                "outAB",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 3,
+                        "help_string": "outAB",
+                        "argstr": "-o",
+                        "output_file_template": ["{inpA}_out", "{inpB}_out"],
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", input_spec=my_input_spec, inpA="inpA", inpB="inpB"
+    )
+    # both inpA and inpB are provided so inpA_out and inpB_out are in the command
+    assert shelly.cmdline == "executable inpA inpB -o inpA_out inpB_out"
+
+
+def test_shell_cmd_inputs_template_4():
+    """ additional inputs, one uses output_file_template with a list"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "argstr": "",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+            (
+                "inpB",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 2, "help_string": "inpB", "argstr": ""},
+                ),
+            ),
+            (
+                "outAB",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 3,
+                        "help_string": "outAB",
+                        "argstr": "-o",
+                        "output_file_template": ["{inpA}_out", "{inpB}_out"],
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", input_spec=my_input_spec, inpA="inpA"
+    )
+    # inpB is not provided so inpB_out not in the output
+    assert shelly.cmdline == "executable inpA -o inpA_out"
 
 
 def test_shell_cmd_inputs_di(tmpdir):
@@ -649,13 +860,18 @@ def test_shell_cmd_inputs_di(tmpdir):
             (
                 "correctedImage",
                 attr.ib(
-                    type=ty.Any,
+                    type=str,
                     metadata={
                         "help_string": """
                         The output consists of the noise corrected version of the input image.
                         Optionally, one can also output the estimated noise image.
                         """,
+                        "output_file_template": [
+                            "{inputImageFilename}",
+                            "{maskImageFilename}",
+                        ],
                         "argstr": "-o",
+                        "position": -1,
                     },
                 ),
             ),
@@ -705,6 +921,8 @@ def test_shell_cmd_inputs_di(tmpdir):
 
     my_input_file = tmpdir.join("a_file.txt")
     my_input_file.write("content")
+    my_mask_file = tmpdir.join("a_mask_file.txt")
+    my_mask_file.write("content")
 
     # no input provided
     shelly = ShellCommandTask(executable="DenoiseImage", input_spec=my_input_spec)
@@ -718,7 +936,22 @@ def test_shell_cmd_inputs_di(tmpdir):
         inputImageFilename=my_input_file,
         input_spec=my_input_spec,
     )
-    assert shelly.cmdline == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2"
+    assert (
+        shelly.cmdline
+        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -o {my_input_file}"
+    )
+
+    # input file name and mask file
+    shelly = ShellCommandTask(
+        executable="DenoiseImage",
+        inputImageFilename=my_input_file,
+        maskImageFilename=my_mask_file,
+        input_spec=my_input_spec,
+    )
+    assert (
+        shelly.cmdline
+        == f"DenoiseImage -i {my_input_file} -x {my_mask_file} -s 1 -p 1 -r 2 -o {my_input_file} {my_mask_file}"
+    )
 
     # input file name and help_short
     shelly = ShellCommandTask(
@@ -727,4 +960,7 @@ def test_shell_cmd_inputs_di(tmpdir):
         help_short=True,
         input_spec=my_input_spec,
     )
-    assert shelly.cmdline == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -h"
+    assert (
+        shelly.cmdline
+        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -h -o {my_input_file}"
+    )

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1113,7 +1113,7 @@ def test_shell_cmd_inputs_di(tmpdir):
     )
     assert (
         shelly.cmdline
-        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -o [{my_input_file}_out {my_input_file}_noise]"
+        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -o [{my_input_file}_out, {my_input_file}_noise]"
     )
 
     # input file name and help_short

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -685,7 +685,7 @@ def test_shell_cmd_inputs_template_3():
                         "position": 3,
                         "help_string": "outAB",
                         "argstr": "-o",
-                        "output_file_template": ["{inpA}_out", "{inpB}_out"],
+                        "output_file_template": "{inpA}_out {inpB}_out",
                     },
                 ),
             ),
@@ -732,7 +732,7 @@ def test_shell_cmd_inputs_template_4():
                         "position": 3,
                         "help_string": "outAB",
                         "argstr": "-o",
-                        "output_file_template": ["{inpA}_out", "{inpB}_out"],
+                        "output_file_template": "{inpA}_out {inpB}-out",
                     },
                 ),
             ),
@@ -796,7 +796,7 @@ def test_shell_cmd_inputs_di(tmpdir):
             (
                 "maskImageFilename",
                 attr.ib(
-                    type=File,
+                    type=str,
                     metadata={
                         "help_string": "If a mask image is specified, denoising is only performed in the mask region.",
                         "argstr": "-x",
@@ -865,10 +865,7 @@ def test_shell_cmd_inputs_di(tmpdir):
                         The output consists of the noise corrected version of the input image.
                         Optionally, one can also output the estimated noise image.
                         """,
-                        "output_file_template": [
-                            "{inputImageFilename}",
-                            "{maskImageFilename}",
-                        ],
+                        "output_file_template": "[{inputImageFilename} {maskImageFilename}]",
                         "argstr": "-o",
                         "position": -1,
                     },
@@ -921,7 +918,6 @@ def test_shell_cmd_inputs_di(tmpdir):
     my_input_file = tmpdir.join("a_file.txt")
     my_input_file.write("content")
     my_mask_file = tmpdir.join("a_mask_file.txt")
-    my_mask_file.write("content")
 
     # no input provided
     shelly = ShellCommandTask(executable="DenoiseImage", input_spec=my_input_spec)
@@ -937,7 +933,7 @@ def test_shell_cmd_inputs_di(tmpdir):
     )
     assert (
         shelly.cmdline
-        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -o {my_input_file}"
+        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -o [{my_input_file}]"
     )
 
     # input file name and mask file
@@ -949,7 +945,7 @@ def test_shell_cmd_inputs_di(tmpdir):
     )
     assert (
         shelly.cmdline
-        == f"DenoiseImage -i {my_input_file} -x {my_mask_file} -s 1 -p 1 -r 2 -o {my_input_file} {my_mask_file}"
+        == f"DenoiseImage -i {my_input_file} -x {my_mask_file} -s 1 -p 1 -r 2 -o [{my_input_file} {my_mask_file}]"
     )
 
     # input file name and help_short
@@ -961,5 +957,5 @@ def test_shell_cmd_inputs_di(tmpdir):
     )
     assert (
         shelly.cmdline
-        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -h -o {my_input_file}"
+        == f"DenoiseImage -i {my_input_file} -s 1 -p 1 -r 2 -h -o [{my_input_file}]"
     )

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1046,7 +1046,7 @@ def test_shell_cmd_inputs_di(tmpdir):
                     type=str,
                     metadata={
                         "help_string": "Combined output",
-                        "argstr": "-o [{correctedImage} {noiseImage}]",
+                        "argstr": "-o [{correctedImage}, {noiseImage}]",
                         "position": -1,
                         "readonly": True,
                     },

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1,0 +1,697 @@
+# -*- coding: utf-8 -*-
+
+import attr
+import typing as ty
+import os, sys
+import pytest
+from pathlib import Path
+
+
+from ..task import ShellCommandTask
+from ..specs import ShellOutSpec, ShellSpec, SpecInfo, File
+
+
+def test_shell_cmd_execargs_1():
+    # separate command into exec + args
+    shelly = ShellCommandTask(executable="executable", args="arg")
+    assert shelly.cmdline == "executable arg"
+
+
+def test_shell_cmd_execargs_2():
+    # separate command into exec + args
+    shelly = ShellCommandTask(executable=["cmd_1", "cmd_2"], args="arg")
+    assert shelly.cmdline == "cmd_1 cmd_2 arg"
+
+
+def test_shell_cmd_inputs_1():
+    """ additional input with provided position """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inp1", "argstr": ""},
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", args="arg", inpA="inp1", input_spec=my_input_spec
+    )
+    assert shelly.cmdline == "executable inp1 arg"
+
+
+def test_shell_cmd_inputs_1a():
+    """ additional input without provided position """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            ("inpA", attr.ib(type=str, metadata={"help_string": "inpA", "argstr": ""}))
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", args="arg", inpA="inpNone1", input_spec=my_input_spec
+    )
+    # inp1 should be firt one after executable
+    assert shelly.cmdline == "executable inpNone1 arg"
+
+
+def test_shell_cmd_inputs_1b():
+    """ additional input with negative position """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={"position": -1, "help_string": "inpA", "argstr": ""},
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    # separate command into exec + args
+    shelly = ShellCommandTask(
+        executable="executable", args="arg", inpA="inp-1", input_spec=my_input_spec
+    )
+    # inp1 should be last before arg
+    assert shelly.cmdline == "executable inp-1 arg"
+
+
+def test_shell_cmd_inputs_2():
+    """ additional inputs with provided positions """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 2, "help_string": "inpA", "argstr": ""},
+                ),
+            ),
+            (
+                "inpB",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpN", "argstr": ""},
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    # separate command into exec + args
+    shelly = ShellCommandTask(
+        executable="executable", inpB="inp1", inpA="inp2", input_spec=my_input_spec
+    )
+    assert shelly.cmdline == "executable inp1 inp2"
+
+
+def test_shell_cmd_inputs_2a():
+    """ additional inputs without provided positions """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            ("inpA", attr.ib(type=str, metadata={"help_string": "inpA", "argstr": ""})),
+            ("inpB", attr.ib(type=str, metadata={"help_string": "inpB", "argstr": ""})),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    # separate command into exec + args
+    shelly = ShellCommandTask(
+        executable="executable",
+        inpA="inpNone1",
+        inpB="inpNone2",
+        input_spec=my_input_spec,
+    )
+    # position taken from the order in input spec
+    assert shelly.cmdline == "executable inpNone1 inpNone2"
+
+
+def test_shell_cmd_inputs_2_err():
+    """ additional inputs with provided positions (exception due to the duplication)"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpA", "argstr": ""},
+                ),
+            ),
+            (
+                "inpB",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpB", "argstr": ""},
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA="inp1", inpB="inp1", input_spec=my_input_spec
+    )
+    with pytest.raises(Exception) as e:
+        shelly.cmdline
+    assert "1 is already used" in str(e.value)
+
+
+def test_shell_cmd_inputs_3():
+    """ additional inputs: positive pos, negative pos and  no pos """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpA", "argstr": ""},
+                ),
+            ),
+            (
+                "inpB",
+                attr.ib(
+                    type=str,
+                    metadata={"position": -1, "help_string": "inpB", "argstr": ""},
+                ),
+            ),
+            ("inpC", attr.ib(type=str, metadata={"help_string": "inpC", "argstr": ""})),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    # separate command into exec + args
+    shelly = ShellCommandTask(
+        executable="executable",
+        inpA="inp1",
+        inpB="inp-1",
+        inpC="inpNone",
+        input_spec=my_input_spec,
+    )
+    # input without position shoild be between positive an negative positions
+    assert shelly.cmdline == "executable inp1 inpNone inp-1"
+
+
+def test_shell_cmd_inputs_argstr_1():
+    """ additional string inputs with argstr """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpA", "argstr": "-v"},
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA="inp1", input_spec=my_input_spec
+    )
+    # flag used before inp1
+    assert shelly.cmdline == "executable -v inp1"
+
+
+def test_shell_cmd_inputs_argstr_2():
+    """ additional bool inputs with argstr """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=bool,
+                    metadata={"position": 1, "help_string": "inpA", "argstr": "-v"},
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    # separate command into exec + args
+    shelly = ShellCommandTask(
+        executable="executable", args="arg", inpA=True, input_spec=my_input_spec
+    )
+    # a flag is used without any additional argument
+    assert shelly.cmdline == "executable -v arg"
+
+
+def test_shell_cmd_inputs_list_1():
+    """ providing list as an additional input, no sep, no argstr """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=ty.List[str],
+                    metadata={"position": 2, "help_string": "inpA", "argstr": ""},
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["el_1", "el_2", "el_3"], input_spec=my_input_spec
+    )
+    # multiple elements
+    assert shelly.cmdline == "executable el_1 el_2 el_3"
+
+
+def test_shell_cmd_inputs_list_2():
+    """ providing list as an additional input, no sep, but argstr """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=ty.List[str],
+                    metadata={"position": 2, "help_string": "inpA", "argstr": "-v"},
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["el_1", "el_2", "el_3"], input_spec=my_input_spec
+    )
+    assert shelly.cmdline == "executable -v el_1 el_2 el_3"
+
+
+def test_shell_cmd_inputs_list_3():
+    """ providing list as an additional input, no sep, argstr with ..."""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=ty.List[str],
+                    metadata={"position": 2, "help_string": "inpA", "argstr": "-v..."},
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["el_1", "el_2", "el_3"], input_spec=my_input_spec
+    )
+    # a flag is repeated
+    assert shelly.cmdline == "executable -v el_1 -v el_2 -v el_3"
+
+
+def test_shell_cmd_inputs_list_sep_1():
+    """ providing list as an additional input:, sep, no argstr"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "sep": ",",
+                        "argstr": "",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["aaa", "bbb", "ccc"], input_spec=my_input_spec
+    )
+    # separated by commas
+    assert shelly.cmdline == "executable aaa,bbb,ccc"
+
+
+def test_shell_cmd_inputs_list_sep_2():
+    """ providing list as an additional input:, sep, and argstr"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "sep": ",",
+                        "argstr": "-v",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["aaa", "bbb", "ccc"], input_spec=my_input_spec
+    )
+    # a flag is used once
+    assert shelly.cmdline == "executable -v aaa,bbb,ccc"
+
+
+def test_shell_cmd_inputs_sep_3():
+    """ providing list as an additional input:, sep, argstr with ..."""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "sep": ",",
+                        "argstr": "-v...",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["aaa", "bbb", "ccc"], input_spec=my_input_spec
+    )
+    # a flag is repeated
+    assert shelly.cmdline == "executable -v aaa, -v bbb, -v ccc"
+
+
+def test_shell_cmd_inputs_sep_4():
+    """ providing 1-el list as an additional input:, sep, argstr with ..., """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "sep": ",",
+                        "argstr": "-v...",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["aaa"], input_spec=my_input_spec
+    )
+    assert shelly.cmdline == "executable -v aaa"
+
+
+def test_shell_cmd_inputs_sep_4a():
+    """ providing str instead of list as an additional input:, sep, argstr with ..."""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "sep": ",",
+                        "argstr": "-v...",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA="aaa", input_spec=my_input_spec
+    )
+    assert shelly.cmdline == "executable -v aaa"
+
+
+def test_shell_cmd_inputs_format_1():
+    """ additional inputs with argstr that has string formatting"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "argstr": "-v {inpA}",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA="inpA", input_spec=my_input_spec
+    )
+    assert shelly.cmdline == "executable -v inpA"
+
+
+def test_shell_cmd_inputs_format_2():
+    """ additional inputs with argstr that has string formatting and ..."""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "argstr": "-v {inpA}...",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["el_1", "el_2"], input_spec=my_input_spec
+    )
+    assert shelly.cmdline == "executable -v el_1 -v el_2"
+
+
+def test_shell_cmd_inputs_di():
+    """ example from #279 """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "image_dimensionality",
+                attr.ib(
+                    type=int,
+                    metadata={
+                        "help_string": """
+                    2/3/4
+                    This option forces the image to be treated as a specified-dimensional image.
+                    If not specified, the program tries to infer the dimensionality from
+                    the input image.
+                    """,
+                        "allowed_values": [2, 3, 4],
+                        "argstr": "-d",
+                    },
+                ),
+            ),
+            (
+                "inputImageFilename",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "help_string": "A scalar image is expected as input for noise correction.",
+                        "argstr": "-i",
+                    },
+                ),
+            ),
+            (
+                "noise_model",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "help_string": """
+                    Rician/(Gaussian)
+                    Employ a Rician or Gaussian noise model.
+                    """,
+                        "allowed_values": ["Rician", "Gaussian"],
+                        "argstr": "-n",
+                    },
+                ),
+            ),
+            (
+                "maskImageFilename",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "help_string": "If a mask image is specified, denoising is only performed in the mask region.",
+                        "argstr": "-x",
+                    },
+                ),
+            ),
+            (
+                "noise_model",
+                attr.ib(
+                    type=int,
+                    metadata={
+                        "help_string": """
+            Rician/(Gaussian)
+            Employ a Rician or Gaussian noise model.
+            """,
+                        "allowed_values": ["Rician", "Gaussian"],
+                        "argstr": "-n",
+                    },
+                ),
+            ),
+            (
+                "shrink_factor",
+                attr.ib(
+                    type=int,
+                    default=1,
+                    metadata={
+                        "help_string": """
+                    (1)/2/3/...
+                    Running noise correction on large images can be time consuming.
+                    To lessen computation time, the input image can be resampled.
+                    The shrink factor, specified as a single integer, describes this
+                    resampling. Shrink factor = 1 is the default.
+                    """,
+                        "argstr": "-s",
+                    },
+                ),
+            ),
+            (
+                "patch_radius",
+                attr.ib(
+                    type=int,
+                    default=1,
+                    metadata={
+                        "help_string": "Patch radius. Default = 1x1x1",
+                        "argstr": "-p",
+                    },
+                ),
+            ),
+            (
+                "search_radius",
+                attr.ib(
+                    type=int,
+                    default=2,
+                    metadata={
+                        "help_string": "Search radius. Default = 2x2x2.",
+                        "argstr": "-r",
+                    },
+                ),
+            ),
+            (
+                "correctedImage",
+                attr.ib(
+                    type=ty.Any,
+                    metadata={
+                        "help_string": """
+                        The output consists of the noise corrected version of the input image.
+                        Optionally, one can also output the estimated noise image.
+                        """,
+                        "argstr": "-o",
+                    },
+                ),
+            ),
+            (
+                "version",
+                attr.ib(
+                    type=bool,
+                    default=False,
+                    metadata={
+                        "help_string": "Get Version Information.",
+                        "argstr": "--version",
+                    },
+                ),
+            ),
+            (
+                "verbose",
+                attr.ib(
+                    type=bool,
+                    default=0,
+                    metadata={"help_string": "(0)/1. Verbose output. ", "argstr": "-v"},
+                ),
+            ),
+            (
+                "help_short",
+                attr.ib(
+                    type=bool,
+                    default=False,
+                    metadata={
+                        "help_string": "Print the help menu (short version)",
+                        "argstr": "-h",
+                    },
+                ),
+            ),
+            (
+                "help",
+                attr.ib(
+                    type=int,
+                    metadata={
+                        "help_string": "Print the help menu.",
+                        "argstr": "--help",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    # no input provided
+    shelly = ShellCommandTask(executable="DenoiseImage", input_spec=my_input_spec)
+    assert shelly.cmdline == "DenoiseImage -s 1 -p 1 -r 2"
+
+    # input file name
+    shelly = ShellCommandTask(
+        executable="DenoiseImage",
+        inputImageFilename="my_input_file",
+        input_spec=my_input_spec,
+    )
+    assert shelly.cmdline == "DenoiseImage -i my_input_file -s 1 -p 1 -r 2"
+
+    # input file name and help_short
+    shelly = ShellCommandTask(
+        executable="DenoiseImage",
+        inputImageFilename="my_input_file",
+        help_short=True,
+        input_spec=my_input_spec,
+    )
+    assert shelly.cmdline == "DenoiseImage -i my_input_file -s 1 -p 1 -r 2 -h"

--- a/pydra/engine/tests/test_singularity.py
+++ b/pydra/engine/tests/test_singularity.py
@@ -395,6 +395,7 @@ def test_singularity_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -437,7 +438,7 @@ def test_singularity_inputspec_1a(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename,
-                    metadata={"position": 1, "help_string": "input file"},
+                    metadata={"position": 1, "argstr": "", "help_string": "input file"},
                 ),
             )
         ],
@@ -477,7 +478,12 @@ def test_singularity_inputspec_2(plugin, tmpdir):
             (
                 "file1",
                 attr.ib(
-                    type=File, metadata={"position": 1, "help_string": "input file 1"}
+                    type=File,
+                    metadata={
+                        "position": 1,
+                        "argstr": "",
+                        "help_string": "input file 1",
+                    },
                 ),
             ),
             (
@@ -485,7 +491,11 @@ def test_singularity_inputspec_2(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename_2,
-                    metadata={"position": 2, "help_string": "input file 2"},
+                    metadata={
+                        "position": 2,
+                        "argstr": "",
+                        "help_string": "input file 2",
+                    },
                 ),
             ),
         ],
@@ -530,13 +540,22 @@ def test_singularity_inputspec_2a_except(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename_1,
-                    metadata={"position": 1, "help_string": "input file 1"},
+                    metadata={
+                        "position": 1,
+                        "argstr": "",
+                        "help_string": "input file 1",
+                    },
                 ),
             ),
             (
                 "file2",
                 attr.ib(
-                    type=File, metadata={"position": 2, "help_string": "input file 2"}
+                    type=File,
+                    metadata={
+                        "position": 2,
+                        "argstr": "",
+                        "help_string": "input file 2",
+                    },
                 ),
             ),
         ],
@@ -581,13 +600,22 @@ def test_singularity_inputspec_2a(plugin, tmpdir):
                 attr.ib(
                     type=File,
                     default=filename_1,
-                    metadata={"position": 1, "help_string": "input file 1"},
+                    metadata={
+                        "position": 1,
+                        "argstr": "",
+                        "help_string": "input file 1",
+                    },
                 ),
             ),
             (
                 "file2",
                 attr.ib(
-                    type=File, metadata={"position": 2, "help_string": "input file 2"}
+                    type=File,
+                    metadata={
+                        "position": 2,
+                        "argstr": "",
+                        "help_string": "input file 2",
+                    },
                 ),
             ),
         ],
@@ -630,6 +658,7 @@ def test_singularity_cmd_inputspec_copyfile_1(plugin, tmpdir):
                     type=File,
                     metadata={
                         "position": 1,
+                        "argstr": "",
                         "help_string": "orig file",
                         "mandatory": True,
                         "copyfile": True,
@@ -697,6 +726,7 @@ def test_singularity_inputspec_state_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -747,6 +777,7 @@ def test_singularity_inputspec_state_1b(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -790,6 +821,7 @@ def test_singularity_wf_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -845,6 +877,7 @@ def test_singularity_wf_state_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),
@@ -902,6 +935,7 @@ def test_singularity_wf_ndst_inputspec_1(plugin, tmpdir):
                     metadata={
                         "mandatory": True,
                         "position": 1,
+                        "argstr": "",
                         "help_string": "input file",
                     },
                 ),

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -402,7 +402,7 @@ def test_container_cmds(tmpdir):
     containy = DockerTask(name="containy", executable="pwd")
     with pytest.raises(AttributeError) as excinfo:
         containy.cmdline
-    assert "not specified" in str(excinfo.value)
+    assert "mandatory" in str(excinfo.value)
     containy.inputs.image = "busybox"
     assert containy.cmdline
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
including `argstr` and `sep` supported by nipype 

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [ ] I acknowledge that this contribution will be available under the Apache 2 license.
