### PR TITLE
ShellCommandTask NOTHING parameters

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -27,7 +27,10 @@ class MultiInputObj:
     def converter(cls, value):
         from .helpers import ensure_list
 
-        return ensure_list(value)
+        if value == attr.NOTHING:
+            return value
+        else:
+            return ensure_list(value)
 
 
 class MultiOutputObj:

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -475,7 +475,7 @@ class ShellCommandTask(TaskBase):
                 if "{" in argstr and "}" in argstr:
                     cmd_el_str = argstr_formatting(argstr, self.inputs)
                 else:  # argstr has a simple form, e.g. "-f", or "--f"
-                    if value and value != "NOTHING":
+                    if value:
                         cmd_el_str = f"{argstr} {value}"
                     else:
                         cmd_el_str = ""

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -475,7 +475,7 @@ class ShellCommandTask(TaskBase):
                 if "{" in argstr and "}" in argstr:
                     cmd_el_str = argstr_formatting(argstr, self.inputs)
                 else:  # argstr has a simple form, e.g. "-f", or "--f"
-                    if value:
+                    if value and value != "NOTHING":
                         cmd_el_str = f"{argstr} {value}"
                     else:
                         cmd_el_str = ""

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -3,7 +3,7 @@ import typing as ty
 import pytest
 
 from ..task import ShellCommandTask
-from ..specs import ShellOutSpec, ShellSpec, SpecInfo, File
+from ..specs import ShellOutSpec, ShellSpec, SpecInfo, File, MultiInputObj
 from .utils import use_validator
 
 
@@ -531,6 +531,52 @@ def test_shell_cmd_inputs_mandatory_1():
     with pytest.raises(Exception) as e:
         shelly.cmdline
     assert "mandatory" in str(e.value)
+
+
+def test_shell_cmd_inputs_not_given_1():
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "arg1",
+                attr.ib(
+                    type=MultiInputObj,
+                    metadata={
+                        "argstr": "--arg1",
+                        "help_string": "Command line argument 1",
+                    },
+                ),
+            ),
+            (
+                "arg2",
+                attr.ib(
+                    type=MultiInputObj,
+                    metadata={
+                        "argstr": "--arg2",
+                        "help_string": "Command line argument 2",
+                    },
+                ),
+            ),
+            (
+                "arg3",
+                attr.ib(
+                    type=File,
+                    metadata={
+                        "argstr": "--arg3",
+                        "help_string": "Command line argument 3",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+    shelly = ShellCommandTask(
+        name="shelly", executable="executable", input_spec=my_input_spec
+    )
+
+    shelly.inputs.arg2 = "argument2"
+
+    assert shelly.cmdline == f"executable --arg2 argument2"
 
 
 def test_shell_cmd_inputs_template_1():


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
This PR addresses issue #405. In a ShellCommandTask, with input parameter of type MultiInputObj, if a value is not given for that parameter, the cmdline previously would include this parameter with value NOTHING. This PR would simply not include the parameter in the cmdline.

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
