### PR TITLE
Omit false output templates

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -652,7 +652,11 @@ def argstr_formatting(argstr, inputs, value_updates=None):
     for fld in inp_fields:
         fld_name = fld[1:-1]  # extracting the name form {field_name}
         fld_value = inputs_dict[fld_name]
-        if fld_value is attr.NOTHING:
+        fld_attr = getattr(attrs.fields(type(inputs)), fld_name)
+        if fld_value is attr.NOTHING or (
+            fld_value is False
+            and TypeParser.matches_type(fld_attr.type, ty.Union[Path, bool])
+        ):
             # if value is NOTHING, nothing should be added to the command
             val_dict[fld_name] = ""
         else:

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -120,6 +120,7 @@ def template_update(inputs, output_dir, state_ind=None, map_copyfiles=None):
         field
         for field in attr_fields(inputs)
         if field.metadata.get("output_file_template")
+        and getattr(inputs, field.name) is not False
         and all(
             getattr(inputs, required_field) is not attr.NOTHING
             for required_field in field.metadata.get("requires", ())


### PR DESCRIPTION
## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Summary

Optional output fields with `output_file_template`  metadata (i.e. of type=`ty.Union[Path, bool]`) were getting printed to the command line regardless of whether a value for the field was set to False.

## Checklist
- [x] I have added tests to cover my changes (if necessary)
