### PR TITLE
Split command line using quote respecting shlex.split instead of ' '.split

### DIFF
--- a/pydra/conftest.py
+++ b/pydra/conftest.py
@@ -1,5 +1,6 @@
 import shutil
 import os
+import pytest
 
 os.environ["NO_ET"] = "true"
 
@@ -26,3 +27,30 @@ def pytest_generate_tests(metafunc):
         else:
             Plugins = ["cf"]
         metafunc.parametrize("plugin", Plugins)
+
+
+# For debugging in IDE's don't catch raised exceptions and let the IDE
+# break at it
+if os.getenv("_PYTEST_RAISE", "0") != "0":
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_exception_interact(call):
+        raise call.excinfo.value
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_internalerror(excinfo):
+        raise excinfo.value
+
+
+# Example VSCode launch configuration for debugging unittests
+# {
+#     "name": "Test Config",
+#     "type": "python",
+#     "request": "launch",
+#     "purpose": ["debug-test"],
+#     "justMyCode": false,
+#     "console": "internalConsole",
+#     "env": {
+#         "_PYTEST_RAISE": "1"
+#     },
+# }

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -489,6 +489,7 @@ class TaskBase:
         lockfile = self.cache_dir / (checksum + ".lock")
         # Eagerly retrieve cached - see scenarios in __init__()
         self.hooks.pre_run(self)
+        logger.debug(f"'%s' is attempting to acquire lock on %s", self.name, lockfile)
         with SoftFileLock(lockfile):
             if not (rerun or self.task_rerun):
                 result = self.result()
@@ -1063,6 +1064,11 @@ class Workflow(TaskBase):
         output_dir = self.output_dir
         lockfile = self.cache_dir / (checksum + ".lock")
         self.hooks.pre_run(self)
+        logger.debug(
+            f"'%s' is attempting to acquire lock on %s with Pydra lock",
+            self.name,
+            lockfile,
+        )
         async with PydraFileLock(lockfile):
             if not (rerun or self.task_rerun):
                 result = self.result()

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -484,10 +484,8 @@ class ShellCommandTask(TaskBase):
                         cmd_el_str = f"{argstr} {value}"
                     else:
                         cmd_el_str = ""
-            # removing double spacing
-            cmd_el_str = cmd_el_str.strip()
             if cmd_el_str:
-                cmd_add += cmd_el_str
+                cmd_add += shlex.split(cmd_el_str)
         return pos, cmd_add
 
     @property

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -853,7 +853,9 @@ def split_cmd(cmd: str):
     str
         the command line string split into process args
     """
-    args = shlex.split(cmd, posix=(platform.system() != "Windows"))
+    # Check whether running on posix or windows system
+    on_posix = platform.system() != "Windows"
+    args = shlex.split(cmd, posix=on_posix)
     cmd_args = []
     for arg in args:
         match = re.match("('|\")(.*)\\1$", arg)

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -527,7 +527,7 @@ class ShellCommandTask(TaskBase):
 
     def _join_cmd_args(self, args):
         """Safely joins command args quoting any containing spaces"""
-        # Skip the first position as this can be a multi-part command, e.g. 'docker run'
+        # Skip the executable, which can be a multi-part command, e.g. 'docker run'
         return " ".join([args[0]] + [f"'{p}'" if " " in p else p for p in args[1:]])
 
 

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -527,7 +527,9 @@ class ShellCommandTask(TaskBase):
 
     def _join_cmd_args(self, args):
         """Safely joins command args quoting any containing spaces"""
-        # Skip the executable, which can be a multi-part command, e.g. 'docker run'
+        # Skip the executable, which can be a multi-part command, e.g. 'docker run'.
+        # Not sure if this should be expanded to include special chars as well as
+        # spaces or not.
         return " ".join([args[0]] + [f"'{p}'" if " " in p else p for p in args[1:]])
 
 

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -522,7 +522,7 @@ class ShellCommandTask(TaskBase):
                 if self.output_["stderr"]:
                     msg += "\n\nstderr:\n" + self.output_["stderr"]
                 if self.output_["stdout"]:
-                    msg += "\n\nstderr:\n" + self.output_["stdout"]
+                    msg += "\n\nstdout:\n" + self.output_["stdout"]
                 raise RuntimeError(msg)
 
     def _join_cmd_args(self, args):

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -38,6 +38,7 @@ Implement processing nodes.
       <https://colab.research.google.com/drive/1RRV1gHbGJs49qQB1q1d5tQEycVRtuhw6>`__
 
 """
+import platform
 import attr
 import cloudpickle as cp
 import inspect
