### PR TITLE
Added handling of hashing of types with args and typing special forms

### DIFF
--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -114,12 +114,6 @@ def bytes_repr(obj: object, cache: Cache) -> Iterator[bytes]:
         dct = {attr: getattr(obj, attr) for attr in obj.__slots__}
     else:
         dct = obj.__dict__
-            dct = obj.__dict__
-        except AttributeError as e:
-            try:
-                dct = {n: getattr(obj, n) for n in obj.__slots__}  # type: ignore
-            except AttributeError:
-                raise e
     yield from bytes_repr_mapping_contents(dct, cache)
     yield b"}"
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -106,11 +106,14 @@ class HasBytesRepr(Protocol):
 def bytes_repr(obj: object, cache: Cache) -> Iterator[bytes]:
     cls = obj.__class__
     yield f"{cls.__module__}.{cls.__name__}:{{".encode()
+    dct: Dict[str, ty.Any]
     if attrs.has(type(obj)):
         # Drop any attributes that aren't used in comparisons by default
-        dct = attrs.asdict(obj, recurse=False, filter=lambda a, _: bool(a.eq))  # type: ignore
+        dct = attrs.asdict(obj, recurse=False, filter=lambda a, _: bool(a.eq))
+    elif hasattr(obj, "__slots__"):
+        dct = {attr: getattr(obj, attr) for attr in obj.__slots__}
     else:
-        try:
+        dct = obj.__dict__
             dct = obj.__dict__
         except AttributeError as e:
             try:

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -7,6 +7,7 @@ import typing as ty
 from collections.abc import Mapping
 from functools import singledispatch
 from hashlib import blake2b
