### PR TITLE
improving tests that resubmit tasks to slurm

### DIFF
--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -21,8 +21,9 @@ def sleep_add_one(x):
     return x + 1
 
 
-def test_callable_wf(plugin):
+def test_callable_wf(plugin, tmpdir):
     wf = gen_basic_wf()
+
     with pytest.raises(NotImplementedError):
         wf()
 
@@ -31,12 +32,14 @@ def test_callable_wf(plugin):
     del wf, res
 
     wf = gen_basic_wf()
+    wf.cache_dir = tmpdir
+
     sub = Submitter(plugin)
     res = wf(submitter=sub)
     assert res.output.out == 9
 
 
-def test_concurrent_wf(plugin):
+def test_concurrent_wf(plugin, tmpdir):
     # concurrent workflow
     # A --> C
     # B --> D
@@ -48,6 +51,8 @@ def test_concurrent_wf(plugin):
     wf.add(sleep_add_one(name="taskc", x=wf.taska.lzout.out))
     wf.add(sleep_add_one(name="taskd", x=wf.taskb.lzout.out))
     wf.set_output([("out1", wf.taskc.lzout.out), ("out2", wf.taskd.lzout.out)])
+    wf.cache_dir = tmpdir
+
     with Submitter(plugin) as sub:
         sub(wf)
 
@@ -56,7 +61,7 @@ def test_concurrent_wf(plugin):
     assert res.output.out2 == 12
 
 
-def test_concurrent_wf_nprocs():
+def test_concurrent_wf_nprocs(tmpdir):
     # concurrent workflow
     # setting n_procs in Submitter that is passed to the worker
     # A --> C
@@ -69,8 +74,8 @@ def test_concurrent_wf_nprocs():
     wf.add(sleep_add_one(name="taskc", x=wf.taska.lzout.out))
     wf.add(sleep_add_one(name="taskd", x=wf.taskb.lzout.out))
     wf.set_output([("out1", wf.taskc.lzout.out), ("out2", wf.taskd.lzout.out)])
-    # wf.plugin = 'cf'
-    # res = wf.run()
+    wf.cache_dir = tmpdir
+
     with Submitter("cf", n_procs=2) as sub:
         sub(wf)
 
@@ -79,7 +84,7 @@ def test_concurrent_wf_nprocs():
     assert res.output.out2 == 12
 
 
-def test_wf_in_wf(plugin):
+def test_wf_in_wf(plugin, tmpdir):
     """WF(A --> SUBWF(A --> B) --> B)"""
     wf = Workflow(name="wf_in_wf", input_spec=["x"])
     wf.inputs.x = 3
@@ -92,10 +97,12 @@ def test_wf_in_wf(plugin):
     subwf.set_output([("out", subwf.sub_b.lzout.out)])
     # connect, then add
     subwf.inputs.x = wf.wf_a.lzout.out
-    wf.add(subwf)
+    subwf.cache_dir = tmpdir
 
+    wf.add(subwf)
     wf.add(sleep_add_one(name="wf_b", x=wf.sub_wf.lzout.out))
     wf.set_output([("out", wf.wf_b.lzout.out)])
+    wf.cache_dir = tmpdir
 
     with Submitter(plugin) as sub:
         sub(wf)
@@ -105,7 +112,7 @@ def test_wf_in_wf(plugin):
 
 
 @pytest.mark.flaky(reruns=2)  # when dask
-def test_wf2(plugin_dask_opt):
+def test_wf2(plugin_dask_opt, tmpdir):
     """ workflow as a node
         workflow-node with one task and no splitter
     """
@@ -117,6 +124,7 @@ def test_wf2(plugin_dask_opt):
     wf = Workflow(name="wf", input_spec=["x"])
     wf.add(wfnd)
     wf.set_output([("out", wf.wfnd.lzout.out)])
+    wf.cache_dir = tmpdir
 
     with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
@@ -126,7 +134,7 @@ def test_wf2(plugin_dask_opt):
 
 
 @pytest.mark.flaky(reruns=2)  # when dask
-def test_wf_with_state(plugin_dask_opt):
+def test_wf_with_state(plugin_dask_opt, tmpdir):
     wf = Workflow(name="wf_with_state", input_spec=["x"])
     wf.add(sleep_add_one(name="taska", x=wf.lzin.x))
     wf.add(sleep_add_one(name="taskb", x=wf.taska.lzout.out))
