### PR TITLE
Rerun errored

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -438,7 +438,7 @@ class TaskBase:
         with SoftFileLock(lockfile):
             if not (rerun or self.task_rerun):
                 result = self.result()
-                if result is not None:
+                if result is not None and not result.errored:
                     return result
             # adding info file with the checksum in case the task was cancelled
             # and the lockfile has to be removed
@@ -1017,7 +1017,7 @@ class Workflow(TaskBase):
             # retrieve cached results
             if not (rerun or self.task_rerun):
                 result = self.result()
-                if result is not None:
+                if result is not None and not result.errored:
                     return result
             # adding info file with the checksum in case the task was cancelled
             # and the lockfile has to be removed

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -5,7 +5,6 @@ import pytest
 import cloudpickle as cp
 from pathlib import Path
 import re
-import logging
 
 from ... import mark
 from ..core import Workflow

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -1378,9 +1378,9 @@ def test_rerun_errored(tmpdir, capfd):
 
     task = pass_odds(name="pass_odds", x=[1, 2, 3, 4, 5], cache_dir=tmpdir).split("x")
 
-    with pytest.raises(Exception, match="even error") as exinfo:
+    with pytest.raises(Exception, match="even error"):
         task()
-    with pytest.raises(Exception, match="even error") as exinfo:
+    with pytest.raises(Exception, match="even error"):
         task()
 
     out, err = capfd.readouterr()
@@ -1395,8 +1395,7 @@ def test_rerun_errored(tmpdir, capfd):
         if "(error)" in line:
             errors_found += 1
 
-    # There should have been 5 messages of the form "x%2 = XXX" after calling task() the second time
-    # There should have been 2 messages of the form "x%2 = XXX" after calling task() the second time
+    # There should have been 5 messages of the form "x%2 = XXX" after calling task() the first time
+    # and another 2 messagers after calling the second time
     assert tasks_run == 7
-
     assert errors_found == 4

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -4707,9 +4707,9 @@ def test_rerun_errored(tmpdir, capfd):
     wf.add(pass_odds(name="pass_odds", x=[1, 2, 3, 4, 5]).split("x"))
     wf.set_output([("out", wf.pass_odds.lzout.out)])
 
-    with pytest.raises(Exception) as exinfo:
+    with pytest.raises(Exception):
         wf()
-    with pytest.raises(Exception) as exinfo:
+    with pytest.raises(Exception):
         wf()
 
     out, err = capfd.readouterr()
@@ -4724,8 +4724,7 @@ def test_rerun_errored(tmpdir, capfd):
         if "(error)" in line:
             errors_found += 1
 
-    # There should have been 5 messages of the form "x%2 = XXX" after calling task() the second time
-    # There should have been 2 messages of the form "x%2 = XXX" after calling task() the second time
+    # There should have been 5 messages of the form "x%2 = XXX" after calling task() the first time
+    # and another 2 messagers after calling the second time
     assert tasks_run == 7
-
     assert errors_found == 4

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -3,6 +3,7 @@ import shutil, os, sys
 import time
 import attr
 from pathlib import Path
+import logging
 
 from .utils import (
     add2,
@@ -4687,3 +4688,44 @@ def test_inner_outer_wf_duplicate(tmpdir):
 
     res = test_outer.result()
     assert res[0].output.res2 == 23 and res[1].output.res2 == 23
+
+
+def test_rerun_errored(tmpdir, capfd):
+    """Test rerunning a workflow containing errors.
+    Only the errored tasks and workflow should be rerun"""
+
+    @mark.task
+    def pass_odds(x):
+        if x % 2 == 0:
+            print(f"x%2 = {x % 2} (error)\n")
+            raise Exception("even error")
+        else:
+            print(f"x%2 = {x % 2}\n")
+            return x
+
+    wf = Workflow(name="wf", input_spec=["x"], cache_dir=tmpdir)
+    wf.add(pass_odds(name="pass_odds", x=[1, 2, 3, 4, 5]).split("x"))
+    wf.set_output([("out", wf.pass_odds.lzout.out)])
+
+    with pytest.raises(Exception) as exinfo:
+        wf()
+    with pytest.raises(Exception) as exinfo:
+        wf()
+
+    out, err = capfd.readouterr()
+    stdout_lines = out.splitlines()
+
+    tasks_run = 0
+    errors_found = 0
+
+    for line in stdout_lines:
+        if "x%2" in line:
+            tasks_run += 1
+        if "(error)" in line:
+            errors_found += 1
+
+    # There should have been 5 messages of the form "x%2 = XXX" after calling task() the second time
+    # There should have been 2 messages of the form "x%2 = XXX" after calling task() the second time
+    assert tasks_run == 7
+
+    assert errors_found == 4


### PR DESCRIPTION
## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
When a workflow or task errors and its result is stored in cache, rerunning the same workflow/task again should rerun all
errored tasks and workflows (as discussed with @satra  in #482 )

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
