### PR TITLE
FIX: Use pkgutil to declare namespace package

### DIFF
--- a/pydra/__init__.py
+++ b/pydra/__init__.py
@@ -5,6 +5,10 @@ Pydra is a rewrite of the Nipype engine with mapping and joining as
 first-class operations. It forms the core of the Nipype 2.0 ecosystem.
 
 """
+# This call enables pydra.tasks to be used as a namespace package when installed
+# in editable mode. In normal installations it has no effect.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
 import logging
 
 logger = logging.getLogger("pydra")

--- a/pydra/tasks/__init__.py
+++ b/pydra/tasks/__init__.py
@@ -5,7 +5,6 @@ packaged separately.
 To create a task package, please fork the `pydra-tasks-template
 <https://github.com/nipype/pydra-tasks-template>`__.
 """
-try:
-    __import__("pkg_resources").declare_namespace(__name__)
-except ImportError:
-    pass  # must not have setuptools
+# This call enables pydra.tasks to be used as a namespace package when installed
+# in editable mode. In normal installations it has no effect.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Switches from [`pkg_resources.declare_namespace`](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#namespace-package-support) to the stdlib [`pkgutil.extend_path`](https://docs.python.org/3/library/pkgutil.html#pkgutil.extend_path) approach to namespace packages. This has the advantage of avoiding a tight dependency on setuptools machinery in favor of stdlib features, and full compatibility with PEP 420 (implicit) namespace packages.

Specifically, the `pkgutil.extend_path` allows pydra to be installed in either normal or editable mode. Without these, only normal installations are compatible with task packages.

I have tested this locally, and also expanded the GitHub action matrix in nipype/pydra-nipype1#6 to demonstrate this.

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
