### PR TITLE
FIX: Workflow raises exception if result is numpy array

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -16,6 +16,7 @@ from traceback import format_exception
 import typing as ty
 import inspect
 import warnings
+import numpy as np
 
 
 from .specs import (
@@ -156,8 +157,12 @@ def copyfile_workflow(wf_path, result):
     for field in attr_fields(result.output):
         value = getattr(result.output, field.name)
         new_value = _copyfile_single_value(wf_path=wf_path, value=value)
-        if new_value != value:
-            setattr(result.output, field.name, new_value)
+        if isinstance(value, np.ndarray): 
+            if not np.array_equal(value, new_value, equal_nan=True):
+                    setattr(result.output, field.name, new_value)
+        elif new_value != value:
+            setattr(result.output, field.name, new_value)    
+
     return result
 
 


### PR DESCRIPTION
Hi guys,

this is a first ugly workaround to resolve #270 
Feel free to suggest a more generic approach, because this works only for numpy arrays and probably fail for xarray.  