### PR TITLE
Handling input fields checking for Mandatory and Mutually exclusive fields

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -162,10 +162,15 @@ class BaseSpec:
             mdata = fld.metadata
             # checking if the mandatory field is provided
             if getattr(self, fld.name) is attr.NOTHING:
-                if mdata.get("mandatory"):
-                    raise AttributeError(
-                        f"{fld.name} is mandatory, but no value provided"
-                    )
+                if mdata.get("mandatory"):    
+                    # checking if the mandatory field is provided elsewhere in the xor list
+                    alreday_populated = [getattr(self, el) for el in mdata["xor"] if (getattr(self, el) is not attr.NOTHING)]
+                    if alreday_populated: #another input satisfies mandatory attribute via xor condition
+                        continue
+                    else:
+                        raise AttributeError(
+                            f"{fld.name} is mandatory, but no value provided"
+                        )
                 else:
                     continue
             names.append(fld.name)

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -164,7 +164,8 @@ class BaseSpec:
             if getattr(self, fld.name) is attr.NOTHING:
                 if mdata.get("mandatory"):    
                     # checking if the mandatory field is provided elsewhere in the xor list
-                    alreday_populated = [getattr(self, el) for el in mdata["xor"] if (getattr(self, el) is not attr.NOTHING)]
+                    in_exclusion_list = mdata.get("xor") is not None
+                    alreday_populated = in_exclusion_list and [getattr(self, el) for el in mdata["xor"] if (getattr(self, el) is not attr.NOTHING)]
                     if alreday_populated: #another input satisfies mandatory attribute via xor condition
                         continue
                     else:

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -162,11 +162,17 @@ class BaseSpec:
             mdata = fld.metadata
             # checking if the mandatory field is provided
             if getattr(self, fld.name) is attr.NOTHING:
-                if mdata.get("mandatory"):    
+                if mdata.get("mandatory"):
                     # checking if the mandatory field is provided elsewhere in the xor list
                     in_exclusion_list = mdata.get("xor") is not None
