### PR TITLE
[mnt] slurm updates: sbatch args and requeuing

### DIFF
--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -8,6 +8,7 @@ import pytest
 
 from .utils import gen_basic_wf
 from ..core import Workflow
+from ..task import ShellCommandTask
 from ..submitter import Submitter
 from ... import mark
 
@@ -261,3 +262,58 @@ def test_slurm_args_2(tmpdir):
     with pytest.raises(RuntimeError, match="Error returned from sbatch:"):
         with Submitter("slurm", sbatch_args="-N1 --invalid") as sub:
             sub(task)
+
+
+@pytest.mark.skipif(not slurm_available, reason="slurm not installed")
+def test_slurm_cancel_rerun(tmpdir):
+    """ testing that tasks run with slurm is re-queue
+        Running wf with 2 tasks, one sleeps and the other trying to get
+        job_id of the first task and cancel it.
+        The first job should be re-queue and finish without problem.
+        (possibly has to be improved, in theory cancel job might finish before cancel)
+    """
+
+    @mark.task
+    def sleep(x):
+        time.sleep(x)
+        return x
+
+    @mark.task
+    def cancel(job_name_part):
+        import subprocess as sp
+
+        # getting the job_id of the first job that sleeps
+        job_id = ""
+        while job_id == "":
+            time.sleep(1)
+            id_p1 = sp.Popen(["squeue"], stdout=sp.PIPE)
+            id_p2 = sp.Popen(
+                ["grep", job_name_part], stdin=id_p1.stdout, stdout=sp.PIPE
+            )
+            id_p3 = sp.Popen(["awk", "{print $1}"], stdin=id_p2.stdout, stdout=sp.PIPE)
+            job_id = id_p3.communicate()[0].decode("utf-8").strip()
+
+        # # canceling the job
+        proc1 = sp.run(["scancel", job_id])
+        # checking the status of jobs with the name; returning the last item
+        proc2 = sp.run(["sacct", "-j", job_id], stdout=sp.PIPE, stderr=sp.PIPE)
+        return proc2.stdout.decode("utf-8").strip()  # .split("\n")[-1]
+
+    wf = Workflow(name="wf", input_spec=["x", "job_name"], cache_dir=tmpdir)
+    wf.add(sleep(name="sleep", x=wf.lzin.x))
+    wf.add(cancel(nane="cancel", job_name_part=wf.lzin.job_name))
+    # this is a job name for x=10, if x is different checksum and jobname would have to be updated
+    wf.inputs.x = 20
+    wf.inputs.job_name = "sleep"
+
+    wf.set_output([("out", wf.sleep.lzout.out), ("canc_out", wf.cancel.lzout.out)])
+    with Submitter("slurm") as sub:
+        sub(wf)
+
+    res = wf.result()
+    assert res.output.out == 20
+    # checking if indeed the sleep-task job was cancelled by cancel-task
+    assert "CANCELLED" in res.output.canc_out
+    breakpoint()
+    script_dir = tmpdir / "SlurmWorker_scripts"
+    assert script_dir.exists()

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -334,11 +334,10 @@ def test_slurm_cancel_rerun_1(tmpdir):
 
 @pytest.mark.skipif(not slurm_available, reason="slurm not installed")
 def test_slurm_cancel_rerun_2(tmpdir):
-    """ testing that tasks run with slurm is re-queue
-        Running wf with 2 tasks, one sleeps and the other trying to get
+    """ testing that tasks run with slurm that has --no-requeue
+        Running wf with 2 tasks, one sleeps and the other gets
         job_id of the first task and cancel it.
-        The first job should be re-queue and finish without problem.
-        (possibly has to be improved, in theory cancel job might finish before cancel)
+        The first job is not able t be rescheduled and the error is returned.
     """
     wf = Workflow(name="wf", input_spec=["x", "job_name"], cache_dir=tmpdir)
     wf.add(sleep(name="sleep", x=wf.lzin.x))

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -300,7 +300,10 @@ class SlurmWorker(DistributedWorker):
             # Exception: Polling / job failure
             done = await self._poll_job(jobid)
             if done:
-                if done in ["CANCELLED", "TIMEOUT", "PREEMPTED"]:
+                if (
+                    done in ["CANCELLED", "TIMEOUT", "PREEMPTED"]
+                    and "--no-requeue" not in self.sbatch_args
+                ):
                     if (cache_dir / f"{checksum}.lock").exists():
                         # for pyt3.8 we could you missing_ok=True
                         (cache_dir / f"{checksum}.lock").unlink()

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -301,7 +301,7 @@ class SlurmWorker(DistributedWorker):
             done = await self._poll_job(jobid)
             if done:
                 if done == "CANCELLED":
-                    os.remove(cache_dir / f"{checksum}.lock")
+                    (cache_dir / f"{checksum}.lock").unlink(missing_ok=True)
                     cmd_re = ("scontrol", "requeue", jobid)
                     await read_and_display_async(*cmd_re, hide_display=True)
                 else:

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -280,9 +280,13 @@ class SlurmWorker(DistributedWorker):
             error_file = None
         sargs.append(str(batchscript))
         # TO CONSIDER: add random sleep to avoid overloading calls
-        _, stdout, _ = await read_and_display_async("sbatch", *sargs, hide_display=True)
+        rc, stdout, stderr = await read_and_display_async(
+            "sbatch", *sargs, hide_display=True
+        )
         jobid = re.search(r"\d+", stdout)
-        if not jobid:
+        if rc:
+            raise RuntimeError(f"Error returned from sbatch: {stderr}")
+        elif not jobid:
             raise RuntimeError("Could not extract job ID")
         jobid = jobid.group()
         if error_file:


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- tests for adding `sbatch_args` to the Submitter
- better error handling for invalid slurm options
- options for requeuing if the job is cancelled 

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
