### PR TITLE
FIX: Allow any iterable for ShellOutSpec requires

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -636,7 +636,7 @@ class ShellOutSpec:
 
         if "requires" in fld.metadata:
             # if requires is a list of list it is treated as el[0] OR el[1] OR...
-            required_fields = list(fld.metadata["requires"])
+            required_fields = ensure_list(fld.metadata["requires"])
             if all([isinstance(el, list) for el in required_fields]):
                 field_required_OR = required_fields
             # if requires is a list of tuples/strings - I'm creating a 1-el nested list

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -636,11 +636,12 @@ class ShellOutSpec:
 
         if "requires" in fld.metadata:
             # if requires is a list of list it is treated as el[0] OR el[1] OR...
-            if all([isinstance(el, list) for el in fld.metadata["requires"]]):
-                field_required_OR = fld.metadata["requires"]
+            required_fields = list(fld.metadata["requires"])
+            if all([isinstance(el, list) for el in required_fields]):
+                field_required_OR = required_fields
             # if requires is a list of tuples/strings - I'm creating a 1-el nested list
-            elif all([isinstance(el, (str, tuple)) for el in fld.metadata["requires"]]):
-                field_required_OR = [fld.metadata["requires"]]
+            elif all([isinstance(el, (str, tuple)) for el in required_fields]):
+                field_required_OR = [required_fields]
             else:
                 raise Exception(
                     f"requires field can be a list of list, or a list "


### PR DESCRIPTION
## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Summary

Specifying the `requires` metadata for a field in `ShellOutSpec` as a `set` instead of a `list` bypasses part of the metadata checker resulting in an Exception further down the implementation.

This fix allow to specify the `requires` metadata for `ShellOutSpec` as any iterable (including a set), instead of being restricted to a `list`. It's then explicitly transformed to a list of list by the metadata checker, if necessary.
