### PR TITLE
disabling etelemetry for testing

### DIFF
--- a/pydra/conftest.py
+++ b/pydra/conftest.py
@@ -1,4 +1,7 @@
 import shutil
+import os
+
+os.environ["NO_ET"] = "true"
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION

## Summary
<!--- What does your code do? -->
 disabling etelemetry by setting `NO_ET` to true in `conftest.py`

etelemetry can sometimes (e.g. today) really slow down the tests

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
