### PR TITLE
[FIX] Enable `Workflow` constructor to receive `SpecInfo` objects for `input_spec` parameter

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -845,7 +845,9 @@ class Workflow(TaskBase):
                 self.input_spec = input_spec
             elif isinstance(input_spec, SpecInfo):
                 if not any([x == BaseSpec for x in input_spec.bases]):
-                    raise ValueError("Provided SpecInfo must have BaseSpec as it's base.")
+                    raise ValueError(
+                        "Provided SpecInfo must have BaseSpec as it's base."
+                    )
                 self.input_spec = input_spec
             else:
                 self.input_spec = SpecInfo(

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -843,6 +843,10 @@ class Workflow(TaskBase):
         if input_spec:
             if isinstance(input_spec, BaseSpec):
                 self.input_spec = input_spec
+            elif isinstance(input_spec, SpecInfo):
+                if not any([x == BaseSpec for x in input_spec.bases]):
+                    raise ValueError("Provided SpecInfo must have BaseSpec as it's base.")
+                self.input_spec = input_spec
             else:
                 self.input_spec = SpecInfo(
                     name="Inputs",

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -40,10 +40,10 @@ def test_wf_no_input_spec():
 
 def test_wf_specinfo_input_spec():
     input_spec = SpecInfo(
-        name='Input',
+        name="Input",
         fields=[
-            ('a', str, '',{'mandatory': True}),
-            ('b', dict, {"foo": 1, "bar": False}, {'mandatory': False}),
+            ("a", str, "", {"mandatory": True}),
+            ("b", dict, {"foo": 1, "bar": False}, {"mandatory": False}),
         ],
         bases=(BaseSpec,),
     )
@@ -51,20 +51,19 @@ def test_wf_specinfo_input_spec():
         name="workflow",
         input_spec=input_spec,
     )
-    for x in ['a', 'b']:
+    for x in ["a", "b"]:
         assert hasattr(wf.inputs, x)
-    assert wf.inputs.a == ''
+    assert wf.inputs.a == ""
     assert wf.inputs.b == {"foo": 1, "bar": False}
     bad_input_spec = SpecInfo(
-        name='Input',
+        name="Input",
         fields=[
-            ('a', str, {'mandatory': True}),
+            ("a", str, {"mandatory": True}),
         ],
-        bases=(ShellSpec,)
+        bases=(ShellSpec,),
     )
     with pytest.raises(
-        ValueError,
-        match="Provided SpecInfo must have BaseSpec as it's base."
+        ValueError, match="Provided SpecInfo must have BaseSpec as it's base."
     ):
         Workflow(name="workflow", input_spec=bad_input_spec)
 

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -30,11 +30,43 @@ from .utils import (
 from ..submitter import Submitter
 from ..core import Workflow
 from ... import mark
+from ..specs import SpecInfo, BaseSpec, ShellSpec
 
 
 def test_wf_no_input_spec():
     with pytest.raises(ValueError, match="Empty input_spec"):
         Workflow(name="workflow")
+
+
+def test_wf_specinfo_input_spec():
+    input_spec = SpecInfo(
+        name='Input',
+        fields=[
+            ('a', str, '',{'mandatory': True}),
+            ('b', dict, {"foo": 1, "bar": False}, {'mandatory': False}),
+        ],
+        bases=(BaseSpec,),
+    )
+    wf = Workflow(
+        name="workflow",
+        input_spec=input_spec,
+    )
+    for x in ['a', 'b']:
+        assert hasattr(wf.inputs, x)
+    assert wf.inputs.a == ''
+    assert wf.inputs.b == {"foo": 1, "bar": False}
+    bad_input_spec = SpecInfo(
+        name='Input',
+        fields=[
+            ('a', str, {'mandatory': True}),
+        ],
+        bases=(ShellSpec,)
+    )
+    with pytest.raises(
+        ValueError,
+        match="Provided SpecInfo must have BaseSpec as it's base."
+    ):
+        Workflow(name="workflow", input_spec=bad_input_spec)
 
 
 def test_wf_name_conflict1():


### PR DESCRIPTION
Fixes #572 

## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
<!--- What does your code do? -->
This PR adds the possibility to pass an instance of `SpecInfo` to the `Workflow` constructor as is already documented. Prior to this PR, passing such input was triggering a `TypeError` (see #572).

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
