### PR TITLE
added filename to FileNotFoundError messages

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -203,14 +203,14 @@ class BaseSpec:
                     file = Path(el)
                     if not file.exists() and field.type in [File, Directory]:
                         raise FileNotFoundError(
-                            f"the file from the {field.name} input does not exist"
+                            f"the file {file} from the {field.name} input does not exist"
                         )
         else:
             file = Path(getattr(self, field.name))
             # error should be raised only if the type is strictly File or Directory
             if not file.exists() and field.type in [File, Directory]:
                 raise FileNotFoundError(
-                    f"the file from the {field.name} input does not exist"
+                    f"the file {file} from the {field.name} input does not exist"
                 )
 
     def check_metadata(self):
@@ -711,7 +711,7 @@ class ContainerSpec(ShellSpec):
         # error should be raised only if the type is strictly File or Directory
         elif field.type in [File, Directory]:
             raise FileNotFoundError(
-                f"the file from {field.name} input does not exist, "
+                f"the file {file} from {field.name} input does not exist, "
                 f"if the file comes from the container, "
                 f"use field.metadata['container_path']=True"
             )


### PR DESCRIPTION
added `Path` object `file` to error message, such that the error message also reports, which file was not found.

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
Whenever an input that is of type `File` or `Directory` is not found, a FileNotFoundError is raised. Previously, this error message included only information about the field name. This change adds the filename to the error message so a user can easily identify which file was not found. This simplifies the debugging process.


## Checklist
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [x] My code follows the code style of this project
(we are using `black`: you can `pip install pre-commit`,
run `pre-commit install` in the `pydra` directory
and `black` will be run automatically with each commit)
