### PR TITLE
CI: Enable testing for Python 3.11 on Windows

### DIFF
--- a/.github/workflows/testpydra.yml
+++ b/.github/workflows/testpydra.yml
@@ -62,9 +62,6 @@ jobs:
           - os: 'ubuntu-latest'
             python-version: '3.11'
             install: 'archive'
-        exclude:
-          - os: 'windows-latest'
-            python-version: '3.11'
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Now that wheels for lxml-4.9.2 are available.
