### PR TITLE
Add tests for `--error` and `--output` as `sbatch_args` in `test_submitter`

### DIFF
--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -319,7 +319,7 @@ def test_slurm_args_3(tmpdir):
 @need_slurm
 def test_slurm_args_4(tmpdir):
     """testing sbatch_args provided to the submitter
-    test should pass when valid output sbatch_args is provided 
+    test should pass when valid output sbatch_args is provided
     """
     task = sleep_add_one(x=1)
     task.cache_dir = tmpdir

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -299,6 +299,40 @@ def test_slurm_args_2(tmpdir):
             sub(task)
 
 
+@need_slurm
+def test_slurm_args_3(tmpdir):
+    """testing sbatch_args provided to the submitter
+    test should pass when valid error sbatch_args is provided
+    """
+    task = sleep_add_one(x=1)
+    task.cache_dir = tmpdir
+    # submit workflow and every task as slurm job
+    with Submitter("slurm", sbatch_args="--error=error.log") as sub:
+        sub(task)
+
+    res = task.result()
+    assert res.output.out == 2
+    error_log_file = tmpdir / "SlurmWorker_scripts"
+    assert error_log_file.exists()
+
+
+@need_slurm
+def test_slurm_args_4(tmpdir):
+    """testing sbatch_args provided to the submitter
+    test should pass when valid output sbatch_args is provided 
+    """
+    task = sleep_add_one(x=1)
+    task.cache_dir = tmpdir
+    # submit workflow and every task as slurm job
+    with Submitter("slurm", sbatch_args="--output=output.log") as sub:
+        sub(task)
+
+    res = task.result()
+    assert res.output.out == 2
+    output_log_file = tmpdir / "SlurmWorker_scripts"
+    assert output_log_file.exists()
+
+
 @mark.task
 def sleep(x, job_name_part):
     time.sleep(x)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- New feature (non-breaking change which adds functionality)

## Summary
<!--- What does your code do? -->
Added tests for valid `--error` and `--output` as `sbatch_args`.
## Checklist
<!--- Please, let us know if you need help-->
I am getting error for `test_slurm_args_3` while testing (which checks for `--error`) - `AttributeError: 'NoneType' object has no attribute 'replace'`
![image](https://user-images.githubusercontent.com/50960175/228544761-c5609c9d-cda4-4af0-85fe-cda906af93f0.png)
Possible reason for this could be in workers.py [here](https://github.com/nipype/pydra/blob/master/pydra/engine/workers.py#L284). In this, we are assigning `error_file` to `None` when `--error` flag is indeed detected. And [later](https://github.com/nipype/pydra/blob/master/pydra/engine/workers.py#L299) we are using `.replace()` function on `error_file` which is `None` in our case.
