### PR TITLE
SoftFileLock asyncio workaround (#444)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -60,6 +60,11 @@
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
     }
+    {
+      "affiliation": "FCBG, EPFL",
+      "name": "Wigger, Jeffrey",
+      "orcid": "0000-0003-0978-4326"
+    }
   ],
   "keywords": [
     "neuroimaging",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -59,7 +59,7 @@
       "affiliation": "MIT, HMS",
       "name": "Ghosh, Satrajit",
       "orcid": "0000-0002-5312-6729"
-    }
+    },
     {
       "affiliation": "FCBG, EPFL",
       "name": "Wigger, Jeffrey",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -56,14 +56,14 @@
       "orcid": "0000-0001-7814-3501"
     },
     {
-      "affiliation": "MIT, HMS",
-      "name": "Ghosh, Satrajit",
-      "orcid": "0000-0002-5312-6729"
-    },
-    {
       "affiliation": "FCBG, EPFL",
       "name": "Wigger, Jeffrey",
       "orcid": "0000-0003-0978-4326"
+    },
+    {
+      "affiliation": "MIT, HMS",
+      "name": "Ghosh, Satrajit",
+      "orcid": "0000-0002-5312-6729"
     }
   ],
   "keywords": [

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from uuid import uuid4
 
 import cloudpickle as cp
-from filelock import SoftFileLock, Timeout
+from filelock import SoftFileLock
 import asyncio
 import shutil
 from tempfile import mkdtemp
@@ -37,6 +37,7 @@ from .helpers import (
     ensure_list,
     record_error,
     hash_function,
+    PydraFileLock,
 )
 from .helpers_file import copyfile_input, template_update
 from .graph import DiGraph
@@ -1008,51 +1009,42 @@ class Workflow(TaskBase):
             self.create_connections(task)
         lockfile = self.cache_dir / (checksum + ".lock")
         self.hooks.pre_run(self)
-        lock = SoftFileLock(lockfile)
-        acquired_lock = False
-        while not acquired_lock:
+        async with PydraFileLock(lockfile):
+            # retrieve cached results
+            if not (rerun or self.task_rerun):
+                result = self.result()
+                if result is not None:
+                    return result
+            # adding info file with the checksum in case the task was cancelled
+            # and the lockfile has to be removed
+            with open(self.cache_dir / f"{self.uid}_info.json", "w") as jsonfile:
+                json.dump({"checksum": checksum}, jsonfile)
+            odir = self.output_dir
+            if not self.can_resume and odir.exists():
+                shutil.rmtree(odir)
+            cwd = os.getcwd()
+            odir.mkdir(parents=False, exist_ok=True if self.can_resume else False)
+            self.audit.start_audit(odir=odir)
+            result = Result(output=None, runtime=None, errored=False)
+            self.hooks.pre_run_task(self)
             try:
-                lock.acquire(timeout=0)
-                acquired_lock = True
-            except Timeout:
-                await asyncio.sleep(1)
-
-        # retrieve cached results
-        if not (rerun or self.task_rerun):
-            result = self.result()
-            if result is not None:
-                return result
-        # adding info file with the checksum in case the task was cancelled
-        # and the lockfile has to be removed
-        with open(self.cache_dir / f"{self.uid}_info.json", "w") as jsonfile:
-            json.dump({"checksum": checksum}, jsonfile)
-        odir = self.output_dir
-        if not self.can_resume and odir.exists():
-            shutil.rmtree(odir)
-        cwd = os.getcwd()
-        odir.mkdir(parents=False, exist_ok=True if self.can_resume else False)
-        self.audit.start_audit(odir=odir)
-        result = Result(output=None, runtime=None, errored=False)
-        self.hooks.pre_run_task(self)
-        try:
-            self.audit.monitor()
-            await self._run_task(submitter, rerun=rerun)
-            result.output = self._collect_outputs()
-        except Exception as e:
-            etype, eval, etr = sys.exc_info()
-            traceback = format_exception(etype, eval, etr)
-            record_error(self.output_dir, error=traceback)
-            result.errored = True
-            self._errored = True
-            raise
-        finally:
-            self.hooks.post_run_task(self, result)
-            self.audit.finalize_audit(result=result)
-            save(odir, result=result, task=self)
-            # removing the additional file with the chcksum
-            (self.cache_dir / f"{self.uid}_info.json").unlink()
-            os.chdir(cwd)
-        lock.release()
+                self.audit.monitor()
+                await self._run_task(submitter, rerun=rerun)
+                result.output = self._collect_outputs()
+            except Exception as e:
+                etype, eval, etr = sys.exc_info()
+                traceback = format_exception(etype, eval, etr)
+                record_error(self.output_dir, error=traceback)
+                result.errored = True
+                self._errored = True
+                raise
+            finally:
+                self.hooks.post_run_task(self, result)
+                self.audit.finalize_audit(result=result)
+                save(odir, result=result, task=self)
+                # removing the additional file with the chcksum
+                (self.cache_dir / f"{self.uid}_info.json").unlink()
+                os.chdir(cwd)
         self.hooks.post_run(self, result)
         if result is None:
             raise Exception("This should never happen, please open new issue")

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -11,7 +11,6 @@ from uuid import uuid4
 
 import cloudpickle as cp
 from filelock import SoftFileLock
-import asyncio
 import shutil
 from tempfile import mkdtemp
 from traceback import format_exception

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -900,6 +900,7 @@ class PydraFileLock:
 
     def __init__(self, lockfile):
         self.lockfile = lockfile
+        self.timeout = 0.1
 
     async def __aenter__(self):
         lock = SoftFileLock(self.lockfile)
@@ -909,7 +910,9 @@ class PydraFileLock:
                 lock.acquire(timeout=0)
                 acquired_lock = True
             except Timeout:
-                await asyncio.sleep(1)
+                await asyncio.sleep(self.timeout)
+                if self.timeout <= 2:
+                    self.timeout = self.timeout * 2
         self.lock = lock
         return self
 

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -4,7 +4,7 @@ import asyncio.subprocess as asp
 import attr
 import cloudpickle as cp
 from pathlib import Path
-from filelock import SoftFileLock
+from filelock import SoftFileLock, Timeout
 import os
 import sys
 from hashlib import sha256
@@ -893,3 +893,26 @@ def argstr_formatting(argstr, inputs, value_updates=None):
         .strip()
     )
     return argstr_formatted
