### PR TITLE
[fix] formatting cmdline for shelltask

### DIFF
--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -433,7 +433,7 @@ class ShellCommandTask(TaskBase):
                         argstr_f = argstr_formatting(
                             argstr, self.inputs, value_updates={field.name: val}
                         )
-                        argstr_formatted_l.append(argstr_f)
+                        argstr_formatted_l.append(f" {argstr_f}")
                     cmd_el_str = sep.join(argstr_formatted_l)
                 else:  # argstr has a simple form, e.g. "-f", or "--f"
                     cmd_el_str = sep.join([f" {argstr} {val}" for val in value])
@@ -445,7 +445,8 @@ class ShellCommandTask(TaskBase):
                     value = cmd_el_str
                 # if argstr has a more complex form, with "{input_field}"
                 if "{" in argstr and "}" in argstr:
-                    cmd_el_str = argstr_formatting(argstr, self.inputs)
+                    cmd_el_str = argstr.replace(f"{{{field.name}}}", str(value))
+                    cmd_el_str = argstr_formatting(cmd_el_str, self.inputs)
                 else:  # argstr has a simple form, e.g. "-f", or "--f"
                     if value:
                         cmd_el_str = f"{argstr} {value}"

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -441,7 +441,35 @@ def test_shell_cmd_inputs_list_sep_2():
     assert shelly.cmdline == "executable -v aaa,bbb,ccc"
 
 
-def test_shell_cmd_inputs_sep_3():
+def test_shell_cmd_inputs_list_sep_2a():
+    """providing list as an additional input:, sep, and argstr with f-string"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "sep": ",",
+                        "argstr": "-v {inpA}",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["aaa", "bbb", "ccc"], input_spec=my_input_spec
+    )
+    # a flag is used once
+    assert shelly.cmdline == "executable -v aaa,bbb,ccc"
+
+
+def test_shell_cmd_inputs_list_sep_3():
     """providing list as an additional input:, sep, argstr with ..."""
     my_input_spec = SpecInfo(
         name="Input",
@@ -455,6 +483,34 @@ def test_shell_cmd_inputs_sep_3():
                         "help_string": "inpA",
                         "sep": ",",
                         "argstr": "-v...",
+                    },
+                ),
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        executable="executable", inpA=["aaa", "bbb", "ccc"], input_spec=my_input_spec
+    )
+    # a flag is repeated
+    assert shelly.cmdline == "executable -v aaa, -v bbb, -v ccc"
+
+
+def test_shell_cmd_inputs_list_sep_3a():
+    """providing list as an additional input:, sep, argstr with ... and f-string"""
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "sep": ",",
+                        "argstr": "-v {inpA}...",
                     },
                 ),
             )


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
the formatting didn't work well for inputs with `sep` field and  `argstr` containing f-string, tests added


## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
