### PR TITLE
Typing bugfixes

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -652,7 +652,11 @@ def argstr_formatting(argstr, inputs, value_updates=None):
     for fld in inp_fields:
         fld_name = fld[1:-1]  # extracting the name form {field_name}
         fld_value = inputs_dict[fld_name]
-        if fld_value is attr.NOTHING:
+        fld_attr = getattr(attrs.fields(type(inputs)), fld_name)
+        if fld_value is attr.NOTHING or (
+            fld_value is False
+            and TypeParser.matches_type(fld_attr.type, ty.Union[Path, bool])
+        ):
             # if value is NOTHING, nothing should be added to the command
             val_dict[fld_name] = ""
         else:

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -261,7 +261,8 @@ def make_klass(spec):
                     type=tp,
                     **kwargs,
                 )
-            type_checker = TypeParser[newfield.type](newfield.type)
+            checker_label = f"'{name}' field of {spec.name}"
+            type_checker = TypeParser[newfield.type](newfield.type, label=checker_label)
             if newfield.type in (MultiInputObj, MultiInputFile):
                 converter = attr.converters.pipe(ensure_list, type_checker)
             elif newfield.type in (MultiOutputObj, MultiOutputFile):

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -163,9 +163,7 @@ def template_update_single(
                 f"type of '{field.name}' is Path, consider using Union[Path, bool]"
             )
         if inp_val_set is not attr.NOTHING and not isinstance(inp_val_set, LazyField):