+
+
+class PydraFileLock:
+    """Wrapper for filelock's SoftFileLock that makes it work with asyncio."""
+
+    def __init__(self, lockfile):
+        self.lockfile = lockfile
+
+    async def __aenter__(self):
+        lock = SoftFileLock(self.lockfile)
+        acquired_lock = False
+        while not acquired_lock:
+            try:
+                lock.acquire(timeout=0)
+                acquired_lock = True
+            except Timeout:
+                await asyncio.sleep(1)
+        self.lock = lock
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self.lock.release()
+        return None

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -4564,6 +4564,7 @@ def test_graph_5(tmpdir):
         exporting_graphs(wf=wf, name=name)
 
 
+@pytest.mark.timeout(20)
 def test_duplicate_input_on_split_wf(tmpdir):
     """ checking if the workflow gets stuck if it has to run two tasks with equal checksum;
         This can occur when splitting on a list containing duplicate values.
@@ -4589,6 +4590,7 @@ def test_duplicate_input_on_split_wf(tmpdir):
     assert res[0].output.out1 == "test" and res[1].output.out1 == "test"
 
 
+@pytest.mark.timeout(40)
 def test_inner_outer_wf_duplicate(tmpdir):
     """ checking if the execution gets stuck if there is an inner and outer workflows
         thar run two nodes with the exact same inputs.

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -4589,7 +4589,7 @@ def test_duplicate_input_on_split_wf(tmpdir):
     assert res[0].output.out1 == "test" and res[1].output.out1 == "test"
 
 
