### PR TITLE
use cache_dir instead of output_dir

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -1189,7 +1189,7 @@ class Workflow(TaskBase):
                     )
         return attr.evolve(output, **output_wf)
 
-    def create_dotfile(self, type="simple", export=None, name=None, output_dir = None):
+    def create_dotfile(self, type="simple", export=None, name=None, output_dir=None):
         """creating a graph - dotfile and optionally exporting to other formats"""
         outdir = output_dir if output_dir is not None else self.cache_dir
         if not name:
@@ -1197,15 +1197,11 @@ class Workflow(TaskBase):
         if type == "simple":
             for task in self.graph.nodes:
                 self.create_connections(task)
-            dotfile = self.graph.create_dotfile_simple(
-                outdir=outdir, name=name
-            )
+            dotfile = self.graph.create_dotfile_simple(outdir=outdir, name=name)
         elif type == "nested":
             for task in self.graph.nodes:
                 self.create_connections(task)
-            dotfile = self.graph.create_dotfile_nested(
-                outdir=outdir, name=name
-            )
+            dotfile = self.graph.create_dotfile_nested(outdir=outdir, name=name)
         elif type == "detailed":
             # create connections with detailed=True
             for task in self.graph.nodes:
@@ -1213,9 +1209,7 @@ class Workflow(TaskBase):
             # adding wf outputs
             for (wf_out, lf) in self._connections:
                 self.graph.add_edges_description((self.name, wf_out, lf.name, lf.field))
-            dotfile = self.graph.create_dotfile_detailed(
-                outdir=outdir, name=name
-            )
+            dotfile = self.graph.create_dotfile_detailed(outdir=outdir, name=name)
         else:
             raise Exception(
                 f"type of the graph can be simple, detailed or nested, "

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -1189,21 +1189,22 @@ class Workflow(TaskBase):
                     )
         return attr.evolve(output, **output_wf)
 
-    def create_dotfile(self, type="simple", export=None, name=None):
+    def create_dotfile(self, type="simple", export=None, name=None, output_dir = None):
         """creating a graph - dotfile and optionally exporting to other formats"""
+        outdir = output_dir if output_dir is not None else self.cache_dir
         if not name:
             name = f"graph_{self.name}"
         if type == "simple":
             for task in self.graph.nodes:
                 self.create_connections(task)
             dotfile = self.graph.create_dotfile_simple(
-                outdir=self.output_dir, name=name
+                outdir=outdir, name=name
             )
         elif type == "nested":
             for task in self.graph.nodes:
                 self.create_connections(task)
             dotfile = self.graph.create_dotfile_nested(
-                outdir=self.output_dir, name=name
+                outdir=outdir, name=name
             )
         elif type == "detailed":
             # create connections with detailed=True
@@ -1213,7 +1214,7 @@ class Workflow(TaskBase):
             for (wf_out, lf) in self._connections:
                 self.graph.add_edges_description((self.name, wf_out, lf.name, lf.field))
             dotfile = self.graph.create_dotfile_detailed(
-                outdir=self.output_dir, name=name
+                outdir=outdir, name=name
             )
         else:
             raise Exception(


### PR DESCRIPTION
## Types of changes
- Bug fix (non-breaking change which fixes an issue), fixing Issue #442 

## Summary
Add the option of specifying the output directory for the dotfile (the graph of a workflow) and when it is not specified, use `cache_dir` instead of `output_dir` (because when there is splitting the `output_dir` attribute is a list of paths instead of a path).

## Checklist
I have not added tests or updated documentation (there is no much original documentation on this method that I could find)