### PR TITLE
fixing issues with numpy arrays provided as an input

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -44,10 +44,13 @@ def ensure_list(obj, tuple2list=False):
     """
     if obj is None:
         return []
-    if isinstance(obj, list):
+    # list or numpy.array (this might need some extra flag in case an array has to be converted)
+    elif isinstance(obj, list) or hasattr(obj, "__array__"):
         return obj
     elif tuple2list and isinstance(obj, tuple):
         return list(obj)
+    elif isinstance(obj, list):
+        return obj
     return [obj]
 
 

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -59,9 +59,16 @@ def test_task_init_2():
     "splitter, state_splitter, state_rpn, states_ind, states_val",
     [("a", "NA.a", ["NA.a"], [{"NA.a": 0}, {"NA.a": 1}], [{"NA.a": 3}, {"NA.a": 5}])],
 )
-def test_task_init_3(splitter, state_splitter, state_rpn, states_ind, states_val):
+@pytest.mark.parametrize("input_type", ["list", "array"])
+def test_task_init_3(
+    splitter, state_splitter, state_rpn, states_ind, states_val, input_type
+):
     """ task with inputs and splitter"""
-    nn = fun_addtwo(name="NA", a=[3, 5]).split(splitter=splitter)
+    a_in = [3, 5]
+    if input_type == "array":
+        a_in = np.array(a_in)
+
+    nn = fun_addtwo(name="NA", a=a_in).split(splitter=splitter)
 
     assert np.allclose(nn.inputs.a, [3, 5])
     assert nn.state.splitter == state_splitter
@@ -101,9 +108,15 @@ def test_task_init_3(splitter, state_splitter, state_rpn, states_ind, states_val
         ),
     ],
 )
-def test_task_init_3a(splitter, state_splitter, state_rpn, states_ind, states_val):
+@pytest.mark.parametrize("input_type", ["list", "array"])
+def test_task_init_3a(
+    splitter, state_splitter, state_rpn, states_ind, states_val, input_type
+):
     """ task with inputs and splitter"""
-    nn = fun_addvar(name="NA", a=[3, 5], b=[10, 20]).split(splitter=splitter)
+    a_in, b_in = [3, 5], [10, 20]
+    if input_type == "array":
+        a_in, b_in = np.array(a_in), np.array(b_in)
+    nn = fun_addvar(name="NA", a=a_in, b=b_in).split(splitter=splitter)
 
     assert np.allclose(nn.inputs.a, [3, 5])
     assert np.allclose(nn.inputs.b, [10, 20])
@@ -704,9 +717,14 @@ def test_task_nostate_cachelocations_updated(plugin, tmpdir):
 
 
 @pytest.mark.flaky(reruns=2)  # when dask
-def test_task_state_1(plugin_dask_opt):
+@pytest.mark.parametrize("input_type", ["list", "array"])
+def test_task_state_1(plugin_dask_opt, input_type):
     """ task with the simplest splitter"""
-    nn = fun_addtwo(name="NA").split(splitter="a", a=[3, 5])
+    a_in = [3, 5]
+    if input_type == "array":
+        a_in = np.array(a_in)
+
+    nn = fun_addtwo(name="NA").split(splitter="a", a=a_in)
 
     assert nn.state.splitter == "NA.a"
     assert nn.state.splitter_rpn == ["NA.a"]
@@ -818,14 +836,17 @@ def test_task_state_singl_1(plugin):
         ),
     ],
 )
+@pytest.mark.parametrize("input_type", ["list", "array"])
 def test_task_state_2(
-    plugin, splitter, state_splitter, state_rpn, expected, expected_ind
+    plugin, splitter, state_splitter, state_rpn, expected, expected_ind, input_type
 ):
     """ Tasks with two inputs and a splitter (no combiner)"""
-    nn = fun_addvar(name="NA").split(splitter=splitter, a=[3, 5], b=[10, 20])
-
-    assert nn.inputs.a == [3, 5]
-    assert nn.inputs.b == [10, 20]
+    a_in, b_in = [3, 5], [10, 20]
+    if input_type == "array":
+        a_in, b_in = np.array(a_in), np.array(b_in)
+    nn = fun_addvar(name="NA").split(splitter=splitter, a=a_in, b=b_in)
+    assert (nn.inputs.a == np.array([3, 5])).all()
+    assert (nn.inputs.b == np.array([10, 20])).all()
     assert nn.state.splitter == state_splitter
     assert nn.state.splitter_rpn == state_rpn
     assert nn.state.splitter_final == state_splitter

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -108,7 +108,7 @@ def test_task_init_3(
         ),
     ],
 )
-@pytest.mark.parametrize("input_type", ["list", "array"])
+@pytest.mark.parametrize("input_type", ["list", "array", "mixed"])
 def test_task_init_3a(
     splitter, state_splitter, state_rpn, states_ind, states_val, input_type
 ):
@@ -116,6 +116,8 @@ def test_task_init_3a(
     a_in, b_in = [3, 5], [10, 20]
     if input_type == "array":
         a_in, b_in = np.array(a_in), np.array(b_in)
+    elif input_type == "mixed":
+        a_in = np.array(a_in)
     nn = fun_addvar(name="NA", a=a_in, b=b_in).split(splitter=splitter)
 
     assert np.allclose(nn.inputs.a, [3, 5])
@@ -836,7 +838,7 @@ def test_task_state_singl_1(plugin):
         ),
     ],
 )
-@pytest.mark.parametrize("input_type", ["list", "array"])
+@pytest.mark.parametrize("input_type", ["list", "array", "mixed"])
 def test_task_state_2(
     plugin, splitter, state_splitter, state_rpn, expected, expected_ind, input_type
 ):
@@ -844,6 +846,8 @@ def test_task_state_2(
     a_in, b_in = [3, 5], [10, 20]
     if input_type == "array":
         a_in, b_in = np.array(a_in), np.array(b_in)
+    elif input_type == "mixed":
+        a_in = np.array(a_in)
     nn = fun_addvar(name="NA").split(splitter=splitter, a=a_in, b=b_in)
     assert (nn.inputs.a == np.array([3, 5])).all()
     assert (nn.inputs.b == np.array([10, 20])).all()

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ test_requires =
     pytest >= 4.4.0
     pytest-cov
     pytest-env
-    pytest-xdist
+    pytest-xdist < 2.0
     pytest-rerunfailures
     codecov
     numpy
@@ -64,7 +64,7 @@ test =
     pytest >= 4.4.0
     pytest-cov
     pytest-env
-    pytest-xdist
+    pytest-xdist < 2.0
     pytest-rerunfailures
     codecov
     numpy


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
The current splitter didn't work properly when numpy array were provided as an input. Modified `ensure_list` so it doesn't modify an array.

(might need some future work if we allow for "inner splitter" to also have numpy array)

Thanks to @Hoda1394 for reporting!

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