-def test_inner_outer_wf_duplicate():
+def test_inner_outer_wf_duplicate(tmpdir):
     """ checking if the execution gets stuck if there is an inner and outer workflows
         thar run two nodes with the exact same inputs.
     """

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -27,6 +27,7 @@ from .utils import (
 )
 from ..submitter import Submitter
 from ..core import Workflow
+from ... import mark
 
 
 def test_wf_name_conflict1():
@@ -4561,3 +4562,77 @@ def test_graph_5(tmpdir):
     if DOT_FLAG:
         name = f"graph_{sys._getframe().f_code.co_name}"
         exporting_graphs(wf=wf, name=name)
+
+
+def test_duplicate_input_on_split_wf(tmpdir):
+    """ checking if the workflow gets stuck if it has to run two tasks with equal checksum;
+        This can occur when splitting on a list containing duplicate values.
+    """
+    text = ["test"] * 2
+
+    @mark.task
+    def printer(a):
+        return a
+
+    wf = Workflow(name="wf", input_spec=["text"], cache_dir=tmpdir)
+    wf.split(("text"), text=text)
+
+    wf.add(printer(name="printer1", a=wf.lzin.text))
+
+    wf.set_output([("out1", wf.printer1.lzout.out)])
+
+    with Submitter(plugin="cf", n_procs=6) as sub:
+        sub(wf)
+
+    res = wf.result()
+
+    assert res[0].output.out1 == "test" and res[1].output.out1 == "test"
+
+
+def test_inner_outer_wf_duplicate():
+    """ checking if the execution gets stuck if there is an inner and outer workflows
+        thar run two nodes with the exact same inputs.
+    """
+    task_list = ["First", "Second"]
+    start_list = [3]
+
+    @mark.task
+    def one_arg(start_number):
+        for k in range(10):
+            start_number += 1
+        return start_number
+
+    @mark.task
+    def one_arg_inner(start_number):
+        for k in range(10):
+            start_number += 1
+        return start_number
+
+    # Outer workflow
+    test_outer = Workflow(
+        name="test_outer", input_spec=["start_number", "task_name"], cache_dir=tmpdir
+    )
+    # Splitting on both arguments
+    test_outer.split(
+        ["start_number", "task_name"], start_number=start_list, task_name=task_list
+    )
+
+    # Inner Workflow
+    test_inner = Workflow(name="test_inner", input_spec=["start_number1"])
+    test_inner.add(
+        one_arg_inner(name="Ilevel1", start_number=test_inner.lzin.start_number1)
+    )
+    test_inner.set_output([("res", test_inner.Ilevel1.lzout.out)])
+
+    # Outer workflow has two nodes plus the inner workflow
+    test_outer.add(one_arg(name="level1", start_number=test_outer.lzin.start_number))
+    test_outer.add(test_inner)
+    test_inner.inputs.start_number1 = test_outer.level1.lzout.out
+
+    test_outer.set_output([("res2", test_outer.test_inner.lzout.res)])
+
+    with Submitter(plugin="cf") as sub:
+        sub(test_outer)
+
+    res = test_outer.result()
+    assert res[0].output.res2 == 23 and res[1].output.res2 == 23

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ test_requires =
     pytest-env
     pytest-xdist < 2.0
     pytest-rerunfailures
+    pytest-timeout
     codecov
     numpy
     psutil
@@ -68,6 +69,7 @@ test =
     pytest-env
     pytest-xdist < 2.0
     pytest-rerunfailures
+    pytest-timeout
     codecov
     numpy
     pyld


### PR DESCRIPTION
## Acknowledgment
- [X] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
The SoftFileLock does not work with asyncio. This implements the workaround suggested at [#78](https://github.com/benediktschmitt/py-filelock/issues/78).

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