+import logging
 
 # from pathlib import Path
 from typing import (
@@ -17,6 +18,8 @@ from typing import (
     Set,
 )
 import attrs.exceptions
+
+logger = logging.getLogger("pydra")
 
 try:
     from typing import Protocol
@@ -88,7 +91,8 @@ def hash_single(obj: object, cache: Cache) -> Hash:
         h = blake2b(digest_size=16, person=b"pydra-hash")
         for chunk in bytes_repr(obj, cache):
             h.update(chunk)
-        cache[objid] = Hash(h.digest())
+        hsh = cache[objid] = Hash(h.digest())
+        logger.debug("Hash of %s object is %s", obj, hsh)
     return cache[objid]
 
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -3,6 +3,7 @@ import os
 
 # import stat
 import struct
+import typing as ty
 from collections.abc import Mapping
 from functools import singledispatch
 from hashlib import blake2b
@@ -14,7 +15,6 @@ from typing import (
     NewType,
     Sequence,
     Set,
-    _SpecialForm,
 )
 import attrs.exceptions
 
@@ -224,10 +224,27 @@ def bytes_repr_dict(obj: dict, cache: Cache) -> Iterator[bytes]:
     yield b"}"
 
 
-@register_serializer(_SpecialForm)
+@register_serializer(ty._GenericAlias)
+@register_serializer(ty._SpecialForm)
 @register_serializer(type)
 def bytes_repr_type(klass: type, cache: Cache) -> Iterator[bytes]:
-    yield f"type:({klass.__module__}.{klass.__name__})".encode()
+    try:
+        yield f"type:({klass.__module__}.{klass.__name__}".encode()
+    except AttributeError:
+        yield f"type:(typing.{klass._name}:(".encode()  # type: ignore
+    args = ty.get_args(klass)
+    if args:
+
+        def sort_key(a):
+            try:
+                return a.__name__
+            except AttributeError:
+                return a._name
+
+        yield b"["
+        yield from bytes_repr_sequence_contents(sorted(args, key=sort_key), cache)
+        yield b"]"
+    yield b")"
 
 
 @register_serializer(list)

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -242,7 +242,15 @@ def bytes_repr_type(klass: type, cache: Cache) -> Iterator[bytes]:
     origin = ty.get_origin(klass)
     if origin:
         yield f"{origin.__module__}.{type_name(origin)}[".encode()
-        yield from (b for t in ty.get_args(klass) for b in bytes_repr_type(t, cache))
+        for arg in ty.get_args(klass):
+            if isinstance(
+                arg, list
+            ):  # sometimes (e.g. Callable) the args of a type is a list
+                yield b"["
+                yield from (b for t in arg for b in bytes_repr_type(t, cache))
+                yield b"]"
+            else:
+                yield from bytes_repr_type(arg, cache)
         yield b"]"
     else:
         yield f"{klass.__module__}.{type_name(klass)}".encode()

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -242,7 +242,7 @@ def bytes_repr_type(klass: type, cache: Cache) -> Iterator[bytes]:
     origin = ty.get_origin(klass)
     if origin:
         yield f"{origin.__module__}.{type_name(origin)}[".encode()
-        yield from bytes_repr_sequence_contents(ty.get_args(klass), cache)
+        yield from (b for t in ty.get_args(klass) for b in bytes_repr_type(t, cache))
         yield b"]"
     else:
         yield f"{klass.__module__}.{type_name(klass)}".encode()

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -171,7 +171,7 @@ def test_bytes_repr_type1():
 
 def test_bytes_repr_type1a():
     obj_repr = join_bytes_repr(Zip[Json])
-    assert re.match(rb"type:\(fileformats.application.archive.Json__Zip\)", obj_repr)
+    assert obj_repr == rb"type:(fileformats.application.archive.Json__Zip)"
 
 
 def test_bytes_repr_type2():

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -181,12 +181,14 @@ def test_bytes_repr_type2():
         pass
 
     obj_repr = join_bytes_repr(MyClass[int])
-    assert obj_repr == b"type:(pydra.utils.tests.test_hash.MyClass[type:(int)])"
+    assert (
+        obj_repr == b"type:(pydra.utils.tests.test_hash.MyClass[type:(builtins.int)])"
+    )
 
 
 def test_bytes_special_form1():
     obj_repr = join_bytes_repr(ty.Union[int, float])
-    assert re.match(rb"type:\(typing.Union\[.{32}\]\)", obj_repr)
+    assert obj_repr == b"type:(typing.Union[type:(builtins.int)type:(builtins.float)])"
 
 
 def test_bytes_special_form2():
@@ -196,20 +198,22 @@ def test_bytes_special_form2():
 
 def test_bytes_special_form3():
     obj_repr = join_bytes_repr(ty.Optional[Path])
-    assert re.match(rb"type:\(typing.Union\[.{32}\]\)", obj_repr, flags=re.DOTALL)
+    assert (
+        obj_repr == b"type:(typing.Union[type:(pathlib.Path)type:(builtins.NoneType)])"
+    )
 
 
 def test_bytes_special_form4():
     obj_repr = join_bytes_repr(ty.Type[Path])
-    assert re.match(rb"type:\(builtins.type\[.{16}\]\)", obj_repr, flags=re.DOTALL)
+    assert obj_repr == b"type:(builtins.type[type:(pathlib.Path)])"
 
 
 def test_bytes_special_form5():
     obj_repr = join_bytes_repr(ty.Callable[[Path, int], ty.Tuple[float, str]])
-    assert re.match(
-        rb"type:\(collections.abc.Callable\[.{32}\]\)", obj_repr, flags=re.DOTALL
+    assert obj_repr == (
+        b"type:(collections.abc.Callable[[type:(pathlib.Path)type:(builtins.int)]"
+        b"type:(builtins.tuple[type:(builtins.float)type:(builtins.str)])])"
     )
-    assert obj_repr != join_bytes_repr(ty.Callable[[Path, int], ty.Tuple[float, bytes]])
 
 
 def test_recursive_object():

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -135,8 +135,31 @@ def test_bytes_repr_custom_obj():
     assert re.match(rb".*\.MyClass:{str:1:x=.{16}}", obj_repr)
 
 
+def test_bytes_repr_slots_obj():
+    class MyClass:
+        __slots__ = ("x",)
+
+        def __init__(
+            self,
+            x,
+        ):
+            self.x = x
+
+    obj_repr = join_bytes_repr(MyClass(1))
+    assert re.match(rb".*\.MyClass:{str:1:x=.{16}}", obj_repr)
+
+
 def test_bytes_repr_attrs_slots():
     @attrs.define
+    class MyClass:
+        x: int
+
+    obj_repr = join_bytes_repr(MyClass(1))
+    assert re.match(rb".*\.MyClass:{str:1:x=.{16}}", obj_repr)
+
+
+def test_bytes_repr_attrs_no_slots():
+    @attrs.define(slots=False)
     class MyClass:
         x: int
 

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -139,10 +139,7 @@ def test_bytes_repr_slots_obj():
     class MyClass:
         __slots__ = ("x",)
 
-        def __init__(
-            self,
-            x,
-        ):
+        def __init__(self, x):
             self.x = x
 
     obj_repr = join_bytes_repr(MyClass(1))

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import attrs
 import pytest
+import typing as ty
 
 from ..hash import Cache, UnhashableError, bytes_repr, hash_object, register_serializer
 
@@ -143,9 +144,24 @@ def test_bytes_repr_attrs_slots():
     assert re.match(rb".*\.MyClass:{str:1:x=.{16}}", obj_repr)
 
 
-def test_bytes_repr_type():
+def test_bytes_repr_type1():
     obj_repr = join_bytes_repr(Path)
     assert obj_repr == b"type:(pathlib.Path)"
+
+
+def test_bytes_repr_type2():
+    T = ty.TypeVar("T")
+
+    class MyClass(ty.Generic[T]):
+        pass
+
+    obj_repr = join_bytes_repr(MyClass[int])
+    assert re.match(rb"type:\(pydra.utils.tests.test_hash.MyClass\[.{16}\]\)", obj_repr)
+
+
+def test_bytes_special_form():
+    obj_repr = join_bytes_repr(ty.Union[int, float])
+    assert re.match(rb"type:\(typing.Union\[.{32}\]\)", obj_repr)
 
 
 def test_recursive_object():

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import attrs
 import pytest
 import typing as ty
-
+from fileformats.application import Zip, Json
 from ..hash import Cache, UnhashableError, bytes_repr, hash_object, register_serializer
 
 
@@ -172,6 +172,11 @@ def test_bytes_repr_type1():
     assert obj_repr == b"type:(pathlib.Path)"
 
 
+def test_bytes_repr_type1a():
+    obj_repr = join_bytes_repr(Zip[Json])
+    assert re.match(rb"type:\(fileformats.application.Zip\[.{16}\]\)", obj_repr)
+
+
 def test_bytes_repr_type2():
     T = ty.TypeVar("T")
 
@@ -182,9 +187,30 @@ def test_bytes_repr_type2():
     assert re.match(rb"type:\(pydra.utils.tests.test_hash.MyClass\[.{16}\]\)", obj_repr)
 
 
-def test_bytes_special_form():
+def test_bytes_special_form1():
     obj_repr = join_bytes_repr(ty.Union[int, float])
     assert re.match(rb"type:\(typing.Union\[.{32}\]\)", obj_repr)
+
+
+def test_bytes_special_form2():
+    obj_repr = join_bytes_repr(ty.Any)
+    assert re.match(rb"type:\(typing.Any\)", obj_repr)
+
+
+def test_bytes_special_form3():
+    obj_repr = join_bytes_repr(ty.Optional[Path])
+    assert re.match(rb"type:\(typing.Optional\[.{16}\]\)", obj_repr)
+
+
+def test_bytes_special_form4():
+    obj_repr = join_bytes_repr(ty.Type[Path])
+    assert re.match(rb"type:\(builtins.type\[.{16}\]\)", obj_repr)
+
+
+def test_bytes_special_form5():
+    obj_repr = join_bytes_repr(ty.Callable[[Path, int], ty.Tuple[float, str]])
+    assert re.match(rb"type:\(typing.Callable\[.{16}\]\)", obj_repr)
+    assert obj_repr != join_bytes_repr(ty.Callable[[Path, int], ty.Tuple[float, bytes]])
 
 
 def test_recursive_object():

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -181,7 +181,7 @@ def test_bytes_repr_type2():
         pass
 
     obj_repr = join_bytes_repr(MyClass[int])
-    assert re.match(rb"type:\(pydra.utils.tests.test_hash.MyClass\[.{16}\]\)", obj_repr)
+    assert obj_repr == b"type:(pydra.utils.tests.test_hash.MyClass[type:(int)])"
 
 
 def test_bytes_special_form1():

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -174,7 +174,7 @@ def test_bytes_repr_type1():
 
 def test_bytes_repr_type1a():
     obj_repr = join_bytes_repr(Zip[Json])
-    assert re.match(rb"type:\(fileformats.application.Zip\[.{16}\]\)", obj_repr)
+    assert re.match(rb"type:\(fileformats.application.archive.Json__Zip\)", obj_repr)
 
 
 def test_bytes_repr_type2():
@@ -199,17 +199,19 @@ def test_bytes_special_form2():
 
 def test_bytes_special_form3():
     obj_repr = join_bytes_repr(ty.Optional[Path])
-    assert re.match(rb"type:\(typing.Optional\[.{16}\]\)", obj_repr)
+    assert re.match(rb"type:\(typing.Union\[.{32}\]\)", obj_repr, flags=re.DOTALL)
 
 
 def test_bytes_special_form4():
     obj_repr = join_bytes_repr(ty.Type[Path])
-    assert re.match(rb"type:\(builtins.type\[.{16}\]\)", obj_repr)
+    assert re.match(rb"type:\(builtins.type\[.{16}\]\)", obj_repr, flags=re.DOTALL)
 
 
 def test_bytes_special_form5():
     obj_repr = join_bytes_repr(ty.Callable[[Path, int], ty.Tuple[float, str]])
-    assert re.match(rb"type:\(typing.Callable\[.{16}\]\)", obj_repr)
+    assert re.match(
+        rb"type:\(collections.abc.Callable\[.{32}\]\)", obj_repr, flags=re.DOTALL
+    )
     assert obj_repr != join_bytes_repr(ty.Callable[[Path, int], ty.Tuple[float, bytes]])
 
 

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -8,7 +8,7 @@ from pydra import mark
 from ...engine.specs import File, LazyOutField
 from ..typing import TypeParser
 from pydra import Workflow
-from fileformats.serialization import Json
+from fileformats.application import Json
 from .utils import (
     generic_func_task,
     GenericShellTask,


### PR DESCRIPTION
- Bug fix (non-breaking change which fixes an issue)

## Summary
Handles the case of hashing a class with type args, typing special forms (e.g. Union, ty.Type) and classes that inherit from ty.Generic

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
