### PR TITLE
[ENH] Add `_graph_checksums` to `input_spec` if missing

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -798,8 +798,8 @@ class TaskBase:
 
 
 def _sanitize_input_spec(
-        input_spec: ty.Union[BaseSpec, ty.List[str]],
-        wf_name: str,
+    input_spec: ty.Union[BaseSpec, ty.List[str]],
+    wf_name: str,
 ) -> BaseSpec:
     """Makes sure the provided input specifications are valid.
 
@@ -831,9 +831,7 @@ def _sanitize_input_spec(
             return input_spec
         elif isinstance(input_spec, SpecInfo):
             if not any([x == BaseSpec for x in input_spec.bases]):
-                raise ValueError(
-                    "Provided SpecInfo must have BaseSpec as it's base."
-                )
+                raise ValueError("Provided SpecInfo must have BaseSpec as it's base.")
             if "_graph_checksums" not in {f[0] for f in input_spec.fields}:
                 input_spec.fields.insert(0, graph_checksum_input)
             return input_spec

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -798,9 +798,9 @@ class TaskBase:
 
 
 def _sanitize_input_spec(
-    input_spec: ty.Union[BaseSpec, ty.List[str]],
+    input_spec: ty.Union[SpecInfo, ty.List[str]],
     wf_name: str,
-) -> BaseSpec:
+) -> SpecInfo:
     """Makes sure the provided input specifications are valid.
 
     If the input specification is a list of strings, this will
@@ -808,7 +808,7 @@ def _sanitize_input_spec(
 
     Parameters
     ----------
-    input_spec : BaseSpec or List[str]
+    input_spec : SpecInfo or List[str]
         Input specification to be sanitized.
 
     wf_name : str
@@ -817,7 +817,7 @@ def _sanitize_input_spec(
 
     Returns
     -------
-    input_spec : BaseSpec
+    input_spec : SpecInfo
         Sanitized input specifications.
 
     Raises
@@ -827,9 +827,7 @@ def _sanitize_input_spec(
     """
     graph_checksum_input = ("_graph_checksums", ty.Any)
     if input_spec:
-        if isinstance(input_spec, BaseSpec):
-            return input_spec
-        elif isinstance(input_spec, SpecInfo):
+        if isinstance(input_spec, SpecInfo):
             if not any([x == BaseSpec for x in input_spec.bases]):
                 raise ValueError("Provided SpecInfo must have BaseSpec as it's base.")
             if "_graph_checksums" not in {f[0] for f in input_spec.fields}:
@@ -866,7 +864,7 @@ class Workflow(TaskBase):
         audit_flags: AuditFlag = AuditFlag.NONE,
         cache_dir=None,
         cache_locations=None,
-        input_spec: ty.Optional[ty.Union[ty.List[ty.Text], SpecInfo, BaseSpec]] = None,
+        input_spec: ty.Optional[ty.Union[ty.List[ty.Text], SpecInfo]] = None,
         cont_dim=None,
         messenger_args=None,
         messengers=None,

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -51,7 +51,7 @@ def test_wf_specinfo_input_spec():
         name="workflow",
         input_spec=input_spec,
     )
-    for x in ["a", "b"]:
+    for x in ["a", "b", "_graph_checksums"]:
         assert hasattr(wf.inputs, x)
     assert wf.inputs.a == ""
     assert wf.inputs.b == {"foo": 1, "bar": False}


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- New feature (non-breaking change which adds functionality)

## Summary
<!--- What does your code do? -->

Following #573, this PR proposes to automatically add `_graph_checksums` to the `input_spec` provided to the workflow when these specifications are provided directly as a `SpecInfo` instance.
This is already done automatically when `input_spec` is provided as a list of strings.
This PR also proposes to put the input sanitization code in a separate helper function.

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
