### PR TITLE
MNT: Prerelease updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
           name: Install deps
           command: |
             pip install --upgrade pip
+            pip install --no-cache-dir -r docs/requirements.txt
             pip install --no-cache-dir .[doc]
       - run:
           name: Build only this commit

--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,5 @@ exclude =
     docs/tools/
     docs/conf.py
     pydra/_version.py
-    versioneer.py
 max-line-length=105
 ignore = E203,W503,F541

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ cov.xml
 .idea
 
 .DS_Store
+
+# This can be generated in-tree. We never want to commit it.
+pydra/_version.py

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -71,14 +71,14 @@
       "orcid": "0000-0002-4160-2134"
     },
     {
-      "affiliation": "MIT, HMS",
-      "name": "Ghosh, Satrajit",
-      "orcid": "0000-0002-5312-6729"
-    },
-    {
       "affiliation": "Paris Brain Institute",
       "name": "Vaillant, Ghislain",
       "orcid": "0000-0003-0267-3033"
+    },
+    {
+      "affiliation": "MIT, HMS",
+      "name": "Ghosh, Satrajit",
+      "orcid": "0000-0002-5312-6729"
     }
   ],
   "keywords": [

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,8 +3,6 @@ coverage:
   ignore:          # files and folders that will be removed during processing
     - "**/tests"
     - "pydra/_version.py"
-    - "setup.py"
-    - "versioneer.py"
   status:
     project:
       default:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ napoleon_use_param = False
 napoleon_custom_sections = [("Inputs", "Parameters"), ("Outputs", "Parameters")]
 
 # Intersphinx
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"https://docs.python.org/3/": None}
 
 # Linkcode
 # The following is used by sphinx.ext.linkcode to provide links to github

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,8 +45,8 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.linkcode",
     "sphinx.ext.githubpages",
+    "sphinx.ext.napoleon",
     "sphinxcontrib.apidoc",
-    "sphinxcontrib.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# This requirements file includes unreleased dependencies above and beyond those
+# specified in the project.optional-dependencies.doc table of pyproject.toml
+git+https://github.com/AleksandarPetrov/napoleon.git@0dc3f28a309ad602be5f44a9049785a1026451b3#egg=sphinxcontrib-napoleon
+git+https://github.com/effigies/sphinxcontrib-versioning.git@master#egg=sphinxcontrib-versioning

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
 # This requirements file includes unreleased dependencies above and beyond those
 # specified in the project.optional-dependencies.doc table of pyproject.toml
-git+https://github.com/AleksandarPetrov/napoleon.git@0dc3f28a309ad602be5f44a9049785a1026451b3#egg=sphinxcontrib-napoleon
 git+https://github.com/effigies/sphinxcontrib-versioning.git@master#egg=sphinxcontrib-versioning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,6 @@ dev = [
     "pydra[test]",
 ]
 doc = [
-    "attrs >=19.1.0",
-    "cloudpickle",
-    "filelock",
     "packaging",
     "sphinx >=2.1.2",
     "sphinx_rtd_theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ doc = [
     "sphinx >=2.1.2",
     "sphinx_rtd_theme",
     "sphinxcontrib-apidoc ~=0.3.0",
-    "sphinxcontrib-napoleon",
     "sphinxcontrib-versioning",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,13 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
## Types of changes
- Metadata and build information

## Summary
Adds trove classifiers to advertise support for specific Python versions and Windows. Removes redundant requirements in doc extra.

We also need to fix the doc build.

## Checklist
No docs or test needed.