### PR TITLE
FIX: Enable testing with Python 3.11

### DIFF
--- a/.github/workflows/testpydra.yml
+++ b/.github/workflows/testpydra.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        exclude:
+          - os: 'windows-latest'
+            python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testpydra.yml
+++ b/.github/workflows/testpydra.yml
@@ -30,7 +30,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Update build tools
-      run: python -m pip install --upgrade pip build
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build wheel
 
     - name: Build pydra
       run: python -m build

--- a/.github/workflows/testpydra.yml
+++ b/.github/workflows/testpydra.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -58,7 +58,11 @@ class Worker:
         done = set()
         try:
             done, pending = await asyncio.wait(
-                futures, return_when=asyncio.FIRST_COMPLETED
+                [
+                    asyncio.create_task(f) if not isinstance(f, asyncio.Task) else f
+                    for f in futures
+                ],
+                return_when=asyncio.FIRST_COMPLETED,
             )
         except ValueError:
             # nothing pending!
@@ -105,7 +109,11 @@ class DistributedWorker(Worker):
         try:
             self._jobs += len(futures)
             done, pending = await asyncio.wait(
-                futures, return_when=asyncio.FIRST_COMPLETED
+                [
+                    asyncio.create_task(f) if not isinstance(f, asyncio.Task) else f
+                    for f in futures
+                ],
+                return_when=asyncio.FIRST_COMPLETED,
             )
         except ValueError:
             # nothing pending!


### PR DESCRIPTION
Fails due to [asyncio.wait](https://docs.python.org/3.11/library/asyncio-task.html?highlight=asyncio%20wait#asyncio.wait) now forbidding coroutines directly. Those need to be wrapped in tasks first.

Closes #569