### PR TITLE
RF: Change File and Directory to aliases of Path

### DIFF
--- a/pydra/engine/audit.py
+++ b/pydra/engine/audit.py
@@ -1,10 +1,11 @@
 """Module to keep track of provenance information."""
 import os
 import json
+from pathlib import Path
 import attr
 from ..utils.messenger import send_message, make_message, gen_uuid, now, AuditFlag
 from .helpers import ensure_list, gather_runtime_info, hash_file
-from .specs import attr_fields, File, Directory
+from .specs import attr_fields
 
 try:
     import importlib_resources
@@ -181,7 +182,7 @@ class Audit:
         command = task.cmdline if hasattr(task.inputs, "executable") else None
         attr_list = attr_fields(task.inputs)
         for attrs in attr_list:
-            if attrs.type in [File, Directory]:
+            if attrs.type is Path:
                 input_name = attrs.name
                 input_path = os.path.abspath(getattr(task.inputs, input_name))
                 file_hash = hash_file(input_path)

--- a/pydra/engine/boutiques.py
+++ b/pydra/engine/boutiques.py
@@ -7,7 +7,7 @@ from functools import reduce
 
 from ..utils.messenger import AuditFlag
 from ..engine import ShellCommandTask
-from ..engine.specs import SpecInfo, ShellSpec, ShellOutSpec, File, attr_fields
+from ..engine.specs import SpecInfo, ShellSpec, ShellOutSpec, attr_fields
 from .helpers_file import is_local_file
 
 
@@ -122,7 +122,7 @@ class BoshTask(ShellCommandTask):
             else:
                 names_subset.remove(name)
             if input["type"] == "File":
-                tp = File
+                tp = Path
             elif input["type"] == "String":
                 tp = str
             elif input["type"] == "Number":
@@ -171,7 +171,7 @@ class BoshTask(ShellCommandTask):
                 "mandatory": not output["optional"],
                 "output_file_template": path_template,
             }
-            fields.append((name, attr.ib(type=File, metadata=mdata)))
+            fields.append((name, attr.ib(type=Path, metadata=mdata)))
 
         if names_subset:
             raise RuntimeError(f"{names_subset} are not in the zenodo output spec")

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -19,7 +19,6 @@ from traceback import format_exception
 from . import state
 from . import helpers_state as hlpst
 from .specs import (
-    File,
     BaseSpec,
     RuntimeSpec,
     Result,
@@ -83,7 +82,7 @@ class TaskBase:
         audit_flags: AuditFlag = AuditFlag.NONE,
         cache_dir=None,
         cache_locations=None,
-        inputs: ty.Optional[ty.Union[ty.Text, File, ty.Dict]] = None,
+        inputs: ty.Optional[ty.Union[ty.Text, Path, ty.Dict]] = None,
         cont_dim=None,
         messenger_args=None,
         messengers=None,

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -547,14 +547,14 @@ def ensure_list(filename):
 # not sure if this might be useful for Function Task
 def copyfile_input(inputs, output_dir):
     """Implement the base class method."""
-    from .specs import attr_fields, File, MultiInputFile
+    from .specs import attr_fields, MultiInputFile
 
     map_copyfiles = {}
     for fld in attr_fields(inputs):
         copy = fld.metadata.get("copyfile")
-        if copy is not None and fld.type not in [File, MultiInputFile]:
+        if copy is not None and fld.type not in [Path, MultiInputFile]:
             raise Exception(
-                f"if copyfile set, field has to be a File " f"but {fld.type} provided"
+                f"if copyfile set, field has to be a File but {fld.type} provided"
             )
         file = getattr(inputs, fld.name)
         if copy in [True, False] and file != attr.NOTHING:
@@ -628,7 +628,7 @@ def template_update_single(
     based on the value from inputs_dict
     (checking the types of the fields, that have "output_file_template)"
     """
-    from .specs import File, MultiOutputFile, Directory
+    from .specs import MultiOutputFile
 
     # if input_dict_st with state specific value is not available,
     # the dictionary will be created from inputs object
@@ -651,7 +651,7 @@ def template_update_single(
                 f"type of {field.name} is str, consider using Union[str, bool]"
             )
     elif spec_type == "output":
-        if field.type not in [File, MultiOutputFile, Directory]:
+        if field.type not in [Path, MultiOutputFile]:
             raise Exception(
                 f"output {field.name} should be a File, but {field.type} set as the type"
             )
@@ -702,7 +702,6 @@ def _template_formatting(field, inputs, inputs_dict_st):
 
     val_dict = {}
     file_template = None
-    from .specs import attr_fields_dict, File
 
     for fld in inp_fields:
         fld_name = fld[1:-1]  # extracting the name form {field_name}
@@ -715,10 +714,8 @@ def _template_formatting(field, inputs, inputs_dict_st):
         else:
             # checking for fields that can be treated as a file:
             # have type File, or value that is path like (including str with extensions)
-            if (
-                attr_fields_dict(inputs)[fld_name].type is File
-                or isinstance(fld_value, os.PathLike)
-                or (isinstance(fld_value, str) and "." in fld_value)
+            if isinstance(fld_value, os.PathLike) or (
+                isinstance(fld_value, str) and "." in fld_value
             ):
                 if file_template:
                     raise Exception(
@@ -803,12 +800,10 @@ def _element_formatting(template, values_template_dict, file_template, keep_exte
 
 
 def is_local_file(f):
-    from .specs import File, Directory, MultiInputFile
+    from .specs import MultiInputFile
 
     if "container_path" not in f.metadata and (
-        f.type in [File, Directory, MultiInputFile]
-        or "pydra.engine.specs.File" in str(f.type)
-        or "pydra.engine.specs.Directory" in str(f.type)
+        f.type in [Path, MultiInputFile] or "pathlib.Path" in str(f.type)
     ):
         return True
     else:


### PR DESCRIPTION
This attempts to replace File/Directory with TypeAliases, which I think is probably the only reasonable way to make Pydra type-checkable.

The File/Directory stuff is pretty magical. Something somewhere is changing the `output_dir` after using it to do input mapping when running container tasks, but I can't figure out where and I've run out of time to spend on this. Possibly someone else will see it.