-            inp_val_set = TypeParser(ty.Union.__getitem__(OUTPUT_TEMPLATE_TYPES))(
-                inp_val_set
-            )
+            inp_val_set = TypeParser(ty.Union[OUTPUT_TEMPLATE_TYPES])(inp_val_set)
     elif spec_type == "output":
         if not TypeParser.contains_type(FileSet, field.type):
             raise TypeError(

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -120,6 +120,7 @@ def template_update(inputs, output_dir, state_ind=None, map_copyfiles=None):
         field
         for field in attr_fields(inputs)
         if field.metadata.get("output_file_template")
+        and getattr(inputs, field.name) is not False
         and all(
             getattr(inputs, required_field) is not attr.NOTHING
             for required_field in field.metadata.get("requires", ())

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -450,7 +450,8 @@ class ShellOutSpec:
             input_value = getattr(inputs, fld.name, attr.NOTHING)
             if input_value is not attr.NOTHING:
                 if TypeParser.contains_type(FileSet, fld.type):
-                    input_value = TypeParser(fld.type).coerce(input_value)
+                    label = f"output field '{fld.name}' of {self}"
+                    input_value = TypeParser(fld.type, label=label).coerce(input_value)
                 additional_out[fld.name] = input_value
             elif (
                 fld.default is None or fld.default == attr.NOTHING

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -51,6 +51,7 @@ OUTPUT_TEMPLATE_TYPES = (
     ty.List[Path],
     ty.Union[Path, bool],
     ty.Union[ty.List[Path], bool],
+    ty.List[ty.List[Path]],
 )
 
 

--- a/pydra/engine/tests/test_helpers_file.py
+++ b/pydra/engine/tests/test_helpers_file.py
@@ -395,7 +395,7 @@ def test_output_template(tmp_path):
     task = MyCommand(in_file=filename)
     assert task.cmdline == f"my {filename}"
     task.inputs.optional = True
-    assert task.cmdline == f"my {filename} --opt {task.output_dir}/file.out"
+    assert task.cmdline == f"my {filename} --opt {task.output_dir / 'file.out'}"
     task.inputs.optional = False
     assert task.cmdline == f"my {filename}"
     task.inputs.optional = "custom-file-out.txt"

--- a/pydra/engine/tests/test_helpers_file.py
+++ b/pydra/engine/tests/test_helpers_file.py
@@ -2,6 +2,7 @@ import typing as ty
 import sys
 from pathlib import Path
 import attr
+from unittest.mock import Mock
 import pytest
 from fileformats.generic import File
 from ..specs import SpecInfo, ShellSpec
@@ -10,6 +11,7 @@ from ..helpers_file import (
     ensure_list,
     MountIndentifier,
     copy_nested_files,
+    template_update_single,
 )
 
 
@@ -398,3 +400,20 @@ def test_output_template(tmp_path):
     assert task.cmdline == f"my {filename}"
     task.inputs.optional = "custom-file-out.txt"
     assert task.cmdline == f"my {filename} --opt custom-file-out.txt"
+
+
+def test_template_formatting(tmp_path):
+    field = Mock()
+    field.name = "grad"
+    field.argstr = "--grad"
+    field.metadata = {"output_file_template": ("{in_file}.bvec", "{in_file}.bval")}
+    inputs = Mock()
+    inputs_dict = {"in_file": "/a/b/c/file.txt", "grad": True}
+
+    assert template_update_single(
+        field,
+        inputs,
+        inputs_dict_st=inputs_dict,
+        output_dir=tmp_path,
+        spec_type="input",
+    ) == [f"{tmp_path}/file.bvec", f"{tmp_path}/file.bval"]

--- a/pydra/engine/tests/test_helpers_file.py
+++ b/pydra/engine/tests/test_helpers_file.py
@@ -416,4 +416,4 @@ def test_template_formatting(tmp_path):
         inputs_dict_st=inputs_dict,
         output_dir=tmp_path,
         spec_type="input",
-    ) == [f"{tmp_path}/file.bvec", f"{tmp_path}/file.bval"]
+    ) == [str(tmp_path / "file.bvec"), str(tmp_path / "file.bval")]

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -597,3 +597,27 @@ def test_typing_cast(tmp_path, generic_task, specific_task):
     assert out_file.parent != in_file.parent
     assert type(out_file.header) is MyHeader
     assert out_file.header.parent != in_file.header.parent
+
+
+def test_type_is_subclass1():
+    assert TypeParser.is_subclass(ty.Type[File], type)
+
+
+def test_type_is_subclass2():
+    assert not TypeParser.is_subclass(ty.Type[File], ty.Type[Json])
+
+
+def test_type_is_subclass3():
+    assert TypeParser.is_subclass(ty.Type[Json], ty.Type[File])
+
+
+def test_type_is_instance1():
+    assert TypeParser.is_instance(File, ty.Type[File])
+
+
+def test_type_is_instance2():
+    assert not TypeParser.is_instance(File, ty.Type[Json])
+
+
+def test_type_is_instance3():
+    assert TypeParser.is_instance(Json, ty.Type[File])

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -621,3 +621,7 @@ def test_type_is_instance2():
 
 def test_type_is_instance3():
     assert TypeParser.is_instance(Json, ty.Type[File])
+
+
+def test_type_is_instance4():
+    assert TypeParser.is_instance(Json, type)

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -68,7 +68,7 @@ class TypeParser(ty.Generic[T]):
 
     COERCIBLE_DEFAULT: ty.Tuple[ty.Tuple[type, type], ...] = (
         (
-            (ty.Sequence, ty.Sequence),  # type: ignore
+            (ty.Sequence, ty.Sequence),
             (ty.Mapping, ty.Mapping),
             (Path, os.PathLike),
             (str, os.PathLike),

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -421,10 +421,10 @@ class TypeParser(ty.Generic[T]):
                 for arg in tp_args:
                     expand_and_check(arg, pattern_args[0])
                 return
-            elif tp_args[-1] is Ellipsis:
-                for pattern_arg in pattern_args:
-                    expand_and_check(tp_args[0], pattern_arg)
-                return
+            # elif tp_args[-1] is Ellipsis:
+            #     for pattern_arg in pattern_args:
+            #         expand_and_check(tp_args[0], pattern_arg)
+            #     return
             if len(tp_args) != len(pattern_args):
                 raise TypeError(
                     f"Wrong number of type arguments in tuple {tp_args}  compared to pattern "

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -189,18 +189,18 @@ class TypeParser(ty.Generic[T]):
                 obj_args = list(obj)
             except TypeError as e:
                 msg = (
-                    f" (part of coercion from {object_} to {self.pattern}"
+                    f" (part of coercion from {object_!r} to {self.pattern}"
                     if obj is not object_
                     else ""
                 )
                 raise TypeError(
-                    f"Could not coerce to {type_} as {obj} is not iterable{msg}"
+                    f"Could not coerce to {type_} as {obj!r} is not iterable{msg}"
                 ) from e
             if issubclass(origin, tuple):
                 return coerce_tuple(type_, obj_args, pattern_args)
             if issubclass(origin, ty.Iterable):
                 return coerce_sequence(type_, obj_args, pattern_args)
-            assert False, f"Coercion from {obj} to {pattern} is not handled"
+            assert False, f"Coercion from {obj!r} to {pattern} is not handled"
 
         def coerce_basic(obj, pattern):
             """Coerce an object to a "basic types" like `int`, `float`, `bool`, `Path`

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -11,6 +11,7 @@ from ..engine.specs import (
     MultiInputObj,
     MultiOutputObj,
 )
+from fileformats import field
 
 try:
     from typing import get_origin, get_args
@@ -62,15 +63,28 @@ class TypeParser(ty.Generic[T]):
     not_coercible: ty.List[ty.Tuple[TypeOrAny, TypeOrAny]]
 
     COERCIBLE_DEFAULT: ty.Tuple[ty.Tuple[type, type], ...] = (
-        (ty.Sequence, ty.Sequence),  # type: ignore
-        (ty.Mapping, ty.Mapping),
-        (Path, os.PathLike),
-        (str, os.PathLike),
-        (os.PathLike, Path),
-        (os.PathLike, str),
-        (ty.Any, MultiInputObj),
-        (int, float),
+        (
+            (ty.Sequence, ty.Sequence),  # type: ignore
+            (ty.Mapping, ty.Mapping),
+            (Path, os.PathLike),
+            (str, os.PathLike),
+            (os.PathLike, Path),
+            (os.PathLike, str),
+            (ty.Any, MultiInputObj),
+            (int, float),
+            (field.Integer, float),
+            (int, field.Decimal),
+        )
+        + tuple(
+            (f, f.primitive)
+            for f in (field.Integer, field.Decimal, field.Boolean, field.Text)
+        )
+        + tuple(
+            (f.primitive, f)
+            for f in (field.Integer, field.Decimal, field.Boolean, field.Text)
+        )
     )
+
     if HAVE_NUMPY:
         COERCIBLE_DEFAULT += (
             (numpy.integer, int),

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -421,10 +421,6 @@ class TypeParser(ty.Generic[T]):
                 for arg in tp_args:
                     expand_and_check(arg, pattern_args[0])
                 return
-            # elif tp_args[-1] is Ellipsis:
-            #     for pattern_arg in pattern_args:
-            #         expand_and_check(tp_args[0], pattern_arg)
-            #     return
             if len(tp_args) != len(pattern_args):
                 raise TypeError(
                     f"Wrong number of type arguments in tuple {tp_args}  compared to pattern "

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -421,6 +421,10 @@ class TypeParser(ty.Generic[T]):
                 for arg in tp_args:
                     expand_and_check(arg, pattern_args[0])
                 return
+            elif tp_args[-1] is Ellipsis:
+                for pattern_arg in pattern_args:
+                    expand_and_check(tp_args[0], pattern_arg)
+                return
             if len(tp_args) != len(pattern_args):
                 raise TypeError(
                     f"Wrong number of type arguments in tuple {tp_args}  compared to pattern "

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -75,14 +75,8 @@ class TypeParser(ty.Generic[T]):
             (field.Integer, float),
             (int, field.Decimal),
         )
-        + tuple(
-            (f, f.primitive)
-            for f in (field.Integer, field.Decimal, field.Boolean, field.Text)
-        )
-        + tuple(
-            (f.primitive, f)
-            for f in (field.Integer, field.Decimal, field.Boolean, field.Text)
-        )
+        + tuple((f, f.primitive) for f in field.Singular.subclasses() if f.primitive)
+        + tuple((f.primitive, f) for f in field.Singular.subclasses() if f.primitive)
     )
 
     if HAVE_NUMPY:

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -56,11 +56,15 @@ class TypeParser(ty.Generic[T]):
         the tree of more complex nested container types. Overrides 'coercible' to enable
         you to carve out exceptions, such as TypeParser(list, coercible=[(ty.Iterable, list)],
         not_coercible=[(str, list)])
+    label : str
+        the label to be used to identify the type parser in error messages. Especially
+        useful when TypeParser is used as a converter in attrs.fields
     """
 
     tp: ty.Type[T]
     coercible: ty.List[ty.Tuple[TypeOrAny, TypeOrAny]]
     not_coercible: ty.List[ty.Tuple[TypeOrAny, TypeOrAny]]
+    label: str
 
     COERCIBLE_DEFAULT: ty.Tuple[ty.Tuple[type, type], ...] = (
         (
@@ -103,6 +107,7 @@ class TypeParser(ty.Generic[T]):
         not_coercible: ty.Optional[
             ty.Iterable[ty.Tuple[TypeOrAny, TypeOrAny]]
         ] = NOT_COERCIBLE_DEFAULT,
+        label: str = "",
     ):
         def expand_pattern(t):
             """Recursively expand the type arguments of the target type in nested tuples"""
@@ -118,10 +123,12 @@ class TypeParser(ty.Generic[T]):
                 return origin
             if origin not in (ty.Union, type) and not issubclass(origin, ty.Iterable):
                 raise TypeError(
-                    f"TypeParser doesn't know how to handle args ({args}) for {origin} types"
+                    f"TypeParser doesn't know how to handle args ({args}) for {origin} "
+                    f"types{self.label_str}"
                 )
             return (origin, [expand_pattern(a) for a in args])
 
+        self.label = label
         self.tp = tp
         self.coercible = (
             list(coercible) if coercible is not None else [(ty.Any, ty.Any)]
@@ -194,7 +201,7 @@ class TypeParser(ty.Generic[T]):
                     else ""
                 )
                 raise TypeError(
-                    f"Could not coerce to {type_} as {obj!r} is not iterable{msg}"
+                    f"Could not coerce to {type_} as {obj!r} is not iterable{msg}{self.label_str}"
                 ) from e
             if issubclass(origin, tuple):
                 return coerce_tuple(type_, obj_args, pattern_args)
@@ -221,7 +228,8 @@ class TypeParser(ty.Generic[T]):
                 except TypeError as e:
                     reasons.append(e)
             raise TypeError(
-                f"Could not coerce object, {obj!r}, to any of the union types {pattern_args}:\n\n"
+                f"Could not coerce object, {obj!r}, to any of the union types "
+                f"{pattern_args}{self.label_str}:\n\n"
                 + "\n\n".join(f"{a} -> {e}" for a, e in zip(pattern_args, reasons))
             )
 
@@ -240,7 +248,7 @@ class TypeParser(ty.Generic[T]):
                     else ""
                 )
                 raise TypeError(
-                    f"Could not coerce to {type_} as {obj} is not a mapping type{msg}"
+                    f"Could not coerce to {type_} as {obj} is not a mapping type{msg}{self.label_str}"
                 ) from e
             return coerce_obj(
                 {
@@ -263,7 +271,7 @@ class TypeParser(ty.Generic[T]):
             elif len(pattern_args) != len(obj_args):
                 raise TypeError(
                     f"Incorrect number of items in tuple, expected "
-                    f"{len(pattern_args)}, got {len(obj_args)}"
+                    f"{len(pattern_args)}, got {len(obj_args)}{self.label_str}"
                 )
             return coerce_obj(
                 [expand_and_coerce(o, p) for o, p in zip(obj_args, pattern_args)], type_
@@ -281,7 +289,7 @@ class TypeParser(ty.Generic[T]):
         def coerce_type(type_: ty.Type[ty.Any], pattern_args: ty.List[ty.Type[ty.Any]]):
             if not any(issubclass(type_, t) for t in pattern_args):
                 raise TypeError(
-                    f"{type_} is not one of the specified types {pattern_args}"
+                    f"{type_} is not one of the specified types {pattern_args}{self.label_str}"
                 )
             return type_
 
@@ -297,7 +305,9 @@ class TypeParser(ty.Generic[T]):
                     if obj is not object_
                     else ""
                 )
-                raise TypeError(f"Cannot coerce {obj!r} into {type_}{msg}") from e
+                raise TypeError(
+                    f"Cannot coerce {obj!r} into {type_}{msg}{self.label_str}"
+                ) from e
 
         return expand_and_coerce(object_, self.pattern)
 
@@ -323,7 +333,7 @@ class TypeParser(ty.Generic[T]):
                 raise TypeError("Splits without any type arguments are invalid")
             if len(args) > 1:
                 raise TypeError(
-                    f"Splits with more than one type argument ({args}) are invalid"
+                    f"Splits with more than one type argument ({args}) are invalid{self.label_str}"
                 )
             return self.check_type(args[0])
 
@@ -343,7 +353,7 @@ class TypeParser(ty.Generic[T]):
                     )
                 raise TypeError(
                     f"{tp} doesn't match pattern {pattern}, when matching {type_} to "
-                    f"{self.pattern}"
+                    f"{self.pattern}{self.label_str}"
                 )
             tp_args = get_args(tp)
             self.check_coercible(tp_origin, pattern_origin)
@@ -378,7 +388,7 @@ class TypeParser(ty.Generic[T]):
                     if reasons:
                         raise TypeError(
                             f"Cannot coerce {tp} to "
-                            f"ty.Union[{', '.join(str(a) for a in pattern_args)}], "
+                            f"ty.Union[{', '.join(str(a) for a in pattern_args)}]{self.label_str}, "
                             f"because {tp_arg} cannot be coerced to any of its args:\n\n"
                             + "\n\n".join(
                                 f"{a} -> {e}" for a, e in zip(pattern_args, reasons)
@@ -414,7 +424,7 @@ class TypeParser(ty.Generic[T]):
             if len(tp_args) != len(pattern_args):
                 raise TypeError(
                     f"Wrong number of type arguments in tuple {tp_args}  compared to pattern "
-                    f"{pattern_args} in attempting to match {type_} to {self.pattern}"
+                    f"{pattern_args} in attempting to match {type_} to {self.pattern}{self.label_str}"
                 )
             for t, p in zip(tp_args, pattern_args):
                 expand_and_check(t, p)
@@ -426,7 +436,8 @@ class TypeParser(ty.Generic[T]):
                 if not tp_args:
                     raise TypeError(
                         "Generic ellipsis type arguments not specific enough to match "
-                        f"{pattern_args} in attempting to match {type_} to {self.pattern}"
+                        f"{pattern_args} in attempting to match {type_} to "
+                        f"{self.pattern}{self.label_str}"
                     )
             for arg in tp_args:
                 expand_and_check(arg, pattern_args[0])
@@ -476,8 +487,8 @@ class TypeParser(ty.Generic[T]):
 
         if not matches_criteria(self.coercible):
             raise TypeError(
-                f"Cannot coerce {repr(source)} into {target} as the coercion doesn't match "
-                f"any of the explicit inclusion criteria: "
+                f"Cannot coerce {repr(source)} into {target}{self.label_str} as the "
+                "coercion doesn't match any of the explicit inclusion criteria: "
                 + ", ".join(
                     f"{type_name(s)} -> {type_name(t)}" for s, t in self.coercible
                 )
@@ -485,7 +496,7 @@ class TypeParser(ty.Generic[T]):
         matches_not_coercible = matches_criteria(self.not_coercible)
         if matches_not_coercible:
             raise TypeError(
-                f"Cannot coerce {repr(source)} into {target} as it is explicitly "
+                f"Cannot coerce {repr(source)} into {target}{self.label_str} as it is explicitly "
                 "excluded by the following coercion criteria: "
                 + ", ".join(
                     f"{type_name(s)} -> {type_name(t)}"
@@ -798,6 +809,10 @@ class TypeParser(ty.Generic[T]):
             type_ = cls.get_item_type(type_)
             depth += 1
         return type_, depth
+
+    @property
+    def label_str(self):
+        return f" in {self.label} " if self.label else ""
 
     get_origin = staticmethod(get_origin)
     get_args = staticmethod(get_args)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
- Fixes up the handling of typing of inputs with `output_file_template` defined
- Allows `output_file_template` to define tuple/list templates for options with multiple files paths (e.g. mrconvert --export_grad_fsl BVEC BVAL)
- More descriptive messages on typing errors: task and field provided along with type mismatch
- Adds fileformats.field types to default coercions, e.g. fileformats.field.Integer -> int and vice versa

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
