### PR TITLE
FIX: Allow staticmethod be passed to callable metadata in ouput spec

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -593,7 +593,12 @@ class ShellOutSpec:
                     return attr.NOTHING
                 return val
         elif "callable" in fld.metadata:
-            call_args = inspect.getfullargspec(fld.metadata["callable"])
+            callable_ = fld.metadata["callable"]
+            if isinstance(callable_, staticmethod):
+                # In case callable is defined as a static method,
+                # retrieve the function wrapped in the descriptor.
+                callable_ = callable_.__func__
+            call_args = inspect.getfullargspec(callable_)
             call_args_val = {}
             for argnm in call_args.args:
                 if argnm == "field":
@@ -615,7 +620,7 @@ class ShellOutSpec:
                             f"has to be in inputs or be field or output_dir, "
                             f"but {argnm} is used"
                         )
-            return fld.metadata["callable"](**call_args_val)
+            return callable_(**call_args_val)
         else:
             raise Exception("(_field_metadata) is not a current valid metadata key.")
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
<!--- What does your code do? -->
This PR provides a fix allowing the `callable` field metadata be defined as a staticmethod to the output spec class.

Before this fix, the following would fail:

```python

@attrs.define(kw_only=True)
class MyOutSpec(pydra.specs.ShellOutSpec):

    @staticmethod
    def get_foo(field):
        return "foo.bar"

    foo: pydra.specs.File = attrs.field(
        metadata={
            help="some output help",
            callable=get_foo,
        }
    )
```

The reason for that is that the actual callable is wrapped inside the `staticmethod` descriptor and does not expose the `Callable` interface, which makes runtime reflection with `inspect` fail with a `TypeError`. The solution is just to recover the wrapped method inside the descriptor.
 
## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
