### PR TITLE
Output directory from output_file_template

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -556,7 +556,6 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
     based on the value from inputs_dict
     (checking the types of the fields, that have "output_file_template)"
     """
-
     from .specs import File, MultiOutputFile, Directory
 
     if spec_type == "input":
@@ -575,11 +574,7 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
                 f"type of {field.name} is str, consider using Union[str, bool]"
             )
     elif spec_type == "output":
-        if field.type not in [
-            File,
-            MultiOutputFile,
-            Directory,
-        ]:
+        if field.type not in [File, MultiOutputFile, Directory]:
             raise Exception(
                 f"output {field.name} should be a File, but {field.type} set as the type"
             )

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -556,7 +556,8 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
     based on the value from inputs_dict
     (checking the types of the fields, that have "output_file_template)"
     """
-    from .specs import File, MultiOutputFile
+
+    from .specs import File, MultiOutputFile, Directory
 
     if spec_type == "input":
         if field.type not in [str, ty.Union[str, bool]]:
@@ -574,7 +575,11 @@ def template_update_single(field, inputs_dict, output_dir=None, spec_type="input
                 f"type of {field.name} is str, consider using Union[str, bool]"
             )
     elif spec_type == "output":
-        if field.type not in [File, MultiOutputFile]:
+        if field.type not in [
+            File,
+            MultiOutputFile,
+            Directory,
+        ]:
             raise Exception(
                 f"output {field.name} should be a File, but {field.type} set as the type"
             )

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -13,6 +13,7 @@ from ..specs import (
     ShellSpec,
     SpecInfo,
     File,
+    Directory,
     MultiOutputFile,
     MultiInputObj,
 )
@@ -2930,7 +2931,7 @@ def test_shell_cmd_outputspec_7b_error():
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
 def test_shell_cmd_outputspec_7c(tmpdir, plugin, results_function):
     """
-        customised output_spec, adding Directory to the output,
+        customised output_spec, adding Directory to the output named by args
     """
 
     def get_lowest_directory(directory_path):
@@ -2945,7 +2946,7 @@ def test_shell_cmd_outputspec_7c(tmpdir, plugin, results_function):
             (
                 "resultsDir",
                 attr.ib(
-                    type=File,
+                    type=Directory,
                     metadata={
                         "output_file_template": "{args}",
                         "help_string": "output file",
@@ -2964,13 +2965,71 @@ def test_shell_cmd_outputspec_7c(tmpdir, plugin, results_function):
         resultsDir="outdir",
     ).split("args")
 
-    with Submitter(plugin=plugin) as sub:
-        shelly(submitter=sub)
-    res = shelly.result()
-
+    res = results_function(shelly, plugin)
     for index, arg_dir in enumerate(args):
         assert Path(Path(tmpdir) / Path(arg_dir)).exists() == True
         assert get_lowest_directory(arg_dir) == f"/dir{index+1}"
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_outputspec_7d(tmpdir, plugin, results_function):
+    """
+        customised output_spec, adding Directory to the output named by input spec
+    """
+
+    def get_lowest_directory(directory_path):
+        return str(directory_path).replace(str(Path(directory_path).parents[0]), "")
+
+    cmd = "mkdir"
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "resultsDir",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "new directory",
+                        "argstr": "",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    my_output_spec = SpecInfo(
+        name="Output",
+        fields=[
+            (
+                "resultsDir",
+                attr.ib(
+                    type=Directory,
+                    metadata={
+                        "output_file_template": "{resultsDir}",
+                        "help_string": "output file",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellOutSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        input_spec=my_input_spec,
+        output_spec=my_output_spec,
+        resultsDir=Path(tmpdir) / Path("test"),
+    )
+
+    res = results_function(shelly, plugin)
+    assert (Path(tmpdir) / Path("test")).exists() == True
+    assert get_lowest_directory(res.output.resultsDir) == get_lowest_directory(
+        Path(tmpdir) / Path("test")
+    )
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Output directory names can be specified in output_file_template. Recent changes to pydra have allowed an output field to be of type Directory. This PR allows those the name of the directory to be set using the output_file_template metadata field.

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
