### PR TITLE
[FIX] Gracefully handle empty `input_spec` arg passed to Workflow init

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -795,27 +795,30 @@ class Workflow(TaskBase):
             TODO
 
         """
-        if input_spec:
-            if isinstance(input_spec, BaseSpec):
-                self.input_spec = input_spec
-            else:
-                self.input_spec = SpecInfo(
-                    name="Inputs",
-                    fields=[("_graph_checksums", ty.Any)]
-                    + [
-                        (
-                            nm,
-                            attr.ib(
-                                type=ty.Any,
-                                metadata={
-                                    "help_string": f"{nm} input from {name} workflow"
-                                },
-                            ),
-                        )
-                        for nm in input_spec
-                    ],
-                    bases=(BaseSpec,),
-                )
+        if not input_spec:
+            raise Exception("No input_spec provided to Workflow")
+
+        if isinstance(input_spec, BaseSpec):
+            self.input_spec = input_spec
+        else:
+            self.input_spec = SpecInfo(
+                name="Inputs",
+                fields=[("_graph_checksums", ty.Any)]
+                + [
+                    (
+                        nm,
+                        attr.ib(
+                            type=ty.Any,
+                            metadata={
+                                "help_string": f"{nm} input from {name} workflow"
+                            },
+                        ),
+                    )
+                    for nm in input_spec
+                ],
+                bases=(BaseSpec,),
+            )
+
         self.output_spec = output_spec
 
         if name in dir(self):

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -795,29 +795,29 @@ class Workflow(TaskBase):
             TODO
 
         """
-        if not input_spec:
-            raise Exception("No input_spec provided to Workflow")
-
-        if isinstance(input_spec, BaseSpec):
-            self.input_spec = input_spec
+        if input_spec:
+            if isinstance(input_spec, BaseSpec):
+                self.input_spec = input_spec
+            else:
+                self.input_spec = SpecInfo(
+                    name="Inputs",
+                    fields=[("_graph_checksums", ty.Any)]
+                    + [
+                        (
+                            nm,
+                            attr.ib(
+                                type=ty.Any,
+                                metadata={
+                                    "help_string": f"{nm} input from {name} workflow"
+                                },
+                            ),
+                        )
+                        for nm in input_spec
+                    ],
+                    bases=(BaseSpec,),
+                )
         else:
-            self.input_spec = SpecInfo(
-                name="Inputs",
-                fields=[("_graph_checksums", ty.Any)]
-                + [
-                    (
-                        nm,
-                        attr.ib(
-                            type=ty.Any,
-                            metadata={
-                                "help_string": f"{nm} input from {name} workflow"
-                            },
-                        ),
-                    )
-                    for nm in input_spec
-                ],
-                bases=(BaseSpec,),
-            )
+            raise ValueError("Empty input_spec provided to Workflow")
 
         self.output_spec = output_spec
 

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -32,6 +32,11 @@ from ..core import Workflow
 from ... import mark
 
 
+def test_wf_no_input_spec():
+    with pytest.raises(ValueError):
+        Workflow(name="workflow")
+
+
 def test_wf_name_conflict1():
     """raise error when workflow name conflicts with a class attribute or method"""
     with pytest.raises(ValueError) as excinfo1:

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -33,7 +33,7 @@ from ... import mark
 
 
 def test_wf_no_input_spec():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Empty input_spec"):
         Workflow(name="workflow")
 
 


### PR DESCRIPTION
This PR handles the case where an empty `input_spec` is provided to a Workflow init by raising a ValueError. Otherwise, the init enters an infinite recursion loop attempting to access the input spec.

## Acknowledgment
- [ x ] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Handles the case when an empty input_spec is provided to Workflow init by raising an exception

## Checklist
<!--- Please, let us know if you need help-->
- [ x ] All tests passing
- [ x  ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ x ] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
