### PR TITLE
[fix] fixing for `ContainerTasks`: input_spec and bindings

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -660,9 +660,17 @@ def _element_formatting(template, fld_name, fld_value, keep_extension):
 
 
 def is_local_file(f):
-    from .specs import File
+    # breakpoint()
+    from .specs import File, Directory, MultiInputFile
 
-    return f.type is File and "container_path" not in f.metadata
+    if "container_path" not in f.metadata and (
+        f.type in [File, Directory, MultiInputFile]
+        or "pydra.engine.specs.File" in str(f.type)
+        or "pydra.engine.specs.Directory" in str(f.type)
+    ):
+        return True
+    else:
+        return False
 
 
 def is_existing_file(value):

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -234,8 +234,14 @@ class ShellCommandTask(TaskBase):
             )
 
         if type_cont == "docker":
+            # changing base class of spec if user defined
+            if "input_spec" in kwargs:
+                kwargs["input_spec"].bases = (DockerSpec,)
             return DockerTask(image=image, bindings=bind, *args, **kwargs)
         elif type_cont == "singularity":
+            # changing base class of spec if user defined
+            if "input_spec" in kwargs:
+                kwargs["input_spec"].bases = (SingularitySpec,)
             return SingularityTask(image=image, bindings=bind, *args, **kwargs)
         else:
             raise Exception(
@@ -376,14 +382,13 @@ class ShellCommandTask(TaskBase):
         if value is attr.NOTHING or value is None:
             return None
         if check_file:
-            if is_local_file(field):
+            if is_local_file(field) and getattr(self, "bind_paths", None):
                 value = str(value)
                 # changing path to the cpath (the directory should be mounted)
-                if getattr(self, "bind_paths", None):
-                    lpath = Path(value)
-                    cdir = self.bind_paths(ind=ind)[lpath.parent][0]
-                    cpath = cdir.joinpath(lpath.name)
-                    value = str(cpath)
+                lpath = Path(value)
+                cdir = self.bind_paths(ind=ind)[lpath.parent][0]
+                cpath = cdir.joinpath(lpath.name)
+                value = str(cpath)
         return value
 
     def _command_shelltask_executable(self, field, state_ind, ind):

--- a/pydra/engine/tests/test_dockertask.py
+++ b/pydra/engine/tests/test_dockertask.py
@@ -5,7 +5,7 @@ import attr
 from ..task import DockerTask, ShellCommandTask
 from ..submitter import Submitter
 from ..core import Workflow
-from ..specs import ShellOutSpec, SpecInfo, File, DockerSpec
+from ..specs import ShellOutSpec, SpecInfo, File, DockerSpec, ShellSpec
 from .utils import no_win, need_docker
 
 
@@ -657,7 +657,7 @@ def test_docker_outputspec_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-def test_docker_inputspec_1(plugin, tmpdir):
+def test_docker_inputspec_1(tmpdir):
     """ a simple customized input spec for docker task """
     filename = str(tmpdir.join("file_pydra.txt"))
     with open(filename, "w") as f:
@@ -699,7 +699,7 @@ def test_docker_inputspec_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-def test_docker_inputspec_1a(plugin, tmpdir):
+def test_docker_inputspec_1a(tmpdir):
     """ a simple customized input spec for docker task
         a default value is used
     """
@@ -729,6 +729,50 @@ def test_docker_inputspec_1a(plugin, tmpdir):
         image="busybox",
         executable=cmd,
         input_spec=my_input_spec,
+        strip=True,
+    )
+
+    res = docky()
+    assert res.output.stdout == "hello from pydra"
+
+
+@no_win
+@need_docker
+def test_docker_inputspec_1_dockerflag(tmpdir):
+    """ a simple customized input spec for docker task
+        using ShellTask with container_info
+    """
+    filename = str(tmpdir.join("file_pydra.txt"))
+    with open(filename, "w") as f:
+        f.write("hello from pydra")
+
+    cmd = "cat"
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "file",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "mandatory": True,
+                        "position": 1,
+                        "argstr": "",
+                        "help_string": "input file",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    docky = ShellCommandTask(
+        name="docky",
+        executable=cmd,
+        file=filename,
+        input_spec=my_input_spec,
+        container_info=("docker", "busybox"),
         strip=True,
     )
 

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -1456,7 +1456,7 @@ def test_shell_cmd_inputspec_10_err(tmpdir):
     )
     shelly.cache_dir = tmpdir
 
-    with pytest.raises(AttributeError) as e:
+    with pytest.raises(FileNotFoundError):
         res = shelly()
 
 

--- a/pydra/engine/tests/test_tasks_files.py
+++ b/pydra/engine/tests/test_tasks_files.py
@@ -134,7 +134,9 @@ def test_broken_file(tmpdir):
             sub(nn)
 
     nn2 = file_add2_annot(name="add2_annot", file=file)
-    with pytest.raises(AttributeError, match="file from the file input does not exist"):
+    with pytest.raises(
+        FileNotFoundError, match="file from the file input does not exist"
+    ):
         with Submitter(plugin="cf") as sub:
             sub(nn2)
 
@@ -161,7 +163,9 @@ def test_broken_file_link(tmpdir):
 
     # raises error before task is run
     nn2 = file_add2_annot(name="add2_annot", file=file_link)
-    with pytest.raises(AttributeError, match="file from the file input does not exist"):
+    with pytest.raises(
+        FileNotFoundError, match="file from the file input does not exist"
+    ):
         with Submitter(plugin="cf") as sub:
             sub(nn2)
 


### PR DESCRIPTION


## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- fixing `input_spec` for `ShellCommandTask` with the `container_info` (base class has to be  changed`DockerSpec` or `SingularitySpec`)
- fixing automatic binding detections for `ContainerTask` that have files as input (`is_local_file` is now slightly more robust that work for input that has more complex type in the spec)

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
