### PR TITLE
using asyncio.SelectorEventLoop() to get a loop

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -649,8 +649,16 @@ def get_open_loop():
     if os.name == "nt":
         loop = asyncio.ProactorEventLoop()  # for subprocess' pipes on Windows
     else:
-        loop = asyncio.SelectorEventLoop()
-    asyncio.set_event_loop(loop)
+        try:
+            loop = asyncio.get_event_loop()
+        # in case RuntimeError: There is no current event loop in thread 'MainThread'
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        else:
+            if loop.is_closed():
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
     return loop
 
 

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -648,12 +648,9 @@ def get_open_loop():
     """
     if os.name == "nt":
         loop = asyncio.ProactorEventLoop()  # for subprocess' pipes on Windows
-        asyncio.set_event_loop(loop)
     else:
-        loop = asyncio.get_event_loop()
-        if loop.is_closed():
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+        loop = asyncio.SelectorEventLoop()
+    asyncio.set_event_loop(loop)
     return loop
 
 


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
I was getting error from `asyncio.get_event_loop()` when pydra was run after `datalad` (also uses `asyncio`).

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
