### PR TITLE
[ENH] Changes to BoshTask

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -596,8 +596,15 @@ def template_update_single(field, inputs, output_dir=None, spec_type="input"):
         return attr.NOTHING
     else:  # inputs_dict[field.name] is True or spec_type is output
         value = _template_formatting(field, inputs)
-        # changing path so it is in the output_dir
-        if output_dir and value is not attr.NOTHING:
+        # changing path so it is in the output_dir, but only if absolute_path is not set
+        if (
+            output_dir
+            and value is not attr.NOTHING
+            and (
+                "absolute_path" not in field.metadata
+                or not field.metadata["absolute_path"]
+            )
+        ):
             # should be converted to str, it is also used for input fields that should be str
             if type(value) is list:
                 return [str(output_dir / Path(val).name) for val in value]

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -399,6 +399,7 @@ class ShellSpec(BaseSpec):
             "keep_extension",
             "xor",
             "sep",
+            "absolute_path",
         }
         for fld in attr_fields(self, exclude_names=("_func", "_graph_checksums")):
             mdata = fld.metadata
@@ -495,7 +496,9 @@ class ShellOutSpec:
                 output_names.append(fld.name)
             elif (
                 fld.metadata
-                and self._field_metadata(fld, inputs, output_dir, outputs=None, check_existance = False)
+                and self._field_metadata(
+                    fld, inputs, output_dir, outputs=None, check_existance=False
+                )
                 != attr.NOTHING
             ):
                 output_names.append(fld.name)
@@ -529,7 +532,9 @@ class ShellOutSpec:
             else:
                 raise AttributeError(f"no file matches {default.name}")
 
-    def _field_metadata(self, fld, inputs, output_dir, outputs=None, check_existance = True):
+    def _field_metadata(
+        self, fld, inputs, output_dir, outputs=None, check_existance=True
+    ):
         """Collect output file if metadata specified."""
         if self._check_requires(fld, inputs) is False:
             return attr.NOTHING
@@ -543,17 +548,27 @@ class ShellOutSpec:
             value = template_update_single(
                 fld, inputs=inputs, output_dir=output_dir, spec_type="output"
             )
+
             if fld.type is MultiOutputFile and type(value) is list:
-                # TODO: how to handle list outputs that do not exist
-                return [Path(val) for val in value]
+                # TODO: how to deal with mandatory list outputs
+                ret = []
+                for val in value:
+                    val = Path(val)
+                    if check_existance and not val.exists():
+                        ret.append(attr.NOTHING)
+                    else:
+                        ret.append(val)
+                return ret
             else:
                 val = Path(value)
                 # checking if the file exists
                 if check_existance and not val.exists():
                     # if mandatory raise exception
-                    if 'mandatory' in fld.metadata:
-                        if fld.metadata['mandatory']:
-                            raise Exception(f"mandatory output for variable {fld.name} does not exit")
+                    if "mandatory" in fld.metadata:
+                        if fld.metadata["mandatory"]:
+                            raise Exception(
+                                f"mandatory output for variable {fld.name} does not exit"
+                            )
                     return attr.NOTHING
                 return val
         elif "callable" in fld.metadata:

--- a/pydra/engine/tests/aux_files/boutiques_specs_test_1.json
+++ b/pydra/engine/tests/aux_files/boutiques_specs_test_1.json
@@ -1,0 +1,31 @@
+{
+    "name": "Test-1",
+    "description": "A testing file",
+    "tool-version": "v0.1.0",
+    "schema-version": "0.5",
+    "command-line": "touch [FILE]",
+    "container-image": {
+        "image": "ubuntu:latest",
+        "type": "docker"
+    },
+    "inputs": [
+        {
+            "id": "file",
+            "name": "file",
+            "description": "A file to be created.",
+            "optional": false,
+            "type": "String",
+            "default-value": "outy.txt",
+            "value-key": "[FILE]"
+        }
+    ],
+    "output-files": [
+        {
+            "path-template": "[FILE]",
+            "description": "Created File",
+            "optional": false,
+            "id": "created_file",
+            "name": "created-file"
+        }
+    ]
+}

