### PR TITLE
fix: hashing function for numpy objects tostring/tobytes was not…

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -695,7 +695,10 @@ def hash_value(value, tp=None, metadata=None, precalculated=None):
         ):
             return hash_dir(value, precalculated=precalculated)
         elif type(value).__module__ == "numpy":  # numpy objects
-            return sha256(value.tostring()).hexdigest()
+            return [
+                hash_value(el, tp, metadata, precalculated)
+                for el in ensure_list(value.tolist())
+            ]
         else:
             return value
 


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
`tostring`/ `tobytes` was not  working properly for arrays with `dtype=object` -- after `pk.loads(pk.dumps(array))` was giving a different output, so hash was changing.
Moving to `tolist` and creating hash values for all elements

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