@@ -134,6 +142,7 @@ def test_wf_with_state(plugin_dask_opt):
     wf.inputs.x = [1, 2, 3]
     wf.split("x")
     wf.set_output([("out", wf.taskb.lzout.out)])
+    wf.cache_dir = tmpdir
 
     with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
@@ -295,13 +304,12 @@ def cancel(job_name_part):
         job_id = id_p3.communicate()[0].decode("utf-8").strip()
 
     # # canceling the job
-    proc1 = sp.run(["scancel", job_id])
-    # checking the status of jobs with the name; returning the last item
-    proc2 = sp.run(["sacct", "-j", job_id], stdout=sp.PIPE, stderr=sp.PIPE)
-    return proc2.stdout.decode("utf-8").strip()
+    proc = sp.run(["scancel", job_id, "--verbose"], stdout=sp.PIPE, stderr=sp.PIPE)
+    # cancelling the job returns message in the sterr
+    return proc.stderr.decode("utf-8").strip()
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=1)
 @pytest.mark.skipif(not slurm_available, reason="slurm not installed")
 def test_slurm_cancel_rerun_1(tmpdir):
     """ testing that tasks run with slurm is re-queue
@@ -315,25 +323,26 @@ def test_slurm_cancel_rerun_1(tmpdir):
         input_spec=["x", "job_name_cancel", "job_name_resqueue"],
         cache_dir=tmpdir,
     )
-    wf.add(sleep(name="sleep", x=wf.lzin.x, job_name_part=wf.lzin.job_name_cancel))
-    wf.add(cancel(nane="cancel", job_name_part=wf.lzin.job_name_resqueue))
+    wf.add(sleep(name="sleep1", x=wf.lzin.x, job_name_part=wf.lzin.job_name_cancel))
+    wf.add(cancel(name="cancel1", job_name_part=wf.lzin.job_name_resqueue))
     wf.inputs.x = 10
-    wf.inputs.job_name_resqueue = "sleep"
-    wf.inputs.job_name_cancel = "cancel"
+    wf.inputs.job_name_resqueue = "sleep1"
+    wf.inputs.job_name_cancel = "cancel1"
 
-    wf.set_output([("out", wf.sleep.lzout.out), ("canc_out", wf.cancel.lzout.out)])
+    wf.set_output([("out", wf.sleep1.lzout.out), ("canc_out", wf.cancel1.lzout.out)])
     with Submitter("slurm") as sub:
         sub(wf)
 
     res = wf.result()
     assert res.output.out == 10
     # checking if indeed the sleep-task job was cancelled by cancel-task
-    assert "CANCELLED" in res.output.canc_out
+    assert "Terminating" in res.output.canc_out
+    assert "Invalid" not in res.output.canc_out
     script_dir = tmpdir / "SlurmWorker_scripts"
     assert script_dir.exists()
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=1)
 @pytest.mark.skipif(not slurm_available, reason="slurm not installed")
 def test_slurm_cancel_rerun_2(tmpdir):
     """ testing that tasks run with slurm that has --no-requeue
@@ -342,13 +351,13 @@ def test_slurm_cancel_rerun_2(tmpdir):
         The first job is not able t be rescheduled and the error is returned.
     """
     wf = Workflow(name="wf", input_spec=["x", "job_name"], cache_dir=tmpdir)
-    wf.add(sleep(name="sleep", x=wf.lzin.x))
-    wf.add(cancel(nane="cancel", job_name_part=wf.lzin.job_name))
+    wf.add(sleep(name="sleep2", x=wf.lzin.x))
+    wf.add(cancel(name="cancel2", job_name_part=wf.lzin.job_name))
 
     wf.inputs.x = 10
-    wf.inputs.job_name = "sleep"
+    wf.inputs.job_name = "sleep2"
 
-    wf.set_output([("out", wf.sleep.lzout.out), ("canc_out", wf.cancel.lzout.out)])
+    wf.set_output([("out", wf.sleep2.lzout.out), ("canc_out", wf.cancel2.lzout.out)])
     with pytest.raises(Exception):
         with Submitter("slurm", sbatch_args="--no-requeue") as sub:
             sub(wf)


### PR DESCRIPTION


## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- fixing/improving tests for requeuing tasks (I believe tests didn't work if the task was resubmitted to quickly or when both tests were running the same time with the same jon names)

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