--- a/pydra/engine/tests/aux_files/boutiques_specs_test_1_absolute.json
+++ b/pydra/engine/tests/aux_files/boutiques_specs_test_1_absolute.json
@@ -1,0 +1,31 @@
+{
+    "name": "Test-1",
+    "description": "A testing file",
+    "tool-version": "v0.1.0",
+    "schema-version": "0.5",
+    "command-line": "touch [FILE]",
+    "container-image": {
+        "image": "ubuntu:latest",
+        "type": "docker"
+    },
+    "inputs": [
+        {
+            "id": "file",
+            "name": "file",
+            "description": "A file to be created.",
+            "optional": false,
+            "type": "String",
+            "value-key": "[FILE]"
+        }
+    ],
+    "output-files": [
+        {
+            "path-template": "[FILE]",
+            "description": "Created File",
+            "optional": false,
+            "id": "created_file",
+            "name": "created-file",
+            "uses-absolute-path": true
+        }
+    ]
+}

--- a/pydra/engine/tests/aux_files/boutiques_specs_test_1_extension.json
+++ b/pydra/engine/tests/aux_files/boutiques_specs_test_1_extension.json
@@ -1,0 +1,41 @@
+{
+    "name": "Test-1",
+    "description": "A testing file",
+    "tool-version": "v0.1.0",
+    "schema-version": "0.5",
+    "command-line": "touch [FILE] [FILEH]",
+    "container-image": {
+        "image": "ubuntu:latest",
+        "type": "docker"
+    },
+    "inputs": [
+        {
+            "id": "file",
+            "name": "file",
+            "description": "A file to be created.",
+            "optional": false,
+            "type": "String",
+            "default-value": "outy.tt.txt.gz.nii.txt",
+            "value-key": "[FILE]"
+        },
+        {
+            "id": "file_hidden",
+            "name": "file_hidden",
+            "description": "A file to be created.",
+            "optional": false,
+            "type": "String",
+            "default-value": "outy.tt",
+            "value-key": "[FILEH]"
+        }
+    ],
+    "output-files": [
+        {
+            "path-template": "[FILE]",
+            "description": "Created File",
+            "optional": true,
+            "id": "created_file",
+            "name": "created-file",
+            "path-template-stripped-extensions": [".nii", ".gz", ".txt"]
+        }
+    ]
+}

--- a/pydra/engine/tests/aux_files/boutiques_specs_test_2.json
+++ b/pydra/engine/tests/aux_files/boutiques_specs_test_2.json
@@ -1,0 +1,23 @@
+{
+    "name": "Test-1",
+    "description": "A testing file",
+    "tool-version": "v0.1.0",
+    "schema-version": "0.5",
+    "command-line": "echo [FILE]",
+    "container-image": {
+        "image": "ubuntu:latest",
+        "type": "docker"
+    },
+    "inputs": [
+        {
+            "id": "file",
+            "name": "file",
+            "description": "A file to be created.",
+            "optional": true,
+            "type": "String",
+            "value-key": "[FILE]",
+            "command-line-flag": "-f",
+            "command-line-flag-separator": "tt"
+        }
+    ]
+}

--- a/pydra/engine/tests/aux_files/boutiques_specs_test_int.json
+++ b/pydra/engine/tests/aux_files/boutiques_specs_test_int.json
@@ -1,0 +1,22 @@
+{
+    "name": "Test-1",
+    "description": "A testing file",
+    "tool-version": "v0.1.0",
+    "schema-version": "0.5",
+    "command-line": "echo [NUM]",
+    "container-image": {
+        "image": "ubuntu:latest",
+        "type": "docker"
+    },
+    "inputs": [
+        {
+            "id": "num",
+            "name": "num",
+            "description": "A num to be echoed.",
+            "optional": true,
+            "type": "Number",
+            "integer": true,
+            "value-key": "[NUM]"
+        }
+    ]
+}

