### PR TITLE
Revert "raise error when workflow returns None"

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -126,7 +126,7 @@ def save(task_path: Path, result=None, task=None, name_prefix=None):
     lockfile = task_path.parent / (task_path.name + "_save.lock")
     with SoftFileLock(lockfile):
         if result:
-            if task_path.name.startswith("Workflow") and result.output is not None:
+            if task_path.name.startswith("Workflow"):
                 # copy files to the workflow directory
                 result = copyfile_workflow(wf_path=task_path, result=result)
             with (task_path / f"{name_prefix}_result.pklz").open("wb") as fp:

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -70,11 +70,11 @@ class FunctionTask(TaskBase):
         audit_flags: AuditFlag = AuditFlag.NONE,
         cache_dir=None,
         cache_locations=None,
-        input_spec: ty.Optional[ty.Union[SpecInfo, BaseSpec]] = None,
+        input_spec: ty.Optional[SpecInfo] = None,
         messenger_args=None,
         messengers=None,
         name=None,
-        output_spec: ty.Optional[ty.Union[SpecInfo, BaseSpec]] = None,
+        output_spec: ty.Optional[BaseSpec] = None,
         rerun=False,
         **kwargs,
     ):

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -41,19 +41,8 @@ def test_wf_name_conflict2():
     wf.add(add2(name="task_name", x=wf.lzin.x))
     with pytest.raises(ValueError) as excinfo:
         wf.add(identity(name="task_name", x=3))
+
     assert "Another task named task_name is already added" in str(excinfo.value)
-
-
-def test_wf_no_output(plugin):
-    """ Raise error when output isn't set with set_output"""
-    wf = Workflow(name="wf_1", input_spec=["x"])
-    wf.add(add2(name="add2", x=wf.lzin.x))
-    wf.inputs.x = 2
-
-    with pytest.raises(ValueError) as excinfo:
-        with Submitter(plugin=plugin) as sub:
-            sub(wf)
-    assert "Workflow output cannot be None" in str(excinfo.value)
 
 
 def test_wf_1(plugin):


### PR DESCRIPTION
Reverts nipype/pydra#292

@nicolocin and @djarecka - i'm reverting this change for now. it seems to create a state where complex workflows don't finish. should have looked at more testing before merge.