-                    alreday_populated = in_exclusion_list and [getattr(self, el) for el in mdata["xor"] if (getattr(self, el) is not attr.NOTHING)]
-                    if alreday_populated: #another input satisfies mandatory attribute via xor condition
+                    alreday_populated = in_exclusion_list and [
+                        getattr(self, el)
+                        for el in mdata["xor"]
+                        if (getattr(self, el) is not attr.NOTHING)
+                    ]
+                    if (
+                        alreday_populated
+                    ):  # another input satisfies mandatory attribute via xor condition
                         continue
                     else:
                         raise AttributeError(

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -419,6 +419,7 @@ def test_task_inputs_mandatory_with_xOR_one_mandatory_is_OK():
     task.inputs.input_2 = attr.NOTHING
     task.inputs.check_fields_input_spec()
 
+
 def test_task_inputs_mandatory_with_xOR_one_mandatory_out_3_is_OK():
     """input spec with mandatory inputs"""
     task = SimpleTask()
@@ -426,6 +427,7 @@ def test_task_inputs_mandatory_with_xOR_one_mandatory_out_3_is_OK():
     task.inputs.input_2 = attr.NOTHING
     task.inputs.input_3 = True
     task.inputs.check_fields_input_spec()
+
 
 def test_task_inputs_mandatory_with_xOR_zero_mandatory_raises_error():
     """input spec with mandatory inputs"""
@@ -448,6 +450,7 @@ def test_task_inputs_mandatory_with_xOR_two_mandatories_raises_error():
         task.inputs.check_fields_input_spec()
     assert "input_2 is mutually exclusive with ('input_1', 'input_2'" in str(excinfo.value)
     assert excinfo.type is AttributeError
+
 
 def test_task_inputs_mandatory_with_xOR_3_mandatories_raises_error():
     """input spec with mandatory inputs"""

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -376,7 +376,7 @@ class SimpleTask(ShellCommandTask):
     input_fields=[
             (
                 "input_1",
-                bool,
+                str,
                 {
                     "help_string": "help",
                     "mandatory": True,
@@ -403,10 +403,10 @@ class SimpleTask(ShellCommandTask):
     executable = "cmd"
 
 
-def test_task_inputs_mandatory_with_xOR_one_mandatory_is_enough():
+def test_task_inputs_mandatory_with_xOR_one_mandatory_is_OK():
     """input spec with mandatory inputs"""
     task = SimpleTask()
-    task.inputs.input_1 = True
+    task.inputs.input_1 = 'Input1'
     task.inputs.input_2 = attr.NOTHING
     task.inputs.check_fields_input_spec()
 
@@ -421,7 +421,7 @@ def test_task_inputs_mandatory_with_xOR_zero_mandatory_raises_error():
 def test_task_inputs_mandatory_with_xOR_two_mandatories_raises_error():
     """input spec with mandatory inputs"""
     task = SimpleTask()
-    task.inputs.input_1 = True
+    task.inputs.input_1 = 'Input1'
     task.inputs.input_2 = True
     
     with pytest.raises(Exception) as excinfo:

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -380,7 +380,7 @@ class SimpleTask(ShellCommandTask):
                 {
                     "help_string": "help",
                     "mandatory": True,
-                    "xor": ("input_1", "input_2"),
+                    "xor": ("input_1", "input_2", "input_3"),
                 }
             ),
             (
@@ -390,9 +390,18 @@ class SimpleTask(ShellCommandTask):
                     "help_string": "help",
                     "mandatory": True,
                     "argstr": "--i2",
-                    "xor": ("input_1", "input_2"),
+                    "xor": ("input_1", "input_2", "input_3"),
                 }
-    )
+            ),
+            (
+                "input_3",
+                bool,
+                {
+                    "help_string": "help",
+                    "mandatory": True,
+                    "xor": ("input_1", "input_2", "input_3"),
+                }
+            )
     ]
     task_input_spec = SpecInfo(name="Input", fields=input_fields, bases=(ShellSpec,))
     task_output_fields = []
@@ -410,12 +419,23 @@ def test_task_inputs_mandatory_with_xOR_one_mandatory_is_OK():
     task.inputs.input_2 = attr.NOTHING
     task.inputs.check_fields_input_spec()
 
+def test_task_inputs_mandatory_with_xOR_one_mandatory_out_3_is_OK():
+    """input spec with mandatory inputs"""
+    task = SimpleTask()
+    task.inputs.input_1 = attr.NOTHING
+    task.inputs.input_2 = attr.NOTHING
+    task.inputs.input_3 = True
+    task.inputs.check_fields_input_spec()
+
 def test_task_inputs_mandatory_with_xOR_zero_mandatory_raises_error():
     """input spec with mandatory inputs"""
     task = SimpleTask()
     task.inputs.input_1 = attr.NOTHING
     task.inputs.input_2 = attr.NOTHING
-    task.inputs.check_fields_input_spec()
+    with pytest.raises(Exception) as excinfo:
+        task.inputs.check_fields_input_spec()
+    assert "input_1 is mandatory, but no value provided" in str(excinfo.value)
+    assert excinfo.type is AttributeError
 
 
 def test_task_inputs_mandatory_with_xOR_two_mandatories_raises_error():
@@ -426,5 +446,17 @@ def test_task_inputs_mandatory_with_xOR_two_mandatories_raises_error():
     
     with pytest.raises(Exception) as excinfo:
         task.inputs.check_fields_input_spec()
