### PR TITLE
FIX: Provide templated fields to cmdline only when requirements are met

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -591,9 +591,19 @@ def template_update(inputs, output_dir, state_ind=None, map_copyfiles=None):
 
     from .specs import attr_fields
 
+    # Collect templated inputs for which all requirements are satisfied.
     fields_templ = [
-        fld for fld in attr_fields(inputs) if fld.metadata.get("output_file_template")
+        field
+        for field in attr_fields(inputs)
+        if field.metadata.get("output_file_template")
+        and all(
+            [
+                getattr(inputs, required_field) is not attr.NOTHING
+                for required_field in field.metadata.get("requires", [])
+            ]
+        )
     ]
+
     dict_mod = {}
     for fld in fields_templ:
         if fld.type not in [str, ty.Union[str, bool]]:

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -597,10 +597,8 @@ def template_update(inputs, output_dir, state_ind=None, map_copyfiles=None):
         for field in attr_fields(inputs)
         if field.metadata.get("output_file_template")
         and all(
-            [
-                getattr(inputs, required_field) is not attr.NOTHING
-                for required_field in field.metadata.get("requires", [])
-            ]
+            getattr(inputs, required_field) is not attr.NOTHING
+            for required_field in field.metadata.get("requires", ())
         )
     ]
 

--- a/pydra/engine/tests/test_shelltask_inputspec.py
+++ b/pydra/engine/tests/test_shelltask_inputspec.py
@@ -1721,6 +1721,58 @@ def test_shell_cmd_inputs_template_10():
     assert shelly.output_names == ["return_code", "stdout", "stderr", "outA"]
 
 
+def test_shell_cmd_inputs_template_requires_1():
+    """Given an input specification with a templated output file subject to required fields,
+    ensure the field is set only when all requirements are met."""
+
+    my_input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "in_file",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "help_string": "input file",
+                        "mandatory": True,
+                        "argstr": "",
+                    },
+                ),
+            ),
+            (
+                "with_tpl",
+                attr.ib(
+                    type=bool,
+                    metadata={"help_string": "enable template"},
+                ),
+            ),
+            (
+                "out_file",
+                attr.ib(
+                    type=str,
+                    metadata={
+                        "help_string": "output file",
+                        "argstr": "--tpl",
+                        "output_file_template": "tpl.{in_file}",
+                        "requires": {"with_tpl"},
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    # When requirements are not met.
+    shelly = ShellCommandTask(
+        executable="cmd", input_spec=my_input_spec, in_file="in.file"
+    )
+    assert "--tpl" not in shelly.cmdline
+
+    # When requirements are met.
+    shelly.inputs.with_tpl = True
+    assert "tpl.in.file" in shelly.cmdline
+
+
 def test_shell_cmd_inputs_template_function_1():
     """one input field uses output_file_template that is a simple function
     this can be easily done by simple template as in test_shell_cmd_inputs_template_1

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -4843,7 +4843,7 @@ def test_duplicate_input_on_split_wf(tmpdir):
 @pytest.mark.timeout(40)
 def test_inner_outer_wf_duplicate(tmpdir):
     """checking if the execution gets stuck if there is an inner and outer workflows
-    thar run two nodes with the exact same inputs.
+    that run two nodes with the exact same inputs.
     """
     task_list = ["First", "Second"]
     start_list = [3]

--- a/pydra/utils/profiler.py
+++ b/pydra/utils/profiler.py
@@ -9,7 +9,7 @@ _MB = 1024.0**2
 
 
 class ResourceMonitor(threading.Thread):
-    """A thread to monitor a specific PID with a certain frequence to a file."""
+    """A thread to monitor a specific PID with a certain frequency to a file."""
 
     def __init__(self, pid, interval=5, logdir=None, fname=None):
         """


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary

Issue #619 showed an example where a templated field can be provided in the generated command-line string,
despite being guarded by another boolean option via `requires`. This PR ensures that the helper function responsible for computing interpolated fields only consider templated fields for which all their required fields are set.

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)

Closes #619