### PR TITLE
[fix] fixing cmdline for shell tasks with templates and spliter

### DIFF
--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -325,6 +325,15 @@ class ShellCommandTask(TaskBase):
         index : int
             Index in flattened list of states
         """
+        if index is not None:
+            modified_inputs = template_update(
+                self.inputs, output_dir=self.output_dir[index]
+            )
+        else:
+            modified_inputs = template_update(self.inputs, output_dir=self.output_dir)
+        if modified_inputs is not None:
+            self.inputs = attr.evolve(self.inputs, **modified_inputs)
+
         pos_args = []  # list for (position, command arg)
         self._positions_provided = []
         for field in attr_fields(
@@ -468,9 +477,6 @@ class ShellCommandTask(TaskBase):
         # checking the inputs fields before returning the command line
         self.inputs.check_fields_input_spec()
         orig_inputs = attr.asdict(self.inputs)
-        modified_inputs = template_update(self.inputs, output_dir=self.output_dir)
-        if modified_inputs is not None:
-            self.inputs = attr.evolve(self.inputs, **modified_inputs)
         if isinstance(self, ContainerTask):
             if self.state:
                 cmdline = []

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1770,6 +1770,51 @@ def test_shell_cmd_inputs_template_11():
         assert out_file.name == "test1" or out_file.name == "test2"
 
 
+def test_shell_cmd_inputs_template_1_st():
+    """additional inputs, one uses output_file_template (and argstr)
+    testing cmdline when splitter defined
+    """
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "inpA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 1,
+                        "help_string": "inpA",
+                        "argstr": "",
+                        "mandatory": True,
+                    },
+                ),
+            ),
+            (
+                "outA",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "position": 2,
+                        "help_string": "outA",
+                        "argstr": "-o",
+                        "output_file_template": "{inpA}_out",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    shelly = ShellCommandTask(
+        name="f",
+        executable="executable",
+        input_spec=my_input_spec,
+        inpA=["inpA", "inpB"],
+    ).split("inpA")
+
+    assert shelly.cmdline
+
+
 # TODO: after deciding how we use requires/templates
 def test_shell_cmd_inputs_di(tmpdir, use_validator):
     """example from #279"""


### PR DESCRIPTION
## Acknowledgment
- [ ] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
- fixing cmdline for shell tasks with templates and spliter
- fixes #439 

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
