### PR TITLE
[enh, mnt] attr.classes and spec refactoring, new MultiInputObj 

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -130,16 +130,26 @@ class TaskBase:
         if name in dir(self):
             raise ValueError("Cannot use names of attributes or methods as task name")
         self.name = name
+        if not inputs:
+            inputs = {}
         if not self.input_spec:
             raise Exception("No input_spec in class: %s" % self.__class__.__name__)
         klass = make_klass(self.input_spec)
-        # todo should be used to input_check in spec??
-        self.inputs = klass(
-            **{
-                (f.name[1:] if f.name.startswith("_") else f.name): f.default
-                for f in attr.fields(klass)
-            }
-        )
+        inp_dict = {}
+        for f in attr.fields(klass):
+            if f.name.startswith("_"):
+                # in attrs names that starts with "_" could be set when name provided w/o "_"
+                name = f.name[1:]
+            else:
+                name = f.name
+            if name in inputs:
+                inp_dict[name] = inputs[name]
+            else:
+                # if the field not in inputs, the default value should be used
+                inp_dict[name] = f.default
+        self.inputs = klass(**inp_dict)
+        # checking if metadata is set properly
+        self.inputs.check_metadata()
         self.input_names = [
             field.name
             for field in attr.fields(klass)
@@ -154,18 +164,7 @@ class TaskBase:
         self._done = False
         if self._input_sets is None:
             self._input_sets = {}
-        if inputs:
-            if isinstance(inputs, dict):
-                inputs = {k: v for k, v in inputs.items() if k in self.input_names}
-            elif Path(inputs).is_file():
-                inputs = json.loads(Path(inputs).read_text())
-            elif isinstance(inputs, str):
-                if self._input_sets is None or inputs not in self._input_sets:
-                    raise ValueError(f"Unknown input set {inputs!r}")
-                inputs = self._input_sets[inputs]
-            self.inputs = attr.evolve(self.inputs, **inputs)
-            self.inputs.check_metadata()
-            self.state_inputs = inputs
+        self.state_inputs = {k: v for k, v in inputs.items() if k in self.input_names}
 
         self.audit = Audit(
             audit_flags=audit_flags,
@@ -412,8 +411,11 @@ class TaskBase:
                 self.hooks.post_run_task(self, result)
                 self.audit.finalize_audit(result)
                 save(odir, result=result, task=self)
-                for k, v in orig_inputs.items():
-                    setattr(self.inputs, k, v)
+                # # function etc. shouldn't change anyway, so removing
+                orig_inputs = dict(
+                    (k, v) for (k, v) in orig_inputs.items() if not k.startswith("_")
+                )
+                self.inputs = attr.evolve(self.inputs, **orig_inputs)
                 os.chdir(cwd)
         self.hooks.post_run(self, result)
         return result

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -18,7 +18,16 @@ import inspect
 import warnings
 
 
-from .specs import Runtime, File, Directory, attr_fields, Result, LazyField
+from .specs import (
+    Runtime,
+    File,
+    Directory,
+    attr_fields,
+    Result,
+    LazyField,
+    MultiOutputObj,
+    MultiInputObj,
+)
 from .helpers_file import hash_file, hash_dir, copyfile, is_existing_file
 
 
@@ -293,7 +302,7 @@ def custom_validator(instance, attribute, value):
         or value is None
         or attribute.name.startswith("_")  # e.g. _func
         or isinstance(value, LazyField)
-        or tp_attr in [ty.Any, inspect._empty]
+        or tp_attr in [ty.Any, inspect._empty, MultiOutputObj, MultiInputObj]
     ):
         check_type = False  # no checking of the type
     elif isinstance(tp_attr, type) or tp_attr in [File, Directory]:

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -235,13 +235,12 @@ def make_klass(spec):
         newfields = dict()
         for item in fields:
             if len(item) == 2:
+                name = item[0]
                 if isinstance(item[1], attr._make._CountingAttr):
-                    newfields[item[0]] = item[1]
-                    newfields[item[0]].validator(custom_validator)
+                    newfields[name] = item[1]
+                    newfields[name].validator(custom_validator)
                 else:
-                    newfields[item[0]] = attr.ib(
-                        type=item[1], validator=custom_validator
-                    )
+                    newfields[name] = attr.ib(type=item[1], validator=custom_validator)
             else:
                 if (
                     any([isinstance(ii, attr._make._CountingAttr) for ii in item])
@@ -273,6 +272,9 @@ def make_klass(spec):
                             metadata=mdata,
                             validator=custom_validator,
                         )
+            # if type has converter, e.g. MultiInputObj
+            if hasattr(newfields[name].type, "converter"):
+                newfields[name].converter = newfields[name].type.converter
         fields = newfields
     return attr.make_class(spec.name, fields, bases=spec.bases, kw_only=True)
 

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -99,11 +99,56 @@ class BaseSpec:
         for field, value in temp_values.items():
             setattr(self, field, value)
 
+    def check_fields_input_spec(self):
+        """
+        Check fields from input spec based on the medatada.
+
+        e.g., if xor, requires are fulfilled, if value provided when mandatory.
+
+        """
+        fields = attr_fields(self)
+        names = []
+        require_to_check = {}
+        for fld in fields:
+            mdata = fld.metadata
+            # checking if the mandatory field is provided
+            if getattr(self, fld.name) is attr.NOTHING:
+                if mdata.get("mandatory"):
+                    raise AttributeError(
+                        f"{fld.name} is mandatory, but no value provided"
+                    )
+                else:
+                    continue
+            names.append(fld.name)
+
+            # checking if fields meet the xor and requires are
+            if "xor" in mdata:
+                if [el for el in mdata["xor"] if el in names]:
+                    raise AttributeError(
+                        f"{fld.name} is mutually exclusive with {mdata['xor']}"
+                    )
+
+            if "requires" in mdata:
+                if [el for el in mdata["requires"] if el not in names]:
+                    # will check after adding all fields to names
+                    require_to_check[fld.name] = mdata["requires"]
+
+            if fld.type is File:
+                self._file_check_n_bindings(fld)
+
+        for nm, required in require_to_check.items():
+            required_notfound = [el for el in required if el not in names]
+            if required_notfound:
+                raise AttributeError(f"{nm} requires {required_notfound}")
+
+    def _file_check_n_bindings(self, field):
+        """for tasks without container, this is simple check if the file exists"""
+        file = Path(getattr(self, field.name))
+        if not file.exists():
+            raise AttributeError(f"the file from the {field.name} input does not exist")
+
     def check_metadata(self):
         """Check contained metadata."""
-
-    def check_fields_input_spec(self):
-        """Check input fields."""
 
     def template_update(self):
         """Update template."""
@@ -187,6 +232,56 @@ class RuntimeSpec:
     outdir: ty.Optional[str] = None
     container: ty.Optional[str] = "shell"
     network: bool = False
+
+
+@attr.s(auto_attribs=True, kw_only=True)
+class FunctionSpec(BaseSpec):
+    """Specification for a process invoked from a shell."""
+
+    def check_metadata(self):
+        """
+        Check the metadata for fields in input_spec and fields.
+
+        Also sets the default values when available and needed.
+
+        """
+        supported_keys = {
+            "allowed_values",
+            "copyfile",
+            "help_string",
+            "mandatory",
+            # "readonly", #likely not needed
+            # "output_field_name", #likely not needed
+            # "output_file_template", #likely not needed
+            "requires",
+            "keep_extension",
+            "xor",
+            "sep",
+        }
+        # special inputs, don't have to follow rules for standard inputs
+        special_input = ["_func", "_graph_checksums"]
+
+        fields = [fld for fld in attr_fields(self) if fld.name not in special_input]
+        for fld in fields:
+            mdata = fld.metadata
+            # checking keys from metadata
+            if set(mdata.keys()) - supported_keys:
+                raise AttributeError(
+                    f"only these keys are supported {supported_keys}, but "
+                    f"{set(mdata.keys()) - supported_keys} provided"
+                )
+            # checking if the help string is provided (required field)
+            if "help_string" not in mdata:
+                raise AttributeError(f"{fld.name} doesn't have help_string field")
+            # not allowing for default if the field is mandatory
+            if not fld.default == attr.NOTHING and mdata.get("mandatory"):
+                raise AttributeError(
+                    "default value should not be set when the field is mandatory"
+                )
+            # setting default if value not provided and default is available
+            if getattr(self, fld.name) is None:
+                if not fld.default == attr.NOTHING:
+                    setattr(self, fld.name, fld.default)
 
 
 @attr.s(auto_attribs=True, kw_only=True)
@@ -276,56 +371,9 @@ class ShellSpec(BaseSpec):
                 if not fld.default == attr.NOTHING:
                     setattr(self, fld.name, fld.default)
 
-    def check_fields_input_spec(self):
-        """
-        Check fields from input spec based on the medatada.
-
-        e.g., if xor, requires are fulfilled, if value provided when mandatory.
-
-        """
-        fields = attr_fields(self)
-        names = []
-        require_to_check = {}
-        for fld in fields:
-            mdata = fld.metadata
-            # checking if the mandatory field is provided
-            if getattr(self, fld.name) is attr.NOTHING:
-                if mdata.get("mandatory"):
-                    raise AttributeError(
-                        f"{fld.name} is mandatory, but no value provided"
-                    )
-                else:
-                    continue
-            names.append(fld.name)
-
-            # checking if fields meet the xor and requires are
-            if "xor" in mdata:
-                if [el for el in mdata["xor"] if el in names]:
-                    raise AttributeError(
-                        f"{fld.name} is mutually exclusive with {mdata['xor']}"
-                    )
-
-            if "requires" in mdata:
-                if [el for el in mdata["requires"] if el not in names]:
-                    # will check after adding all fields to names
-                    require_to_check[fld.name] = mdata["requires"]
-
-            if fld.type is File:
-                self._file_check(fld)
-
-        for nm, required in require_to_check.items():
-            required_notfound = [el for el in required if el not in names]
-            if required_notfound:
-                raise AttributeError(f"{nm} requires {required_notfound}")
-
-    def _file_check(self, field):
-        file = Path(getattr(self, field.name))
-        if not file.exists():
-            raise AttributeError(f"the file from the {field.name} input does not exist")
-
 
 @attr.s(auto_attribs=True, kw_only=True)
-class ShellOutSpec(BaseSpec):
+class ShellOutSpec:
     """Output specification of a generic shell process."""
 
     return_code: int
@@ -432,7 +480,7 @@ class ContainerSpec(ShellSpec):
     ] = attr.ib(default=None, metadata={"help_string": "bindings"})
     """Mount points to be bound into the container."""
 
