### PR TITLE
adding MultiInputFile and MultiOutputFile (instead of #373)

### DIFF
--- a/.github/workflows/testpydra.yml
+++ b/.github/workflows/testpydra.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Disable etelemetry
-      run:  echo ::set-env name=NO_ET::TRUE
+      run:  echo "NO_ET=TRUE" >> $GITHUB_ENV
     - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/testsingularity.yml
+++ b/.github/workflows/testsingularity.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - name: Set env
         run: |
-          echo ::set-env name=RELEASE_VERSION::v3.5.0
-          echo ::set-env name=NO_ET::TRUE
+          echo "RELEASE_VERSION=v3.5.0" >> $GITHUB_ENV
+          echo "NO_ET=TRUE" >> $GITHUB_ENV
       - name: Setup Singularity
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/testslurm.yml
+++ b/.github/workflows/testslurm.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Disable etelemetry
-      run: echo ::set-env name=NO_ET::TRUE
+      run: echo "NO_ET=TRUE" >> $GITHUB_ENV
     - uses: actions/checkout@v2
     - name: Pull docker image
       run: |

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -27,6 +27,8 @@ from .specs import (
     LazyField,
     MultiOutputObj,
     MultiInputObj,
+    MultiInputFile,
+    MultiOutputFile,
 )
 from .helpers_file import hash_file, hash_dir, copyfile, is_existing_file
 
@@ -311,7 +313,15 @@ def custom_validator(instance, attribute, value):
         or value is None
         or attribute.name.startswith("_")  # e.g. _func
         or isinstance(value, LazyField)
-        or tp_attr in [ty.Any, inspect._empty, MultiOutputObj, MultiInputObj]
+        or tp_attr
+        in [
+            ty.Any,
+            inspect._empty,
+            MultiOutputObj,
+            MultiInputObj,
+            MultiOutputFile,
+            MultiInputFile,
+        ]
     ):
         check_type = False  # no checking of the type
     elif isinstance(tp_attr, type) or tp_attr in [File, Directory]:

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -541,7 +541,7 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
     based on the value from inputs_dict
     (checking the types of the fields, that have "output_file_template)"
     """
-    from .specs import File
+    from .specs import File, MultiOutputFile
 
     if spec_type == "input":
         if field.type not in [str, ty.Union[str, bool]]:
@@ -559,7 +559,7 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
                 f"type of {field.name} is str, consider using Union[str, bool]"
             )
     elif spec_type == "output":
-        if field.type is not File:
+        if field.type not in [File, MultiOutputFile]:
             raise Exception(
                 f"output {field.name} should be a File, but {field.type} set as the type"
             )
@@ -572,26 +572,30 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
         # if input fld is set to False, the fld shouldn't be used (setting NOTHING)
         return attr.NOTHING
     else:  # inputs_dict[field.name] is True or spec_type is output
-        template = field.metadata["output_file_template"]
-        # as default, we assume that keep_extension is True
-        keep_extension = field.metadata.get("keep_extension", True)
-        value = _template_formatting(
-            template, inputs_dict, keep_extension=keep_extension
-        )
+        value = _template_formatting(field, inputs_dict)
         # changing path so it is in the output_dir
         if output_dir and value is not attr.NOTHING:
             # should be converted to str, it is also used for input fields that should be str
-            return str(output_dir / Path(value).name)
+            if type(value) is list:
+                return [str(output_dir / Path(val).name) for val in value]
+            else:
+                return str(output_dir / Path(value).name)
         else:
             return value
 
 
-def _template_formatting(template, inputs_dict, keep_extension=True):
+def _template_formatting(field, inputs_dict):
     """Formatting a single template based on values from inputs_dict.
-    Taking into account that field values and template could have file extensions
-    (assuming that if template has extension, the field value extension is removed,
-    if field has extension, and no template extension, than it is moved to the end),
+    Taking into account that the field with a template can be a MultiOutputFile
+    and the field values needed in the template can be a list -
+    returning a list of formatted templates in that case.
     """
+    from .specs import MultiOutputFile
+
+    template = field.metadata["output_file_template"]
+    # as default, we assume that keep_extension is True
+    keep_extension = field.metadata.get("keep_extension", True)
+
     inp_fields = re.findall("{\w+}", template)
     if len(inp_fields) == 0:
         return template
@@ -600,29 +604,59 @@ def _template_formatting(template, inputs_dict, keep_extension=True):
         fld_value = inputs_dict[fld_name]
         if fld_value is attr.NOTHING:
             return attr.NOTHING
-        fld_value_parent = Path(fld_value).parent
-        fld_value_name = Path(fld_value).name
-
-        name, *ext = fld_value_name.split(".", maxsplit=1)
-        filename = str(fld_value_parent / name)
-
-        # if keep_extension is False, the extensions are removed
-        if keep_extension is False:
-            ext = []
-        if template.endswith(inp_fields[0]):
-            # if no suffix added in template, the simplest formatting should work
-            # recreating fld_value with the updated extension
-            fld_value_upd = ".".join([filename] + ext)
-            formatted_value = template.format(**{fld_name: fld_value_upd})
-        elif "." not in template:  # the template doesn't have its own extension
-            # if the fld_value has extension, it will be moved to the end
-            formatted_value = ".".join([template.format(**{fld_name: filename})] + ext)
-        else:  # template has its own extension
-            # removing fld_value extension if any
-            formatted_value = template.format(**{fld_name: filename})
+        # if field is MultiOutputFile and the fld_value is a list,
+        # each element of the list should be used separately in the template
+        # and return a list with formatted values
+        if field.type is MultiOutputFile and type(fld_value) is list:
+            formatted_value = []
+            for el in fld_value:
+                formatted_value.append(
+                    _element_formatting(
+                        template,
+                        fld_name=fld_name,
+                        fld_value=el,
+                        keep_extension=keep_extension,
+                    )
+                )
+        else:
+            formatted_value = _element_formatting(
+                template,
+                fld_name=fld_name,
+                fld_value=fld_value,
+                keep_extension=keep_extension,
+            )
         return formatted_value
     else:
         raise NotImplementedError("should we allow for more args in the template?")
+
+
+def _element_formatting(template, fld_name, fld_value, keep_extension):
+    """Formatting a single template for a single element of field value (if a list).
+    Taking into account that field values and template could have file extensions
+    (assuming that if template has extension, the field value extension is removed,
+    if field has extension, and no template extension, than it is moved to the end),
+    """
+    fld_value_parent = Path(fld_value).parent
+    fld_value_name = Path(fld_value).name
+
+    name, *ext = fld_value_name.split(".", maxsplit=1)
+    filename = str(fld_value_parent / name)
+
+    # if keep_extension is False, the extensions are removed
+    if keep_extension is False:
+        ext = []
+    if template.endswith(f"{{{fld_name}}}"):
+        # if no suffix added in template, the simplest formatting should work
+        # recreating fld_value with the updated extension
+        fld_value_upd = ".".join([filename] + ext)
+        formatted_value = template.format(**{fld_name: fld_value_upd})
+    elif "." not in template:  # the template doesn't have its own extension
+        # if the fld_value has extension, it will be moved to the end
+        formatted_value = ".".join([template.format(**{fld_name: filename})] + ext)
+    else:  # template has its own extension
+        # removing fld_value extension if any
+        formatted_value = template.format(**{fld_name: filename})
+    return formatted_value
 
 
 def is_local_file(f):

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -8,7 +8,14 @@ from pathlib import Path
 from ..task import ShellCommandTask
 from ..submitter import Submitter
 from ..core import Workflow
-from ..specs import ShellOutSpec, ShellSpec, SpecInfo, File
+from ..specs import (
+    ShellOutSpec,
+    ShellSpec,
+    SpecInfo,
+    File,
+    MultiOutputFile,
+    MultiInputObj,
+)
 from .utils import result_no_submitter, result_submitter, use_validator
 
 if sys.platform.startswith("win"):
@@ -2627,6 +2634,157 @@ def test_shell_cmd_outputspec_5a():
     res = shelly()
     assert res.output.stdout == ""
     assert res.output.out1.exists()
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_outputspec_6(tmpdir, plugin, results_function):
+    """
+        providing output with output_file_name and using MultiOutputFile as a type.
+        the input field used in the template is a MultiInputObj, so it can be and is a list
+    """
+    file = tmpdir.join("script.sh")
+    file.write(f'for var in "$@"; do touch file"$var".txt; done')
+
+    cmd = "bash"
+    new_files_id = ["1", "2", "3"]
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "script",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "help_string": "script file",
+                        "mandatory": True,
+                        "position": 1,
+                        "argstr": "",
+                    },
+                ),
+            ),
+            (
+                "files_id",
+                attr.ib(
+                    type=MultiInputObj,
+                    metadata={
+                        "position": 2,
+                        "argstr": "...",
+                        "sep": " ",
+                        "help_string": "list of name indices",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    my_output_spec = SpecInfo(
+        name="Output",
+        fields=[
+            (
+                "new_files",
+                attr.ib(
+                    type=MultiOutputFile,
+                    metadata={
+                        "output_file_template": "file{files_id}.txt",
+                        "help_string": "output file",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellOutSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        input_spec=my_input_spec,
+        output_spec=my_output_spec,
+        script=file,
+        files_id=new_files_id,
+    )
+
+    res = results_function(shelly, plugin)
+    assert res.output.stdout == ""
+    for file in res.output.new_files:
+        assert file.exists()
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_outputspec_6a(tmpdir, plugin, results_function):
+    """
+        providing output with output_file_name and using MultiOutputFile as a type.
+        the input field used in the template is a MultiInputObj, but a single element is used
+    """
+    file = tmpdir.join("script.sh")
+    file.write(f'for var in "$@"; do touch file"$var".txt; done')
+
+    cmd = "bash"
+    new_files_id = "1"
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "script",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "help_string": "script file",
+                        "mandatory": True,
+                        "position": 1,
+                        "argstr": "",
+                    },
+                ),
+            ),
+            (
+                "files_id",
+                attr.ib(
+                    type=MultiInputObj,
+                    metadata={
+                        "position": 2,
+                        "argstr": "...",
+                        "sep": " ",
+                        "help_string": "list of name indices",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    my_output_spec = SpecInfo(
+        name="Output",
+        fields=[
+            (
+                "new_files",
+                attr.ib(
+                    type=MultiOutputFile,
+                    metadata={
+                        "output_file_template": "file{files_id}.txt",
+                        "help_string": "output file",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellOutSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        input_spec=my_input_spec,
+        output_spec=my_output_spec,
+        script=file,
+        files_id=new_files_id,
+    )
+
+    res = results_function(shelly, plugin)
+    assert res.output.stdout == ""
+    assert res.output.new_files.exists()
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])


### PR DESCRIPTION
## Acknowledgment
- [ ] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
`MultiInputOutput` can be used in a `ShellTask` together with a template to return a list in case the input used in a template is a list

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
