### PR TITLE
reverting adding absolute_path

### DIFF
--- a/docs/output_spec.rst
+++ b/docs/output_spec.rst
@@ -72,10 +72,6 @@ The metadata dictionary for `output_spec` can include:
    If provided the field is added to the output spec with changed name.
    The same as in `input_spec`.
 
-`absolute_path` (`bool` default: `False`):
-   A flag that specifies if the `output_file_template` is an absolute path. If the flag is not set,
-   then the `output_file_template` is searched in the nodes output directory.
-
 `keep_extension` (`bool`, default: `True`):
    A flag that specifies if the file extension should be removed from the field value.
    The same as in `input_spec`.

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -610,22 +610,15 @@ def template_update_single(
         return attr.NOTHING
     else:  # inputs_dict[field.name] is True or spec_type is output
         value = _template_formatting(field, inputs, inputs_dict_st)
-        # changing path so it is in the output_dir, but only if absolute_path is not set
-        if (
-            output_dir
-            and value is not attr.NOTHING
-            and (
-                "absolute_path" not in field.metadata
-                or not field.metadata["absolute_path"]
-            )
-        ):
+        # changing path so it is in the output_dir
+        if output_dir and value is not attr.NOTHING:
             # should be converted to str, it is also used for input fields that should be str
             if type(value) is list:
                 return [str(output_dir / Path(val).name) for val in value]
             else:
                 return str(output_dir / Path(value).name)
         else:
-            return value
+            return attr.NOTHING
 
 
 def _template_formatting(field, inputs, inputs_dict_st):

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -400,7 +400,6 @@ class ShellSpec(BaseSpec):
             "keep_extension",
             "xor",
             "sep",
-            "absolute_path",
             "formatter",
         }
         for fld in attr_fields(self, exclude_names=("_func", "_graph_checksums")):
@@ -557,11 +556,6 @@ class ShellOutSpec:
                     val = Path(val)
                     if check_existance and not val.exists():
                         ret.append(attr.NOTHING)
-                    elif check_existance and (
-                        fld.metadata.get("absolute_path", False)
-                        and not val.is_absolute()
-                    ):
-                        ret.append(attr.NOTHING)
                     else:
                         ret.append(val)
                 return ret
@@ -575,10 +569,6 @@ class ShellOutSpec:
                             raise Exception(
                                 f"mandatory output for variable {fld.name} does not exit"
                             )
-                    return attr.NOTHING
-                if check_existance and (
-                    fld.metadata.get("absolute_path", False) and not val.is_absolute()
-                ):
                     return attr.NOTHING
                 return val
         elif "callable" in fld.metadata:


### PR DESCRIPTION
## Acknowledgment
- [X] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Discussed reversion of the addition of ```absolute_path```. Also as discussed, support for outputs with absolute paths will be readded later (Not in this PR) without the need to explicitly set the ```absolute_path``` option.
This reversion broke the test ```test_shell_cmd_outputspec_8d```. I rewrote it such that it does not need an absolute path in the outputs. 

## Checklist
<!--- Please, let us know if you need help-->
- [x] All tests passing
- [ ] I have added tests to cover my changes
- [X] I have updated documentation (if necessary)
- [X] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
