### PR TITLE
FIX: If result.output is None, return None for all fields

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -269,6 +269,8 @@ class Result:
         field_name : `str`
             Name of field in LazyField object
         """
+        if self.output is None:
+            return None
         if field_name == "all_":
             return attr.asdict(self.output, recurse=False)
         else:


### PR DESCRIPTION
## Types of changes
- Bug fix

## Summary

`Result.output: ty.Optional[ty.Any] = None`, but we assume that it's here. In https://github.com/nipype/pydra-tutorial/runs/8254183236, it is possible for it to be `None` when this is called, so it seems like one sensible thing to do is return `None`.

That said, it's possible that there's a bigger problem and we should not be trying to retrieve fields without first checking that `result.output is not None`.

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
