### PR TITLE
MNT: Add git-archive support for setuptools_scm

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/testpydra.yml
+++ b/.github/workflows/testpydra.yml
@@ -6,17 +6,62 @@ on:
       - master
   pull_request:
 
-
 defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+
 jobs:
   build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3
+      - run: pip install --upgrade build twine
+      - run: python -m build
+      - run: twine check dist/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - name: Build archive
+        run: |
+          git clean -fxd
+          mkdir archive
+          git archive -o archive/pydra.zip HEAD
+      - uses: actions/upload-artifact@v3
+        with:
+          name: archive
+          path: archive/
+
+  test:
+    needs: ['build']
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        install: ['wheel']
+        include:
+          - os: 'ubuntu-latest'
+            python-version: '3.11'
+            install: 'sdist'
+          - os: 'ubuntu-latest'
+            python-version: '3.11'
+            install: 'repo'
+          - os: 'ubuntu-latest'
+            python-version: '3.11'
+            install: 'archive'
         exclude:
           - os: 'windows-latest'
             python-version: '3.11'
@@ -25,29 +70,59 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Disable etelemetry
-      run:  echo "NO_ET=TRUE" >> $GITHUB_ENV
-    - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Update build tools
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install build wheel
+      - name: Fetch sdist/wheel
+        uses: actions/download-artifact@v3
+        if: matrix.install == 'sdist' || matrix.install == 'wheel'
+        with:
+          name: dist
+          path: dist/
+      - name: Fetch git archive
+        uses: actions/download-artifact@v3
+        if: matrix.install == 'archive'
+        with:
+          name: archive
+          path: archive/
+      - name: Fetch repository
+        uses: actions/checkout@v3
+        if: matrix.install == 'repo'
 
-    - name: Build pydra
-      run: python -m build
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Update pip
+        run: python -m pip install --upgrade pip
 
+      - name: Determine installation target
+        run: |
+          if [[ "$INSTALL" = "sdist" ]]; then
+              echo "ARCHIVE=$( ls dist/*.tar.gz )" >> $GITHUB_ENV
+          elif [[ "$INSTALL" = "wheel" ]]; then
+              echo "ARCHIVE=$( ls dist/*.whl )" >> $GITHUB_ENV
+          elif [[ "$INSTALL" = "archive" ]]; then
+              echo "ARCHIVE=$( ls archive/*.zip )" >> $GITHUB_ENV
+          elif [[ "$INSTALL" = "repo" ]]; then
+              echo "ARCHIVE=." >> $GITHUB_ENV
+          fi
+        env:
+          INSTALL: ${{ matrix.install }}
 
-    - name: Install Pydra tests dependencies
-      run: pip install "$( ls dist/pydra*.whl )[test]"
+      - name: Install Pydra
+        run: pip install $ARCHIVE
 
+      - name: Print version
+        run: python -c "import pydra; print(pydra.__version__)"
 
-    - name: Pytest
-      run: pytest -vs -n auto --cov pydra  --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
+      - name: Install Pydra tests dependencies
+        run: pip install pydra[test]
 
+      - name: Disable etelemetry
+        run:  echo "NO_ET=TRUE" >> $GITHUB_ENV
 
-    - name: Upload to codecov
-      run: codecov -f cov.xml -F unittests -e GITHUB_WORKFLOW
+      - name: Pytest
+        run: |
+          pytest -vs -n auto --doctest-modules --pyargs pydra \
+                 --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml
+
+      - name: Upload to codecov
+        run: codecov -f cov.xml -F unittests -e GITHUB_WORKFLOW

--- a/pydra/conftest.py
+++ b/pydra/conftest.py
@@ -15,12 +15,21 @@ def pytest_generate_tests(metafunc):
             Plugins = ["slurm"]
         else:
             Plugins = ["cf"]
-        if metafunc.config.getoption("dask"):
-            Plugins.append("dask")
+        try:
+            if metafunc.config.getoption("dask"):
+                Plugins.append("dask")
+        except ValueError:
+            # Called as --pyargs, so --dask isn't available
+            pass
         metafunc.parametrize("plugin_dask_opt", Plugins)
 
     if "plugin" in metafunc.fixturenames:
-        if metafunc.config.getoption("dask"):
+        use_dask = False
+        try:
+            use_dask = metafunc.config.getoption("dask")
+        except ValueError:
+            pass
+        if use_dask:
             Plugins = []
         elif bool(shutil.which("sbatch")):
             Plugins = ["slurm"]


### PR DESCRIPTION
## Types of changes
- Maintenance task: Add and test git-archive support

## Summary
Versioneer permitted `git archive` to store some limited version information in the artifacts, such as those generated by GitHub. setuptools_scm needs special prodding to do this.

This adds and tests the feature. In the process, I've split the build and test stages from the main tests so that we can test different installation methods.

## Checklist
- [x] I have added tests to cover my changes (if necessary)
