### PR TITLE
WIP: Raise excepetion when an upstream task errored in a workflow

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -677,7 +677,7 @@ class Workflow(TaskBase):
 
         """
         if input_spec:
-            if isinstance(input_spec, BaseSpec):
+            if isinstance(input_spec, BaseSpec):  # TODO: test this block
                 self.input_spec = input_spec
             else:
                 self.input_spec = SpecInfo(

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -3677,12 +3677,7 @@ def test_wf_resultfile_3(plugin):
 
 
 def test_wf_upstream_error1(plugin):
-    """ workflow with two tasks, task2 dependent on an task1 which raised an error
-        now - AttributeError: 'NoneType' object has no attribute 'out' @ specs.py::get_value()
-              >>>  return getattr(result.output, self.field)
-              workflow doesn't finish running
-        goal - custom upstream task error
-    """
+    """ workflow with two tasks, task2 dependent on an task1 which raised an error"""
     wf = Workflow(name="wf", input_spec=["x"])
     wf.add(fun_addvar_default(name="addvar1", a=wf.lzin.x))
     wf.inputs.x = "hi"  # TypeError for adding str and int
@@ -3697,8 +3692,7 @@ def test_wf_upstream_error1(plugin):
 
 
 def test_wf_upstream_error2(plugin):
-    """ one of two outputs of task1 errors, workflow-level split on task 1
-            task2 is dependent on task1 output, task2 is dependent on task1 output
+    """ task2 dependent on task1, task1 errors, workflow-level split on task 1
         goal - workflow finish running, one output errors but the other doesn't
     """
     wf = Workflow(name="wf", input_spec=["x"])
@@ -3716,8 +3710,7 @@ def test_wf_upstream_error2(plugin):
 
 
 def test_wf_upstream_error3(plugin):
-    """ one of two outputs of task1 errors, task-level split on task 1
-            task2 is dependent on task1 output
+    """ task2 dependent on task1, task1 errors, task-level split on task 1
         goal - workflow finish running, one output errors but the other doesn't
     """
     wf = Workflow(name="wf", input_spec=["x"])

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -3674,3 +3674,61 @@ def test_wf_resultfile_3(plugin):
             assert val.exists()
             ii = int(key.split("_")[1])
             assert val == wf.output_dir / file_list[ii]
+
+
+def test_wf_upstream_error1(plugin):
+    """ workflow with two tasks, task2 dependent on an task1 which raised an error
+        now - AttributeError: 'NoneType' object has no attribute 'out' @ specs.py::get_value()
+              >>>  return getattr(result.output, self.field)
+              workflow doesn't finish running
+        goal - custom upstream task error
+    """
+    wf = Workflow(name="wf", input_spec=["x"])
+    wf.add(fun_addvar_default(name="addvar1", a=wf.lzin.x))
+    wf.inputs.x = "hi"  # TypeError for adding str and int
+    wf.plugin = plugin
+    wf.add(fun_addvar_default(name="addvar2", a=wf.addvar1.lzout.out))
+    wf.set_output([("out", wf.addvar2.lzout.out)])
+
+    with pytest.raises(Exception) as excinfo:
+        with Submitter(plugin=plugin) as sub:
+            sub(wf)
+    assert "Error in upstream task" in str(excinfo.value)
+
+
+def test_wf_upstream_error2(plugin):
+    """ one of two outputs of task1 errors, workflow-level split on task 1
+            task2 is dependent on task1 output, task2 is dependent on task1 output
+        goal - workflow finish running, one output errors but the other doesn't
+    """
+    wf = Workflow(name="wf", input_spec=["x"])
+    wf.add(fun_addvar_default(name="addvar1", a=wf.lzin.x))
+    wf.inputs.x = [1, "hi"]  # TypeError for adding str and int
+    wf.split("x")  # workflow-level split
+    wf.plugin = plugin
+    wf.add(fun_addvar_default(name="addvar2", a=wf.addvar1.lzout.out))
+    wf.set_output([("out", wf.addvar2.lzout.out)])
+
+    with pytest.raises(Exception) as excinfo:
+        with Submitter(plugin=plugin) as sub:
+            sub(wf)
+    assert "Error in upstream task" in str(excinfo.value)
+
+
+def test_wf_upstream_error3(plugin):
+    """ one of two outputs of task1 errors, task-level split on task 1
+            task2 is dependent on task1 output
+        goal - workflow finish running, one output errors but the other doesn't
+    """
+    wf = Workflow(name="wf", input_spec=["x"])
+    wf.add(fun_addvar_default(name="addvar1", a=wf.lzin.x))
+    wf.inputs.x = [1, "hi"]  # TypeError for adding str and int
+    wf.addvar1.split("a")  # task-level split
+    wf.plugin = plugin
+    wf.add(fun_addvar_default(name="addvar2", a=wf.addvar1.lzout.out))
+    wf.set_output([("out", wf.addvar2.lzout.out)])
+
+    with pytest.raises(Exception) as excinfo:
+        with Submitter(plugin=plugin) as sub:
+            sub(wf)
+    assert "Error in upstream task" in str(excinfo.value)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Fix for #299, extension of #290.   Currently raises exception whenever any of the upstream tasks fails.   Changed `get_value`
function a bit.

TODO: make `test_lazy_out` in `test_specs.py` pass

@satra @djarecka - not sure if my approach makes any sense, please review!

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