@@ -68,6 +69,8 @@ from .helpers import (
     output_from_inputfields,
 )
 from .helpers_file import template_update, is_local_file
+
+running_on_posix = platform.system() != "Windows"
 
 
 class FunctionTask(TaskBase):
@@ -448,7 +451,7 @@ class ShellCommandTask(TaskBase):
             cmd_el_str = field.metadata["formatter"](**call_args_val)
             cmd_el_str = cmd_el_str.strip().replace("  ", " ")
             if cmd_el_str != "":
-                cmd_add += shlex.split(cmd_el_str)
+                cmd_add += shlex.split(cmd_el_str, posix=running_on_posix)
         elif field.type is bool:
             # if value is simply True the original argstr is used,
             # if False, nothing is added to the command
@@ -485,7 +488,7 @@ class ShellCommandTask(TaskBase):
                     else:
                         cmd_el_str = ""
             if cmd_el_str:
-                cmd_add += shlex.split(cmd_el_str)
+                cmd_add += shlex.split(cmd_el_str, posix=running_on_posix)
         return pos, cmd_add
 
     @property

--- a/pydra/engine/tests/test_nipype1_convert.py
+++ b/pydra/engine/tests/test_nipype1_convert.py
@@ -34,6 +34,23 @@ class Interf_2(ShellCommandTask):
     executable = "testing command"
 
 
+class Interf_3(ShellCommandTask):
+    """class with customized input and executables"""
+
+    input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "in_file",
+                str,
+                {"help_string": "in_file", "argstr": ""},
+            )
+        ],
+        bases=(ShellSpec,),
+    )
+    executable = "testing command"
+
+
 class TouchInterf(ShellCommandTask):
     """class with customized input and executables"""
 
@@ -94,6 +111,13 @@ def test_interface_executable_2():
         # task.executable stays the same, but input.executable is changed, so the cmd is changed
         assert task.inputs.executable == "i want a different command"
         assert task.cmdline == "i want a different command"
+
+
+def test_interface_cmdline_with_spaces():
+    task = Interf_3(in_file="/path/to/file/with spaces")
+    assert task.executable == "testing command"
+    assert task.inputs.executable == "testing command"
+    assert task.cmdline == "testing command '/path/to/file/with spaces'"
 
 
 def test_interface_run_1():

--- a/pydra/engine/tests/test_nipype1_convert.py
+++ b/pydra/engine/tests/test_nipype1_convert.py
@@ -43,7 +43,7 @@ class Interf_3(ShellCommandTask):
             (
                 "in_file",
                 str,
-                {"help_string": "in_file", "argstr": ""},
+                {"help_string": "in_file", "argstr": "'{in_file}'"},
             )
         ],
         bases=(ShellSpec,),

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -4805,7 +4805,7 @@ stderr:
 {path_str}: line 3: /command-that-doesnt-exist: No such file or directory
 
 
-stderr:
+stdout:
 first line is ok, it prints 'hello'
 """
     )

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -307,7 +307,7 @@ def test_shell_cmd_inputspec_1(plugin, results_function, use_validator, tmpdir):
     )
     assert shelly.inputs.executable == cmd_exec
     assert shelly.inputs.args == cmd_args
-    assert shelly.cmdline == "echo -n hello from pydra"
+    assert shelly.cmdline == "echo -n 'hello from pydra'"
 
     res = results_function(shelly, plugin)
     assert res.output.stdout == "hello from pydra"
@@ -356,7 +356,7 @@ def test_shell_cmd_inputspec_2(plugin, results_function, use_validator, tmpdir):
     )
     assert shelly.inputs.executable == cmd_exec
     assert shelly.inputs.args == cmd_args
-    assert shelly.cmdline == "echo -n HELLO from pydra"
+    assert shelly.cmdline == "echo -n HELLO 'from pydra'"
     res = results_function(shelly, plugin)
     assert res.output.stdout == "HELLO from pydra"
 

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -1124,7 +1124,7 @@ def test_docker_cmd(tmpdir):
         docky.cmdline
         == f"docker run --rm -v {docky.output_dir}:/output_pydra:rw -w /output_pydra busybox pwd"
     )
-    docky.inputs.container_xargs = ["--rm -it"]
+    docky.inputs.container_xargs = ["--rm", "-it"]
     assert (
         docky.cmdline
         == f"docker run --rm -it -v {docky.output_dir}:/output_pydra:rw -w /output_pydra busybox pwd"


### PR DESCRIPTION

## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
Fixes an issue when there are quotes in argument strings to enclose spaces and other special characters.

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
