### PR TITLE
improving callable use in output spec

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -495,7 +495,25 @@ class ShellOutSpec:
             )
             return Path(value)
         elif "callable" in fld.metadata:
-            return fld.metadata["callable"](fld.name, output_dir)
+            call_args = inspect.getargspec(fld.metadata["callable"])
+            call_args_val = {}
+            for argnm in call_args.args:
+                if argnm == "field":
+                    call_args_val[argnm] = fld
+                elif argnm == "output_dir":
+                    call_args_val[argnm] = output_dir
+                elif argnm == "inputs":
+                    call_args_val[argnm] = inputs
+                else:
+                    try:
+                        call_args_val[argnm] = getattr(inputs, argnm)
+                    except AttributeError:
+                        raise AttributeError(
+                            f"arguments of the callable function from {fld.name} "
+                            f"has to be in inputs or be field or output_dir, "
+                            f"but {argnm} is used"
+                        )
+            return fld.metadata["callable"](**call_args_val)
         else:
             raise Exception("(_field_metadata) is not a current valid metadata key.")
 


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- `callable` function can now use `field`, `output_dir`, entire `inputs` object or a specific field form the inputs.

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