--- a/pydra/engine/tests/test_boutiques.py
+++ b/pydra/engine/tests/test_boutiques.py
@@ -1,6 +1,7 @@
 import os, shutil
 import subprocess as sp
 from pathlib import Path
+import attr
 import pytest
 
 from ..core import Workflow
@@ -36,12 +37,11 @@ def test_boutiques_1(maskfile, plugin, results_function, tmpdir):
 
     assert res.output.return_code == 0
 
-    # checking if the outfile exists and if it has proper name
+    # checking if the outfile exists and if it has a proper name
     assert res.output.outfile.name == "test_brain.nii.gz"
     assert res.output.outfile.exists()
-    # other files should also have proper names, but they do not exist
-    assert res.output.out_outskin_off.name == "test_brain_outskin_mesh.off"
-    assert not res.output.out_outskin_off.exists()
+    # files that do not exist were set to NOTHING
+    assert res.output.out_outskin_off == attr.NOTHING
 
 
 @no_win

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -3018,7 +3018,7 @@ def test_shell_cmd_outputspec_7d(tmpdir, plugin, results_function):
     """
     customised output_spec, adding Directory to the output named by input spec
     """
-
+    # For /tmp/some_dict/test this function returns "/test"
     def get_lowest_directory(directory_path):
         return str(directory_path).replace(str(Path(directory_path).parents[0]), "")
 

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -3052,6 +3052,7 @@ def test_shell_cmd_outputspec_7d(tmpdir, plugin, results_function):
                     metadata={
                         "output_file_template": "{resultsDir}",
                         "help_string": "output file",
+                        "absolute_path": True,
                     },
                 ),
             )

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1726,7 +1726,7 @@ def test_shell_cmd_inputs_template_11():
             attr.ib(
                 type=MultiInputFile,
                 metadata={
-                    "argstr": "--inputFiles ...",
+                    "argstr": "...",
                     "help_string": "The list of input image files to be segmented.",
                 },
             ),
@@ -1751,7 +1751,7 @@ def test_shell_cmd_inputs_template_11():
 
     task = ShellCommandTask(
         name="echoMultiple",
-        executable="echo",
+        executable="touch",
         input_spec=input_spec,
         output_spec=output_spec,
     )


### PR DESCRIPTION
Translating more boutiques specifications to Pydra specs. Checking if output files exist.
## Acknowledgment
- [X] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Adding support for some more bosh input specifications: support for default values, integer values, and mandatory inputs.
QoL: ```bosh_file``` input can now be a string, and ```zenodo_id``` can now also start with the "zenodo" prefix.

This pull request also changes how output files that do not exist are handled. Currently, the path to where the file is expected is returned regardless of the file existing. The change in this pull request will make it return ```attr.NOTHING``` if the file does not exist. If an output is marked as mandatory and the output file does not exist then an error will be raised. The motivation behind this change is that it is otherwise not immediately evident which files were created. For example, BET generates usually only a subset of the outputs, but the current behavior would show paths for all. 

The tests were updated to take this behaviour into account.
In the process I found that the [test](https://github.com/nipype/pydra/blob/f2106f62b5cd2273ef96a5aab69de94e413d9aed/pydra/engine/tests/test_shelltask.py#L3017) ```test_shell_cmd_outputspec_7d``` has an issue. It intends to test whether the directory named ```test``` has been created at ```resultsDir```. However, Pydra checks if the ```test``` directory was created in its current working directory, i.e., the cache directory. The test never failed because pydra returned the path to where it expected the directory to be and the test only checked if the name of the lowest directory matches.  The change of the pull request now has Pydra return ```attr.NOTHING```. I think this is a bug relating to how absolute paths in ```output_file_template``` are being interpreted. A possible solution could be to add a metadata key akin to boutiques' ```uses-absolute-path```.

Also, BoshTask already used mandatory outputs prior to this pull request. However, hey are not yet part of the [output specifications](https://pydra.readthedocs.io/en/latest/output_spec.html). Should it be added there?

## Checklist
<!--- Please, let us know if you need help-->
- [X] All tests passing
- [X] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [X] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
