### PR TITLE
fixing template formatting 

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -600,8 +600,12 @@ def _template_formatting(template, inputs_dict, keep_extension=True):
         fld_value = inputs_dict[fld_name]
         if fld_value is attr.NOTHING:
             return attr.NOTHING
-        fld_value = str(fld_value)  # in case it's a path
-        filename, *ext = fld_value.split(".", maxsplit=1)
+        fld_value_parent = Path(fld_value).parent
+        fld_value_name = Path(fld_value).name
+
+        name, *ext = fld_value_name.split(".", maxsplit=1)
+        filename = str(fld_value_parent / name)
+
         # if keep_extension is False, the extensions are removed
         if keep_extension is False:
             ext = []


### PR DESCRIPTION

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
template formatting didn't work well when the directory name had a dot inside

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
