### PR TITLE
fix/templates with float formatting, multiple fields

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -866,6 +866,8 @@ def argstr_formatting(argstr, inputs, value_updates=None):
         inputs_dict.update(value_updates)
     # getting all fields that should be formatted, i.e. {field_name}, ...
     inp_fields = re.findall("{\w+}", argstr)
+    inp_fields_float = re.findall("{\w+:[0-9.]+f}", argstr)
+    inp_fields += [re.sub(":[0-9.]+f", "", el) for el in inp_fields_float]
     val_dict = {}
     for fld in inp_fields:
         fld_name = fld[1:-1]  # extracting the name form {field_name}

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -12,6 +12,14 @@ def attr_fields(spec, exclude_names=()):
     return [field for field in spec.__attrs_attrs__ if field.name not in exclude_names]
 
 
+def attr_fields_dict(spec, exclude_names=()):
+    return {
+        field.name: field
+        for field in spec.__attrs_attrs__
+        if field.name not in exclude_names
+    }
+
+
 class File:
     """An :obj:`os.pathlike` object, designating a file."""
 
@@ -532,9 +540,8 @@ class ShellOutSpec:
         # if the field is set in input_spec with output_file_template,
         # than the field already should have value
         elif "output_file_template" in fld.metadata:
-            inputs_templ = attr.asdict(inputs)
             value = template_update_single(
-                fld, inputs_templ, output_dir=output_dir, spec_type="output"
+                fld, inputs=inputs, output_dir=output_dir, spec_type="output"
             )
             if fld.type is MultiOutputFile and type(value) is list:
                 return [Path(val) for val in value]

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -1056,6 +1056,48 @@ def test_shell_cmd_inputspec_7b(plugin, results_function, tmpdir):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+def test_shell_cmd_inputspec_7c(plugin, results_function, tmpdir):
+    """
+        providing output name using input_spec,
+        using name_tamplate with txt extension (extension from args should be removed
+    """
+    cmd = "touch"
+    args = "newfile_tmp.txt"
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "out1",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "output_file_template": "{args}.txt",
+                        "help_string": "output file",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="shelly",
+        executable=cmd,
+        args=args,
+        input_spec=my_input_spec,
+        cache_dir=tmpdir,
+    )
+
+    res = results_function(shelly, plugin)
+    assert res.output.stdout == ""
+    assert res.output.out1.exists()
+    # checking if the file is created in a good place
+    assert shelly.output_dir == res.output.out1.parent
+    assert res.output.out1.name == "newfile_tmp.txt"
+
+
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
 def test_shell_cmd_inputspec_8(plugin, results_function, tmpdir):
     """
         providing new file and output name using input_spec,


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->

- [x] allowing for float formatting in `argstr` and `output_file_template` 
- [x] changing template_formatting so it allows for multiple input fields in the templates
- [ ] fixing templates for tasks with splitters - > will be moved to another PR


## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
