### PR TITLE
Allowed more types in output_spec

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -556,6 +556,7 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
     based on the value from inputs_dict
     (checking the types of the fields, that have "output_file_template)"
     """
+
     from .specs import File, MultiOutputFile, Directory
 
     if spec_type == "input":
@@ -575,15 +576,15 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
             )
     elif spec_type == "output":
         if field.type not in [
-                    File,
-                    MultiOutputFile,
-                    Directory,
-                    int,
-                    float,
-                    bool,
-                    str,
-                    list,
-                ]: 
+            File,
+            MultiOutputFile,
+            Directory,
+            int,
+            float,
+            bool,
+            str,
+            list,
+        ]:
             raise Exception(
                 f"output {field.name} should be a File, but {field.type} set as the type"
             )

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -556,7 +556,7 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
     based on the value from inputs_dict
     (checking the types of the fields, that have "output_file_template)"
     """
-    from .specs import File, MultiOutputFile
+    from .specs import File, MultiOutputFile, Directory
 
     if spec_type == "input":
         if field.type not in [str, ty.Union[str, bool]]:
@@ -574,7 +574,16 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
                 f"type of {field.name} is str, consider using Union[str, bool]"
             )
     elif spec_type == "output":
-        if field.type not in [File, MultiOutputFile]:
+        if field.type not in [
+                    File,
+                    MultiOutputFile,
+                    Directory,
+                    int,
+                    float,
+                    bool,
+                    str,
+                    list,
+                ]: 
             raise Exception(
                 f"output {field.name} should be a File, but {field.type} set as the type"
             )

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -2937,32 +2937,14 @@ def test_shell_cmd_outputspec_7c(tmpdir, plugin, results_function):
     def get_lowest_directory(directory_path):
         return str(directory_path).replace(str(Path(directory_path).parents[0]), "")
 
-    cmd = "touch"
-    args = ["newfile_1.txt", "newfile_2.txt"]
-    my_input_spec = SpecInfo(
-        name="Input",
-        fields=[
-            (
-                "resultsDir",
-                attr.ib(
-                    type=Directory,
-                    metadata={
-                        # "position": 1,
-                        # "argstr": "",
-                        "help_string": "output file",
-                        "mandatory": True,
-                    },
-                ),
-            )
-        ],
-        bases=(ShellSpec,),
-    )
+    cmd = "mkdir"
+    args = [f"{tmpdir}/dir1", f"{tmpdir}/dir2"]
 
     my_output_spec = SpecInfo(
         name="Output",
         fields=[
             (
-                "out1",
+                "resultsDir",
                 attr.ib(
                     type=File,
                     metadata={
@@ -2970,54 +2952,26 @@ def test_shell_cmd_outputspec_7c(tmpdir, plugin, results_function):
                         "help_string": "output file",
                     },
                 ),
-            ),
-            (
-                "resultsDir",
-                attr.ib(
-                    type=File,
-                    metadata={
-                        "output_file_template": "{resultsDir}",
-                        "help_string": "output file",
-                    },
-                ),
-            ),
+            )
         ],
         bases=(ShellOutSpec,),
     )
 
-    args_with_dir = [str(Path(tmpdir) / Path(x)) for x in args]
-
-    #    assert args_with_dir == ""
-    #
-    #    args_with_dir = [f"test_{x}" for x in args]
-
-    # args_with_dir = args
-
-    # args = [f'{tmpdir}/newfile_1.txt', f'{tmpdir}/newfile_2.txt']
-
     shelly = ShellCommandTask(
         name="shelly",
         executable=cmd,
-        args=args_with_dir,
+        args=args,
         output_spec=my_output_spec,
-        input_spec=my_input_spec,
-        resultsDir=tmpdir,
+        resultsDir="outdir",
     ).split("args")
 
     with Submitter(plugin=plugin) as sub:
         shelly(submitter=sub)
     res = shelly.result()
 
-    for arg_file in args:
-        assert (Path(tmpdir) / arg_file).exists() == True
-
-
-#    for index, result in enumerate(res):
-#        assert (
-#            Path(f"{tmpdir}/newfile_{index+1}.txt").name
-#            == Path(result.output.out1).name
-#        )
-#        assert get_lowest_directory(result.output.resultsDir) == get_lowest_directory(tmpdir)
+    for index, arg_dir in enumerate(args):
+        assert Path(Path(tmpdir) / Path(arg_dir)).exists() == True
+        assert get_lowest_directory(arg_dir) == f"/dir{index+1}"
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -14,6 +14,7 @@ from ..specs import (
     SpecInfo,
     File,
     MultiOutputFile,
+    Directory,
     MultiInputObj,
 )
 from .utils import result_no_submitter, result_submitter, use_validator
@@ -2925,6 +2926,98 @@ def test_shell_cmd_outputspec_7b_error():
     with pytest.raises(Exception) as e:
         shelly()
     assert "has to have a callable" in str(e.value)
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_outputspec_7c(tmpdir, plugin, results_function):
+    """
+        customised output_spec, adding Directory to the output,
+    """
+
+    def get_lowest_directory(directory_path):
+        return str(directory_path).replace(str(Path(directory_path).parents[0]), "")
+
+    cmd = "touch"
+    args = ["newfile_1.txt", "newfile_2.txt"]
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "resultsDir",
+                attr.ib(
+                    type=Directory,
+                    metadata={
+                        # "position": 1,
+                        # "argstr": "",
+                        "help_string": "output file",
+                        "mandatory": True,
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    my_output_spec = SpecInfo(
+        name="Output",
+        fields=[
+            (
+                "out1",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "output_file_template": "{args}",
+                        "help_string": "output file",
+                    },
+                ),
+            ),
+            (
+                "resultsDir",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "output_file_template": "{resultsDir}",
+                        "help_string": "output file",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellOutSpec,),
+    )
+
+    args_with_dir = [str(Path(tmpdir) / Path(x)) for x in args]
+
+    #    assert args_with_dir == ""
+    #
+    #    args_with_dir = [f"test_{x}" for x in args]
+
+    # args_with_dir = args
+
+    # args = [f'{tmpdir}/newfile_1.txt', f'{tmpdir}/newfile_2.txt']
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        args=args_with_dir,
+        output_spec=my_output_spec,
+        input_spec=my_input_spec,
+        resultsDir=tmpdir,
+    ).split("args")
+
+    with Submitter(plugin=plugin) as sub:
+        shelly(submitter=sub)
+    res = shelly.result()
+
+    for arg_file in args:
+        assert (Path(tmpdir) / arg_file).exists() == True
+
+
+#    for index, result in enumerate(res):
+#        assert (
+#            Path(f"{tmpdir}/newfile_{index+1}.txt").name
+#            == Path(result.output.out1).name
+#        )
+#        assert get_lowest_directory(result.output.resultsDir) == get_lowest_directory(tmpdir)
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Adding Directory, int, float, bool, str, and list to allowed output types. Before this addition, the following error would be thrown if one of these types was included in an output_spec.
`f"output {field.name} should be a File, but {field.type} set as the type"`

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
