### PR TITLE
Adding a container dimension concept to task.split

### DIFF
--- a/pydra/engine/helpers_state.py
+++ b/pydra/engine/helpers_state.py
@@ -747,15 +747,25 @@ def combine_final_groups(combiner, groups, groups_stack, keys):
                     "first".format(comb, groups_stack[-1])
                 )
     groups_final = {inp: gr for (inp, gr) in groups.items() if inp not in combiner_all}
-    gr_final = list(set(groups_final.values()))
+    gr_final = set()
+    for el in groups_final.values():
+        gr_final.update(ensure_list(el))
+    gr_final = list(gr_final)
     map_gr_nr = {nr: i for (i, nr) in enumerate(sorted(gr_final))}
-    groups_final = {inp: map_gr_nr[gr] for (inp, gr) in groups_final.items()}
+    groups_final_map = {}
+    for (inp, gr) in groups_final.items():
+        if isinstance(gr, int):
+            groups_final_map[inp] = map_gr_nr[gr]
+        elif isinstance(gr, list):
+            groups_final_map[inp] = [map_gr_nr[el] for el in gr]
+        else:
+            raise Exception("gr should be an int or a list, something wrong")
     for i, groups_l in enumerate(groups_stack_final):
         groups_stack_final[i] = [map_gr_nr[gr] for gr in groups_l]
 
     keys_final = [key for key in keys if key not in combiner_all]
     # TODO: not sure if I have to calculate and return keys, groups, groups_stack
-    return keys_final, groups_final, groups_stack_final, combiner_all
+    return keys_final, groups_final_map, groups_stack_final, combiner_all
 
 
 def map_splits(split_iter, inputs, cont_dim=None):

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -104,7 +104,7 @@ class Submitter:
         """
         futures = set()
         if runnable.state:
-            runnable.state.prepare_states(runnable.inputs)
+            runnable.state.prepare_states(runnable.inputs, cont_dim=runnable.cont_dim)
             runnable.state.prepare_inputs()
             logger.debug(
                 f"Expanding {runnable} into {len(runnable.state.states_val)} states"

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -14,6 +14,7 @@ from .utils import (
     fun_dict,
     fun_file,
     fun_file_list,
+    op_4var,
 )
 
 from ..core import TaskBase
@@ -1067,6 +1068,22 @@ def test_task_state_6a(plugin, tmpdir):
     assert nn.output_dir
     for odir in nn.output_dir:
         assert odir.exists()
+
+
+def test_task_state_7(tmpdir):
+    task_4var = op_4var(
+        name="op_4var",
+        a="a1",
+        b=[["b1", "b2"], ["b3", "b4"]],
+        c=["c1", "c2"],
+        d=["d1", "d2"],
+        cache_dir=tmpdir,
+    )
+    task_4var.split(("b", ["c", "d"]), cont_dim={"b": 2})
+    task_4var()
+    res = task_4var.result()
+    assert len(res) == 4
+    assert res[3].output.out == "a1 b4 c2 d2"
 
 
 @pytest.mark.flaky(reruns=2)  # when dask

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -1070,22 +1070,6 @@ def test_task_state_6a(plugin, tmpdir):
         assert odir.exists()
 
 
-def test_task_state_7(tmpdir):
-    task_4var = op_4var(
-        name="op_4var",
-        a="a1",
-        b=[["b1", "b2"], ["b3", "b4"]],
-        c=["c1", "c2"],
-        d=["d1", "d2"],
-        cache_dir=tmpdir,
-    )
-    task_4var.split(("b", ["c", "d"]), cont_dim={"b": 2})
-    task_4var()
-    res = task_4var.result()
-    assert len(res) == 4
-    assert res[3].output.out == "a1 b4 c2 d2"
-
-
 @pytest.mark.flaky(reruns=2)  # when dask
 def test_task_state_comb_1(plugin_dask_opt, tmpdir):
     """ task with the simplest splitter and combiner"""
@@ -1375,6 +1359,77 @@ def test_task_state_comb_order():
     results_ba = nn_ba()
     combined_results_ba = [res.output.out for res in results_ba]
     assert combined_results_ba == [13, 15, 23, 25]
+
+
+# Testing with container dimensions for the input
+
+
+def test_task_state_contdim_1(tmpdir):
+    """ task with a spliter and container dimension for one of the value"""
+    task_4var = op_4var(
+        name="op_4var",
+        a="a1",
+        b=[["b1", "b2"], ["b3", "b4"]],
+        c=["c1", "c2"],
+        d=["d1", "d2"],
+        cache_dir=tmpdir,
+    )
+    task_4var.split(("b", ["c", "d"]), cont_dim={"b": 2})
+    task_4var()
+    res = task_4var.result()
+    assert len(res) == 4
+    assert res[3].output.out == "a1 b4 c2 d2"
+
+
+def test_task_state_contdim_2(tmpdir):
+    """ task with a splitter and container dimension for one of the value"""
+    task_4var = op_4var(
+        name="op_4var",
+        a=["a1", "a2"],
+        b=[["b1", "b2"], ["b3", "b4"]],
+        c=["c1", "c2"],
+        d=["d1", "d2"],
+        cache_dir=tmpdir,
+    )
+    task_4var.split(["a", ("b", ["c", "d"])], cont_dim={"b": 2})
+    task_4var()
+    res = task_4var.result()
+    assert len(res) == 8
+    assert res[7].output.out == "a2 b4 c2 d2"
+
+
+def test_task_state_comb_contdim_1(tmpdir):
+    """ task with a splitter-combiner, and container dimension for one of the value"""
+    task_4var = op_4var(
+        name="op_4var",
+        a="a1",
+        b=[["b1", "b2"], ["b3", "b4"]],
+        c=["c1", "c2"],
+        d=["d1", "d2"],
+        cache_dir=tmpdir,
+    )
+    task_4var.split(("b", ["c", "d"]), cont_dim={"b": 2}).combine("b")
+    task_4var()
+    res = task_4var.result()
+    assert len(res) == 4
+    assert res[3].output.out == "a1 b4 c2 d2"
+
+
+def test_task_state_comb_contdim_2(tmpdir):
+    """ task with a splitter-combiner, and container dimension for one of the value"""
+    task_4var = op_4var(
+        name="op_4var",
+        a=["a1", "a2"],
+        b=[["b1", "b2"], ["b3", "b4"]],
+        c=["c1", "c2"],
+        d=["d1", "d2"],
+        cache_dir=tmpdir,
+    )
+    task_4var.split(["a", ("b", ["c", "d"])], cont_dim={"b": 2}).combine("a")
+    task_4var()
+    res = task_4var.result()
+    assert len(res) == 4
+    assert res[3][1].output.out == "a2 b4 c2 d2"
 
 
 # Testing caching for tasks with states

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -45,6 +45,11 @@ else:
 
 
 @mark.task
+def op_4var(a, b, c, d):
+    return f"{a} {b} {c} {d}"
+
+
+@mark.task
 def fun_addtwo(a):
     import time
 


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
fixes #456 

Adding `cont_dim` to the `split` method to allow user to set a specific "container dimension` for the input. This concept was present in the `State`, but forgot to add to the `Task`. 
If input name not in the `cont_dim` it is assumed that only the most outer dimension is used for splitter, e.g. for `B=[[b1, b2], [b3, b4]]` the splitter would give `[b1, b2]` and `[b3, b4]`, but if we indicate that the container dimension is two, i.e., `cont_dim={"B": 2}` than I would treat it as a 2d input and can create a scalar splitter with another (2,2) input. 

**edit**
fixing `combine_final_groups` to fix #459 459

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [x] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
