### PR TITLE
allow more output types to use callables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ cov.xml
 .idea
 
 .DS_Store
-

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ cov.xml
 .idea
 
 .DS_Store
+
+requirement.txt

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ cov.xml
 
 .DS_Store
 
-requirement.txt

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -486,7 +486,7 @@ class ShellOutSpec:
         inputs.check_fields_input_spec()
         output_names = ["return_code", "stdout", "stderr"]
         for fld in attr_fields(self, exclude_names=("return_code", "stdout", "stderr")):
-            if fld.type is not File:
+            if fld.type not in [File, MultiOutputFile, Directory]:
                 raise Exception("not implemented (collect_additional_output)")
             # assuming that field should have either default or metadata, but not both
             if (

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -2769,7 +2769,7 @@ def test_shell_cmd_outputspec_5(plugin, results_function, tmpdir):
 
     my_output_spec = SpecInfo(
         name="Output",
-        fields=[("newfile", attr.ib(type=File, metadata={"callable": gather_output}))],
+        fields=[("newfile", attr.ib(type=MultiOutputFile, metadata={"callable": gather_output}))],
         bases=(ShellOutSpec,),
     )
     shelly = ShellCommandTask(
@@ -2781,6 +2781,12 @@ def test_shell_cmd_outputspec_5(plugin, results_function, tmpdir):
     # newfile is a list
     assert len(res.output.newfile) == 2
     assert all([file.exists for file in res.output.newfile])
+    assert (
+        shelly.output_names
+        == shelly.generated_output_names
+        == ["return_code", "stdout", "stderr", "newfile"]
+    ) 
+    
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
@@ -3106,6 +3112,7 @@ def test_shell_cmd_outputspec_8a(tmpdir, plugin, results_function):
     shelly = ShellCommandTask(
         name="shelly", executable=cmd, args=args, output_spec=my_output_spec
     ).split("args")
+    
 
     results = results_function(shelly, plugin)
     for index, res in enumerate(results):
@@ -3238,7 +3245,11 @@ def test_shell_cmd_outputspec_8d(tmpdir, plugin, results_function):
         cache_dir=tmpdir,
         resultsDir="test",  # Path(tmpdir) / "test" TODO: Not working without absolute path support
     )
-
+    assert (
+        shelly.output_names
+        == shelly.generated_output_names
+        == ["return_code", "stdout", "stderr", "resultsDir"]
+    ) 
     res = results_function(shelly, plugin)
     print("Cache_dirr:", shelly.cache_dir)
     assert (shelly.output_dir / Path("test")).exists() == True

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -2769,7 +2769,12 @@ def test_shell_cmd_outputspec_5(plugin, results_function, tmpdir):
 
     my_output_spec = SpecInfo(
         name="Output",
-        fields=[("newfile", attr.ib(type=MultiOutputFile, metadata={"callable": gather_output}))],
+        fields=[
+            (
+                "newfile",
+                attr.ib(type=MultiOutputFile, metadata={"callable": gather_output}),
+            )
+        ],
         bases=(ShellOutSpec,),
     )
     shelly = ShellCommandTask(
@@ -2785,8 +2790,7 @@ def test_shell_cmd_outputspec_5(plugin, results_function, tmpdir):
         shelly.output_names
         == shelly.generated_output_names
         == ["return_code", "stdout", "stderr", "newfile"]
-    ) 
-    
+    )
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
@@ -3112,7 +3116,6 @@ def test_shell_cmd_outputspec_8a(tmpdir, plugin, results_function):
     shelly = ShellCommandTask(
         name="shelly", executable=cmd, args=args, output_spec=my_output_spec
     ).split("args")
-    
 
     results = results_function(shelly, plugin)
     for index, res in enumerate(results):
@@ -3249,7 +3252,7 @@ def test_shell_cmd_outputspec_8d(tmpdir, plugin, results_function):
         shelly.output_names
         == shelly.generated_output_names
         == ["return_code", "stdout", "stderr", "resultsDir"]
-    ) 
+    )
     res = results_function(shelly, plugin)
     print("Cache_dirr:", shelly.cache_dir)
     assert (shelly.output_dir / Path("test")).exists() == True


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
<!--- What does your code do? -->
- allow `File`, `MultiOutputFile`, and `Directory` in outputs to use `callables`

## Checklist
<!--- Please, let us know if you need help-->
- [X] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
