### PR TITLE
adding flexibility to position of the shell task fields

### DIFF
--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -346,6 +346,10 @@ class ShellCommandTask(TaskBase):
                 "bindings",
             ]:
                 continue
+            elif getattr(self.inputs, f.name) is attr.NOTHING and not f.metadata.get(
+                "readonly"
+            ):
+                continue
             elif f.name == "executable":
                 pos_args.append(
                     self._command_shelltask_executable(
@@ -424,18 +428,22 @@ class ShellCommandTask(TaskBase):
         if pos is None:
             # position will be set at the end
             pass
-        elif not isinstance(pos, int):
-            raise Exception(f"position should be an integer, but {pos} given")
-        elif pos == 0:
-            raise Exception(f"position can't be 0")
-        elif pos < 0:  # position -1 is for args
-            pos = pos - 1
-        # checking if the position is not already used
-        elif pos in self._positions_provided:
-            raise Exception(
-                f"{field.name} can't have provided position, {pos} is already used"
-            )
-        self._positions_provided.append(pos)
+        else:
+            if not isinstance(pos, int):
+                raise Exception(f"position should be an integer, but {pos} given")
+            # checking if the position is not already used
+            if pos in self._positions_provided:
+                raise Exception(
+                    f"{field.name} can't have provided position, {pos} is already used"
+                )
+            else:
+                self._positions_provided.append(pos)
+
+            if pos >= 0:
+                pos = pos + 1  # position 0 is for executable
+            else:  # pos < 0:
+                pos = pos - 1  # position -1 is for args
+
         value = self._field_value(
             field=field, state_ind=state_ind, ind=ind, check_file=True
         )

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -158,11 +158,42 @@ def test_shell_cmd_inputs_2_err():
     )
 
     shelly = ShellCommandTask(
-        executable="executable", inpA="inp1", inpB="inp1", input_spec=my_input_spec
+        executable="executable", inpA="inp1", inpB="inp2", input_spec=my_input_spec
     )
     with pytest.raises(Exception) as e:
         shelly.cmdline
     assert "1 is already used" in str(e.value)
+
+
+def test_shell_cmd_inputs_2_noerr():
+    """ additional inputs with provided positions
+    (duplication of teh position doesn't lead to error, since only one field has value)
+    """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpA", "argstr": ""},
+                ),
+            ),
+            (
+                "inpB",
+                attr.ib(
+                    type=str,
+                    metadata={"position": 1, "help_string": "inpB", "argstr": ""},
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA="inp1", input_spec=my_input_spec
+    )
+    shelly.cmdline
 
 
 def test_shell_cmd_inputs_3():


### PR DESCRIPTION

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
changing to nipype-like syntax:
- removing exception for position 0
- checking for possible duplication in the position only for fields that have provided values (so it's possible to have  two fields with the same position if the user provides a value only to one of them)

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
