### PR TITLE
changing template formatting when value (or default) is False

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -884,6 +884,14 @@ def argstr_formatting(argstr, inputs, value_updates=None):
         if fld_value is attr.NOTHING:
             # if value is NOTHING, nothing should be added to the command
             val_dict[fld_name] = ""
+            print("argst, ", fld_name, "NOT")
+        # if value is False, but the field has a template the output field should not be created
+        elif (
+            fld_value is False
+            and "output_file_template"
+            in [el for el in attr_fields(inputs) if el.name == fld_name][0].metadata
+        ):
+            val_dict[fld_name] = ""
         else:
             val_dict[fld_name] = fld_value
 

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -579,7 +579,6 @@ def template_update(inputs, output_dir, state_ind=None, map_copyfiles=None):
     Should be run when all inputs used in the templates are already set.
 
     """
-
     inputs_dict_st = attr.asdict(inputs, recurse=False)
     if map_copyfiles is not None:
         inputs_dict_st.update(map_copyfiles)
@@ -654,7 +653,7 @@ def template_update_single(
         return inputs_dict_st[field.name]
     elif spec_type == "input" and inputs_dict_st[field.name] is False:
         # if input fld is set to False, the fld shouldn't be used (setting NOTHING)
-        return attr.NOTHING
+        return False
     else:  # inputs_dict[field.name] is True or spec_type is output
         value = _template_formatting(field, inputs, inputs_dict_st)
         # changing path so it is in the output_dir

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1152,6 +1152,8 @@ def test_shell_cmd_inputs_template_6():
         executable="executable", input_spec=my_input_spec, inpA="inpA"
     )
     assert shelly.cmdline == f"executable inpA -o {str(shelly.output_dir / 'inpA_out')}"
+    # checking if the command is the same
+    assert shelly.cmdline == f"executable inpA -o {str(shelly.output_dir / 'inpA_out')}"
 
     # a string is provided for outA, so this should be used as the outA value
     shelly = ShellCommandTask(
@@ -1169,6 +1171,8 @@ def test_shell_cmd_inputs_template_6():
     shelly = ShellCommandTask(
         executable="executable", input_spec=my_input_spec, inpA="inpA", outA=False
     )
+    assert shelly.cmdline == "executable inpA"
+    # checking of the command is the same
     assert shelly.cmdline == "executable inpA"
 
 
@@ -1214,6 +1218,8 @@ def test_shell_cmd_inputs_template_6a():
         executable="executable", input_spec=my_input_spec, inpA="inpA"
     )
     assert shelly.cmdline == "executable inpA"
+    # checking if the command is the same
+    assert shelly.cmdline == "executable inpA"
 
     # a string is provided for outA, so this should be used as the outA value
     shelly = ShellCommandTask(
@@ -1231,6 +1237,8 @@ def test_shell_cmd_inputs_template_6a():
     shelly = ShellCommandTask(
         executable="executable", input_spec=my_input_spec, inpA="inpA", outA=False
     )
+    assert shelly.cmdline == "executable inpA"
+    # checking if the command is the same
     assert shelly.cmdline == "executable inpA"
 
 
@@ -2080,7 +2088,7 @@ def test_shell_cmd_inputs_di(tmpdir, use_validator):
         == f"DenoiseImage -i {tmpdir.join('a_file.ext')} -s 1 -p 1 -r 2 -o [{str(shelly.output_dir / 'a_file_out.ext')}]"
     )
 
-    # input file name, noiseImage is set to True, so template is used in the output
+    # # input file name, noiseImage is set to True, so template is used in the output
     shelly = ShellCommandTask(
         executable="DenoiseImage",
         inputImageFilename=my_input_file,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
<!--- What does your code do? -->

when output use template to create the output path and value is `False` the field should not be used in the cmdline, it was inconsistent


## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
