### PR TITLE
CI: Install libssl1.1 (update for Ubuntu 20.04)

### DIFF
--- a/.github/workflows/testsingularity.yml
+++ b/.github/workflows/testsingularity.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install OS deps
         run: |
           sudo apt-get update
-          sudo apt-get install flawfinder squashfs-tools uuid-dev libuuid1 libffi-dev libssl-dev libssl1.0.0 \
+          sudo apt-get install flawfinder squashfs-tools uuid-dev libuuid1 libffi-dev libssl-dev libssl1.1 \
           libarchive-dev libgpgme11-dev libseccomp-dev wget gcc make pkg-config -y
       - name: Build
         run: |


### PR DESCRIPTION
This fixes the build, but breaks the tests.

```
Task exception was never retrieved
future: <Task finished coro=<ConcurrentFuturesWorker.exec_as_coro() done, defined at /home/runner/work/pydra/pydra/pydra/engine/workers.py:160> exception=RuntimeError("\x1b[34mINFO:   \x1b[0m Convert SIF file to sandbox...\n\x1b[31mFATAL:  \x1b[0m while extracting /home/runner/.singularity/cache/library/sha256.a90d0e27b1933bf806698b8494960bc4f8e71aee9f412f4e802b6d600139f08a/alpine_latest.sif: root filesystem extraction failed: extract command failed: \nwrite_xattr: could not write xattr security.selinux for file /tmp/rootfs-286443402/.exec because you're not superuser!\n\nwrite_xattr: to avoid this error message, either specify -user-xattrs, -no-xattrs, or run as superuser!\n\nFurther error messages of this type are suppressed!\nParallel unsquashfs: Using 2 processors\n413 inodes (438 blocks) to write\n\n\n\ncreated 78 files\ncreated 89 directories\ncreated 334 symlinks\ncreated 0 devices\ncreated 0 fifos\n: exit status 1\n")>
concurrent.futures.process._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.10/x64/lib/python3.7/concurrent/futures/process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/home/runner/work/pydra/pydra/pydra/engine/core.py", line 464, in _run
    self._run_task()
  File "/home/runner/work/pydra/pydra/pydra/engine/task.py", line 505, in _run_task
    raise RuntimeError(self.output_["stderr"])
RuntimeError: INFO:    Convert SIF file to sandbox...
FATAL:   while extracting /home/runner/.singularity/cache/library/sha256.a90d0e27b1933bf806698b8494960bc4f8e71aee9f412f4e802b6d600139f08a/alpine_latest.sif: root filesystem extraction failed: extract command failed: 
write_xattr: could not write xattr security.selinux for file /tmp/rootfs-286443402/.exec because you're not superuser!

write_xattr: to avoid this error message, either specify -user-xattrs, -no-xattrs, or run as superuser!

Further error messages of this type are suppressed!
Parallel unsquashfs: Using 2 processors
413 inodes (438 blocks) to write
```