### PR TITLE
Fix bug in inputs checksum before/after task run when deeply modifying objects

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -454,7 +454,9 @@ class TaskBase:
 
     def _modify_inputs(self):
         """Update and preserve a Task's original inputs"""
-        orig_inputs = attr.asdict(self.inputs, recurse=False)
+        orig_inputs = {
+            k: deepcopy(v) for k, v in attr.asdict(self.inputs, recurse=False).items()
+        }
         map_copyfiles = copyfile_input(self.inputs, self.output_dir)
         modified_inputs = template_update(
             self.inputs, self.output_dir, map_copyfiles=map_copyfiles


### PR DESCRIPTION
## Types of changes
- Bug fix 

## Summary
Deep copy original inputs when saving to restore after task has been run, primarily so that checksum doesn't change after the task has been run (making the node undiscoverable by downstream nodes)

## Checklist
- [x] I have added tests to cover my changes (if necessary): **N/A**
- [x] I have updated documentation (if necessary): **N/A**