-    def _file_check(self, field):
+    def _file_check_n_bindings(self, field):
         file = Path(getattr(self, field.name))
         if field.metadata.get("container_path"):
             # if the path is in a container the input should be treated as a str (hash as a str)

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -20,13 +20,24 @@ class Directory:
 
 
 class MultiInputObj:
-    """An :obj: ty.List[`os.pathlike`] object"""
+    """A ty.List[ty.Any] object, converter changes a single values to a list"""
 
     @classmethod
     def converter(cls, value):
         from .helpers import ensure_list
 
         return ensure_list(value)
+
+
+class MultiOutputObj:
+    """A ty.List[ty.Any] object, converter changes an 1-el list to the single value"""
+
+    @classmethod
+    def converter(cls, value):
+        if isinstance(value, list) and len(value) == 1:
+            return value[0]
+        else:
+            return value
 
 
 @attr.s(auto_attribs=True, kw_only=True)

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -183,8 +183,6 @@ class FunctionTask(TaskBase):
                     output_spec = SpecInfo(
                         name="Output", fields=[("out", return_info)], bases=(BaseSpec,)
                     )
-        elif "return" in func.__annotations__:
-            raise NotImplementedError("Branch not implemented")
         self.output_spec = output_spec
 
     def _run_task(self):

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -104,31 +104,26 @@ class FunctionTask(TaskBase):
 
         """
         if input_spec is None:
-            input_spec = SpecInfo(
-                name="Inputs",
-                fields=[
+            fields = []
+            for val in inspect.signature(func).parameters.values():
+                if val.default is not inspect.Signature.empty:
+                    val_dflt = val.default
+                else:
+                    val_dflt = attr.NOTHING
+                fields.append(
                     (
                         val.name,
                         attr.ib(
-                            default=val.default,
+                            default=val_dflt,
                             type=val.annotation,
                             metadata={
                                 "help_string": f"{val.name} parameter from {func.__name__}"
                             },
                         ),
                     )
-                    if val.default is not inspect.Signature.empty
-                    else (
-                        val.name,
-                        attr.ib(
-                            type=val.annotation, metadata={"help_string": val.name}
-                        ),
-                    )
-                    for val in inspect.signature(func).parameters.values()
-                ]
-                + [("_func", attr.ib(default=cp.dumps(func), type=str))],
-                bases=(BaseSpec,),
-            )
+                )
+            fields.append(("_func", attr.ib(default=cp.dumps(func), type=str)))
+            input_spec = SpecInfo(name="Inputs", fields=fields, bases=(BaseSpec,))
         else:
             input_spec.fields.append(
                 ("_func", attr.ib(default=cp.dumps(func), type=str))

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -485,7 +485,7 @@ def test_task_nostate_4(plugin, tmpdir):
     assert nn.output_dir.exists()
 
 
-def test_task_nostate_5(plugin, tmpdir):
+def test_task_nostate_5(tmpdir):
     """ task with a dictionary of files as an input"""
     file1 = tmpdir.join("file1.txt")
     with open(file1, "w") as f:
@@ -497,8 +497,7 @@ def test_task_nostate_5(plugin, tmpdir):
 
     nn = fun_file_list(name="NA", filename_list=[file1, file2])
 
-    with Submitter(plugin=plugin) as sub:
-        sub(nn)
+    nn()
 
     # checking the results
     results = nn.result()

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -1,7 +1,7 @@
 # Tasks for testing
 import time
 import sys, shutil
-import typing as tp
+import typing as ty
 from pathlib import Path
 import subprocess as sp
 import pytest
@@ -159,14 +159,14 @@ def fun_dict(d):
 
 
 @mark.task
-def fun_write_file(filename: tp.Union[str, File, Path], text="hello"):
+def fun_write_file(filename: ty.Union[str, File, Path], text="hello"):
     with open(filename, "w") as f:
         f.write(text)
     return Path(filename).absolute()
 
 
 @mark.task
-def fun_write_file_list(filename_list: tp.List[tp.Union[str, File, Path]], text="hi"):
+def fun_write_file_list(filename_list: ty.List[ty.Union[str, File, Path]], text="hi"):
     for ii, filename in enumerate(filename_list):
         with open(filename, "w") as f:
             f.write(f"from file {ii}: {text}")
@@ -176,7 +176,7 @@ def fun_write_file_list(filename_list: tp.List[tp.Union[str, File, Path]], text=
 
 @mark.task
 def fun_write_file_list2dict(
-    filename_list: tp.List[tp.Union[str, File, Path]], text="hi"
+    filename_list: ty.List[ty.Union[str, File, Path]], text="hi"
 ):
     filename_dict = {}
     for ii, filename in enumerate(filename_list):
@@ -196,7 +196,7 @@ def fun_file(filename: File):
 
 
 @mark.task
-def fun_file_list(filename_list: File):
+def fun_file_list(filename_list: ty.List[File]):
     txt_list = []
     for filename in filename_list:
         with open(filename) as f:


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
the PR mixes too many things...

- adding `MultiInputObj` as a new type (everything should be converted to a list when the type is used)
- adding converters to `make_klass` for types that have a class method converter (e.g. MultiInputPath)
- adding `__setattr__` to `BaseSpec` to be able validate and convert inputs that are set after initialization: using `attr.validate` (to validate all fields that have validators)  and "manually" calling converters (didn't find a better way to do it with `attrs`) 
- refactoring the way how `self.input` is created from `input_spec` in `TaskBase`
- refactoring spec classes, adding `FunctionSpec`

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
