### PR TITLE
[mnt] make checksum_state faster (fixes 349)

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -262,8 +262,6 @@ class TaskBase:
             TODO
 
         """
-        self.state.prepare_states(self.inputs)
-        self.state.prepare_inputs()
         if state_index is not None:
             inputs_copy = deepcopy(self.inputs)
             for key, ind in self.state.inputs_ind[state_index].items():
@@ -284,6 +282,9 @@ class TaskBase:
             return checksum_ind
         else:
             checksum_list = []
+            if not hasattr(self.state, "inputs_ind"):
+                self.state.prepare_states(self.inputs)
+                self.state.prepare_inputs()
             for ind in range(len(self.state.inputs_ind)):
                 checksum_list.append(self.checksum_states(state_index=ind))
             return checksum_list
@@ -611,7 +612,8 @@ class TaskBase:
                     return self._combined_output(return_inputs=return_inputs)
                 else:
                     results = []
-                    for checksum in self.checksum_states():
+                    for ind in range(len(self.state.inputs_ind)):
+                        checksum = self.checksum_states(state_index=ind)
                         result = load_result(checksum, self.cache_locations)
                         if result is None:
                             return None


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- editing `checksum_states` so it doesn't  run `self.state.prepare_states` if not needed (much faster)
- small edit to `result`: asking for one `checksum` at a time

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.
