### PR TITLE
CI: Squash gh-pages history on each push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ docs_deploy: &docs
     - run:
         name: Install gh-pages tool
         command: |
-          npm install -g --silent gh-pages@2.0.1
+          npm install -g --silent gh-pages@3.1.0
     - checkout
     - run:
         name: Set git settings
@@ -30,7 +30,7 @@ docs_deploy: &docs
         command: touch docs/_build/html/.nojekyll
     - run:
         name: Deploy docs to gh-pages branch
-        command: gh-pages --dotfiles --message "doc(update) [skip ci]" --dist docs/_build/html
+        command: gh-pages --no-history --dotfiles --message "doc(update) [skip ci]" --dist docs/_build/html
 
 version: 2
 jobs:


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance

## Summary

Use the `--no-history` option to keep `gh-pages` from accumulating.

This can only be tested by merging...

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
