### PR TITLE
FIX: Discard lazy fields in template type checks

### DIFF
--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -628,7 +628,7 @@ def template_update_single(
     based on the value from inputs_dict
     (checking the types of the fields, that have "output_file_template)"
     """
-    from .specs import File, MultiOutputFile, Directory
+    from .specs import File, MultiOutputFile, Directory, LazyField
 
     # if input_dict_st with state specific value is not available,
     # the dictionary will be created from inputs object
@@ -642,7 +642,9 @@ def template_update_single(
                 "has to be a string or Union[str, bool]"
             )
         inp_val_set = inputs_dict_st[field.name]
-        if inp_val_set is not attr.NOTHING and not isinstance(inp_val_set, (str, bool)):
+        if inp_val_set is not attr.NOTHING and not isinstance(
+            inp_val_set, (str, bool, LazyField)
+        ):
             raise Exception(
                 f"{field.name} has to be str or bool, but {inp_val_set} set"
             )


### PR DESCRIPTION
See issue #641 for context.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Summary
This PR discards lazy fields in checks performed in template updates.

I am not very happy with this change, but it's the only way I found so far to bypass this issue without major surgery of the code. Not being able to use `output_file_template` in a workflow is quite a bummer.

Open to other suggestions if any 🙏 

## Triage

```python
from os import PathLike
from attrs import define, field
from pydra.engine import Workflow
from pydra.engine.specs import ShellSpec, SpecInfo
from pydra.engine.task import ShellCommandTask


class BackupFile(ShellCommandTask):
    """Example task performing a file backup with cp.

    If not target file is provided, it uses a default file suffixed by copy.
    """

    @define(kw_only=True)
    class InputSpec(ShellSpec):
        source_file: PathLike = field(
            metadata={"help_string": "source file", "mandatory": True, "argstr": ""}
        )

        target_file: str = field(
            metadata={"help_string": "target file", "argstr": "", "output_file_template": "{source_file}_copy"}
        )

    input_spec = SpecInfo(name="Input", bases=(InputSpec,))

    executable = "cp"


def backup(name="backup", **kwargs) -> Workflow:
    wf = Workflow(input_spec=["source_file", "target_file"], name=name, **kwargs)

    wf.add(
        BackupFile(
            name="backup_file",
            source_file=wf.lzin.source_file,
            target_file=wf.lzin.target_file,
        )
    )

    wf.set_output({"target_file": wf.backup_file.lzout.target_file})

    return wf


if __name__ == "__main__":
    from pathlib import Path
    from tempfile import TemporaryDirectory

    # Execute with standalone backup task.
    with TemporaryDirectory() as td:
        source_file = Path(td) / "source1.file"
        source_file.touch()

        task = BackupFile(source_file=source_file)
        result = task()

        print(result.output.target_file)

    # Execute backup task wrapped in a workflow.
    with TemporaryDirectory() as td:
        source_file = Path(td) / "source2.file"
        source_file.touch()

        task = backup(source_file=source_file)
        result = task()

        print(result.output.target_file)
```

Closes: #641 