### PR TITLE
RF: Simplify positioning

### DIFF
--- a/docs/input_spec.rst
+++ b/docs/input_spec.rst
@@ -129,8 +129,8 @@ In the example we used multiple keys in the metadata dictionary including `help_
    If no `argstr` is used the field is not part of the command.
 
 `position` (`int`):
-   Position of the field in the command, could be positive or negative integer.
-   If nothing is provided the field will be inserted between all fields with positive positions
+   Position of the field in the command, could be nonnegative or negative integer.
+   If nothing is provided the field will be inserted between all fields with nonnegative positions
    and fields with negative positions.
 
 `allowed_values` (`list`):

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -839,6 +839,7 @@ def position_sort(args):
     list of objects
     """
     import bisect
+
     pos, none, neg = [], [], []
     for entry in args:
         position = entry[0]

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -427,10 +427,7 @@ class ShellCommandTask(TaskBase):
             # assuming that input that has no arstr is not used in the command
             return None
         pos = field.metadata.get("position", None)
-        if pos is None:
-            # position will be set at the end
-            pass
-        else:
+        if pos is not None:
             if not isinstance(pos, int):
                 raise Exception(f"position should be an integer, but {pos} given")
             # checking if the position is not already used
@@ -438,13 +435,12 @@ class ShellCommandTask(TaskBase):
                 raise Exception(
                     f"{field.name} can't have provided position, {pos} is already used"
                 )
-            else:
-                self._positions_provided.append(pos)
 
-            if pos >= 0:
-                pos = pos + 1  # position 0 is for executable
-            else:  # pos < 0:
-                pos = pos - 1  # position -1 is for args
+            self._positions_provided.append(pos)
+
+            # Shift non-negatives up to allow executable to be 0
+            # Shift negatives down to allow args to be -1
+            pos += 1 if pos >= 0 else -1
 
         value = self._field_value(
             field=field, state_ind=state_ind, ind=ind, check_file=True

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -61,7 +61,7 @@ from .specs import (
 from .helpers import (
     ensure_list,
     execute,
-    position_adjustment,
+    position_sort,
     argstr_formatting,
     output_from_inputfields,
 )
@@ -367,9 +367,11 @@ class ShellCommandTask(TaskBase):
                 if pos_val:
                     pos_args.append(pos_val)
 
-        # sorted elements of the command
-        cmd_args = position_adjustment(pos_args)
-        return cmd_args
+        # Sort command and arguments by position
+        cmd_args = position_sort(pos_args)
+        # pos_args values are each a list of arguments, so concatenate lists after sorting
+        return sum(cmd_args, [])
+
 
     def _field_value(self, field, state_ind, ind, check_file=False):
         """

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -372,7 +372,6 @@ class ShellCommandTask(TaskBase):
         # pos_args values are each a list of arguments, so concatenate lists after sorting
         return sum(cmd_args, [])
 
-
     def _field_value(self, field, state_ind, ind, check_file=False):
         """
         Checking value of the specific field, if value is not set, None is returned.

--- a/pydra/engine/tests/test_helpers.py
+++ b/pydra/engine/tests/test_helpers.py
@@ -14,7 +14,7 @@ from ..helpers import (
     get_available_cpus,
     save,
     load_and_run,
-    position_adjustment,
+    position_sort,
 )
 from .. import helpers_file
 from ..specs import File, Directory
@@ -303,6 +303,6 @@ def test_load_and_run_wf(tmpdir):
         [(None, "b"), (1, "a"), (None, "c")],
     ],
 )
-def test_position_adjustment(pos_args):
-    final_args = position_adjustment(pos_args)
+def test_position_sort(pos_args):
+    final_args = position_sort(pos_args)
     assert final_args == ["a", "b", "c"]


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactor

## Summary
Started looking through #421 but didn't have time to comment before merge. As I tried to understand what was going on, felt moved to simplify some things.

The `position_adjustment` function worked but was not obviously correct from a quick read, so I rewrote to be very explicit. I've checked and it's slightly faster than the old if `None` is present, slightly slower if not (~2% runtime change in either direction). Also, sorting in-place is not generally expected of a sorting function, so `position_sort` does not modify the input. One change to functionality is that `position_sort` does not concatenate the lists of inputs, so it now works for arbitrary objects, not just lists of objects, and we concatenate at the end.


## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [x] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
