### PR TITLE
Add support for arbitrary mappings in a FunctionTask

### DIFF
--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -198,6 +198,8 @@ class FunctionTask(TaskBase):
             self.output_ = {output_names[0]: output}
         elif isinstance(output, tuple) and len(output_names) == len(output):
             self.output_ = dict(zip(output_names, output))
+        elif isinstance(output, dict):
+            self.output_ = {key: output.get(key, None) for key in output_names}
         else:
             raise RuntimeError(
                 f"expected {len(self.output_spec.fields)} elements, "

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -114,6 +114,27 @@ def test_annotated_func(use_validator):
     ]
 
 
+def test_annotated_func_dictreturn(use_validator):
+    """Test mapping from returned dictionary to output spec."""
+
+    @mark.task
+    @mark.annotate({"return": {"sum": int, "mul": int}})
+    def testfunc(a: int, b: int):
+        return dict(sum=a + b, diff=a - b)
+
+    task = testfunc(a=2, b=3)
+    result = task()
+
+    # Part of the annotation and returned, should be exposed to output.
+    assert result.output.sum == 5
+
+    # Part of the annotation but not returned, should be coalesced to None.
+    assert result.output.mul is None
+
+    # Not part of the annotation, should be discarded.
+    assert not hasattr(result.output, "diff")
+
+
 def test_annotated_func_multreturn(use_validator):
     """the function has two elements in the return statement"""
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- New feature (non-breaking change which adds functionality)

## Summary
<!--- What does your code do? -->
This PR adds support for returning total or partial mappings of the output spec by the wrapped function, as an alternative to going through a conversion from the returned tuple to a dictionary via `output_names`. Unlike the named tuple case where the shape of the data is known a priori (I have got exactly 2 output variables which I want named to `foo` and `bar`), this PR adds support for functions which may return more, less or exactly these data as an arbitrary mapping.

This could be particularly useful for dynamic task construction use cases, like BIDS readers, parsers and writers.

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