-    assert "input_2 is mutually exclusive with ('input_1', 'input_2')" in str(excinfo.value)
+    assert "input_2 is mutually exclusive with ('input_1', 'input_2'" in str(excinfo.value)
+    assert excinfo.type is AttributeError
+
+def test_task_inputs_mandatory_with_xOR_3_mandatories_raises_error():
+    """input spec with mandatory inputs"""
+    task = SimpleTask()
+    task.inputs.input_1 = 'Input1'
+    task.inputs.input_2 = True
+    task.inputs.input_3 = False
+    
+    with pytest.raises(Exception) as excinfo:
+        task.inputs.check_fields_input_spec()
+    assert "input_2 is mutually exclusive with ('input_1', 'input_2', 'input_3'" in str(excinfo.value)
     assert excinfo.type is AttributeError

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -374,7 +374,7 @@ def test_input_file_hash_5(tmpdir):
 
 
 
-def test_task_inputs_mandatory_with_xOR():
+def test_task_inputs_mandatory_with_xOR_TF():
     """input spec with mandatory inputs"""
     input_fields=[
             (
@@ -382,7 +382,7 @@ def test_task_inputs_mandatory_with_xOR():
                 bool,
                 {
                     "help_string": "help",
-                    "argstr": "--i1",
+                    "mandatory": True,
                     "xor": ("input_1", "input_2"),
                 }
             ),
@@ -404,10 +404,46 @@ def test_task_inputs_mandatory_with_xOR():
     class MyTask(ShellCommandTask):
         input_spec = task_input_spec
         output_spec = task_output_spec
-        executable = "task"
+        executable = "cmd"
+
+    task = MyTask()
+    task.inputs.input_1 = True
+    task.inputs.input_2 = attr.NOTHING
+    task.inputs.check_fields_input_spec()
+
+def test_task_inputs_mandatory_with_xOR_TT():
+    """input spec with mandatory inputs"""
+    input_fields=[
+            (
+                "input_1",
+                bool,
+                {
+                    "help_string": "help",
+                    "mandatory": True,
+                    "xor": ("input_1", "input_2"),
+                }
+            ),
+            (
+                "input_2",
+                bool,
+                {
+                    "help_string": "help",
+                    "mandatory": True,
+                    "argstr": "--i2",
+                    "xor": ("input_1", "input_2"),
+                }
+    )
+    ]
+    task_input_spec = SpecInfo(name="Input", fields=input_fields, bases=(ShellSpec,))
+    task_output_fields = []
+    task_output_spec = SpecInfo(name="Output", fields=task_output_fields, bases=(ShellOutSpec,))
+
+    class MyTask(ShellCommandTask):
+        input_spec = task_input_spec
+        output_spec = task_output_spec
+        executable = "cmd"
 
     task = MyTask()
     task.inputs.input_1 = True
     task.inputs.input_2 = True
     task.inputs.check_fields_input_spec()
-    #task.cmdline

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -16,13 +16,11 @@ from ..specs import (
     LazyField,
     ShellOutSpec,
 )
-from ..task import (
-    TaskBase,
-    ShellCommandTask
-)
+from ..task import TaskBase, ShellCommandTask
 from ..helpers import make_klass
 import pytest
 import attr
+
 
 def test_basespec():
     spec = BaseSpec()
@@ -372,40 +370,43 @@ def test_input_file_hash_5(tmpdir):
     hash3 = inputs(in_file=[{"file": file_diffcontent, "int": 3}]).hash
     assert hash1 != hash3
 
+
 class SimpleTask(ShellCommandTask):
-    input_fields=[
-            (
-                "input_1",
-                str,
-                {
-                    "help_string": "help",
-                    "mandatory": True,
-                    "xor": ("input_1", "input_2", "input_3"),
-                }
-            ),
-            (
-                "input_2",
-                bool,
-                {
-                    "help_string": "help",
-                    "mandatory": True,
-                    "argstr": "--i2",
-                    "xor": ("input_1", "input_2", "input_3"),
-                }
-            ),
-            (
-                "input_3",
-                bool,
-                {
-                    "help_string": "help",
-                    "mandatory": True,
-                    "xor": ("input_1", "input_2", "input_3"),
-                }
-            )
+    input_fields = [
+        (
+            "input_1",
+            str,
+            {
+                "help_string": "help",
+                "mandatory": True,
+                "xor": ("input_1", "input_2", "input_3"),
+            },
+        ),
+        (
+            "input_2",
+            bool,
+            {
+                "help_string": "help",
+                "mandatory": True,
+                "argstr": "--i2",
+                "xor": ("input_1", "input_2", "input_3"),
+            },
+        ),
+        (
+            "input_3",
+            bool,
+            {
+                "help_string": "help",
+                "mandatory": True,
+                "xor": ("input_1", "input_2", "input_3"),
+            },
+        ),
     ]
     task_input_spec = SpecInfo(name="Input", fields=input_fields, bases=(ShellSpec,))
     task_output_fields = []
-    task_output_spec = SpecInfo(name="Output", fields=task_output_fields, bases=(ShellOutSpec,))
+    task_output_spec = SpecInfo(
+        name="Output", fields=task_output_fields, bases=(ShellOutSpec,)
+    )
 
     input_spec = task_input_spec
     output_spec = task_output_spec
@@ -415,7 +416,7 @@ class SimpleTask(ShellCommandTask):
 def test_task_inputs_mandatory_with_xOR_one_mandatory_is_OK():
     """input spec with mandatory inputs"""
     task = SimpleTask()
-    task.inputs.input_1 = 'Input1'
+    task.inputs.input_1 = "Input1"
     task.inputs.input_2 = attr.NOTHING
     task.inputs.check_fields_input_spec()
 
@@ -443,23 +444,27 @@ def test_task_inputs_mandatory_with_xOR_zero_mandatory_raises_error():
 def test_task_inputs_mandatory_with_xOR_two_mandatories_raises_error():
     """input spec with mandatory inputs"""
     task = SimpleTask()
-    task.inputs.input_1 = 'Input1'
+    task.inputs.input_1 = "Input1"
     task.inputs.input_2 = True
-    
+
     with pytest.raises(Exception) as excinfo:
         task.inputs.check_fields_input_spec()
-    assert "input_2 is mutually exclusive with ('input_1', 'input_2'" in str(excinfo.value)
+    assert "input_2 is mutually exclusive with ('input_1', 'input_2'" in str(
+        excinfo.value
+    )
     assert excinfo.type is AttributeError
 
 
 def test_task_inputs_mandatory_with_xOR_3_mandatories_raises_error():
     """input spec with mandatory inputs"""
     task = SimpleTask()
-    task.inputs.input_1 = 'Input1'
+    task.inputs.input_1 = "Input1"
     task.inputs.input_2 = True
     task.inputs.input_3 = False
-    
+
     with pytest.raises(Exception) as excinfo:
         task.inputs.check_fields_input_spec()
-    assert "input_2 is mutually exclusive with ('input_1', 'input_2', 'input_3'" in str(excinfo.value)
+    assert "input_2 is mutually exclusive with ('input_1', 'input_2', 'input_3'" in str(
+        excinfo.value
+    )
     assert excinfo.type is AttributeError


### PR DESCRIPTION
## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Summary
We identified a possible issue with Pydra task input fields checking.

Input fields can be marked as '_mandatory_' as well as '_mutually exclusive_'.
If 
1. field_A is mandatory
2. field_B is mandatory
3. field_A and field_B are 'mutually exclusive'

then only field_A or field_B is needed, **not both**.

Nipype follows this behavior, but it seems like `check_fields_input_spec()` of the Pydra engine (pydra/pydra/engine/specs.py) is checking those conditions sequentially, not concurrently.
Compared with `_check_mandatory_inputs()` (nipype/interfaces/base/core.py)

## Note
The unit test might be misplaced. Should it go in `test_shelltask_inputspec.py` ?

## Checklist

- [x] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
