### PR TITLE
Use inspect.getfullargspec instead of getargspec

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -572,7 +572,7 @@ class ShellOutSpec:
                     return attr.NOTHING
                 return val
         elif "callable" in fld.metadata:
-            call_args = inspect.getargspec(fld.metadata["callable"])
+            call_args = inspect.getfullargspec(fld.metadata["callable"])
             call_args_val = {}
             for argnm in call_args.args:
                 if argnm == "field":

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -431,7 +431,7 @@ class ShellCommandTask(TaskBase):
         # formatter that creates a custom command argument
         # it can thake the value of the filed, all inputs, or the value of other fields.
         if "formatter" in field.metadata:
-            call_args = inspect.getargspec(field.metadata["formatter"])
+            call_args = inspect.getfullargspec(field.metadata["formatter"])
             call_args_val = {}
             for argnm in call_args.args:
                 if argnm == "field":


### PR DESCRIPTION
The latter triggers deprecation warnings since Python 3.0. Using
`getfullargspec` instead which provides a compatible return type.