### PR TITLE
Permit superclass to subclass lazy typing

### DIFF
--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -263,7 +263,9 @@ def make_klass(spec):
                     **kwargs,
                 )
             checker_label = f"'{name}' field of {spec.name}"
-            type_checker = TypeParser[newfield.type](newfield.type, label=checker_label)
+            type_checker = TypeParser[newfield.type](
+                newfield.type, label=checker_label, allow_lazy_super=True
+            )
             if newfield.type in (MultiInputObj, MultiInputFile):
                 converter = attr.converters.pipe(ensure_list, type_checker)
             elif newfield.type in (MultiOutputObj, MultiOutputFile):

--- a/pydra/engine/helpers.py
+++ b/pydra/engine/helpers.py
@@ -264,7 +264,7 @@ def make_klass(spec):
                 )
             checker_label = f"'{name}' field of {spec.name}"
             type_checker = TypeParser[newfield.type](
-                newfield.type, label=checker_label, allow_lazy_super=True
+                newfield.type, label=checker_label, superclass_auto_cast=True
             )
             if newfield.type in (MultiInputObj, MultiInputFile):
                 converter = attr.converters.pipe(ensure_list, type_checker)

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -445,7 +445,7 @@ class ShellOutSpec:
                 ),
             ):
                 raise TypeError(
-                    f"Support for {fld.type} type, required for {fld.name} in {self}, "
+                    f"Support for {fld.type} type, required for '{fld.name}' in {self}, "
                     "has not been implemented in collect_additional_output"
                 )
             # assuming that field should have either default or metadata, but not both

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -133,21 +133,7 @@ def test_task_init_3a(
 
 
 def test_task_init_4():
-    """task with interface and inputs. splitter set using split method"""
-    nn = fun_addtwo(name="NA")
-    nn.split(splitter="a", a=[3, 5])
-    assert np.allclose(nn.inputs.a, [3, 5])
-
-    assert nn.state.splitter == "NA.a"
-    assert nn.state.splitter_rpn == ["NA.a"]
-
-    nn.state.prepare_states(nn.inputs)
-    assert nn.state.states_ind == [{"NA.a": 0}, {"NA.a": 1}]
-    assert nn.state.states_val == [{"NA.a": 3}, {"NA.a": 5}]
-
-
-def test_task_init_4a():
-    """task with a splitter and inputs set in the split method"""
+    """task with interface splitter and inputs set in the split method"""
     nn = fun_addtwo(name="NA")
     nn.split(splitter="a", a=[3, 5])
     assert np.allclose(nn.inputs.a, [3, 5])

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -8,7 +8,7 @@ from pydra import mark
 from ...engine.specs import File, LazyOutField
 from ..typing import TypeParser
 from pydra import Workflow
-from fileformats.application import Json
+from fileformats.application import Json, Yaml, Xml
 from .utils import (
     generic_func_task,
     GenericShellTask,
@@ -609,6 +609,14 @@ def test_type_is_subclass2():
 
 def test_type_is_subclass3():
     assert TypeParser.is_subclass(ty.Type[Json], ty.Type[File])
+
+
+def test_type_is_subclass4():
+    assert TypeParser.is_subclass(ty.Union[Json, Yaml], ty.Union[Json, Yaml, Xml])
+
+
+def test_type_is_subclass5():
+    assert not TypeParser.is_subclass(ty.Union[Json, Yaml, Xml], ty.Union[Json, Yaml])
 
 
 def test_type_is_instance1():

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -611,12 +611,32 @@ def test_type_is_subclass3():
     assert TypeParser.is_subclass(ty.Type[Json], ty.Type[File])
 
 
-def test_type_is_subclass4():
+def test_union_is_subclass1():
     assert TypeParser.is_subclass(ty.Union[Json, Yaml], ty.Union[Json, Yaml, Xml])
 
 
-def test_type_is_subclass5():
+def test_union_is_subclass2():
     assert not TypeParser.is_subclass(ty.Union[Json, Yaml, Xml], ty.Union[Json, Yaml])
+
+
+def test_union_is_subclass3():
+    assert TypeParser.is_subclass(Json, ty.Union[Json, Yaml])
+
+
+def test_union_is_subclass4():
+    assert not TypeParser.is_subclass(ty.Union[Json, Yaml], Json)
+
+
+def test_generic_is_subclass1():
+    assert TypeParser.is_subclass(ty.List[int], list)
+
+
+def test_generic_is_subclass2():
+    assert not TypeParser.is_subclass(list, ty.List[int])
+
+
+def test_generic_is_subclass3():
+    assert not TypeParser.is_subclass(ty.List[float], ty.List[int])
 
 
 def test_type_is_instance1():

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -718,7 +718,9 @@ def test_generic_is_subclass3():
     assert not TypeParser.is_subclass(ty.List[float], ty.List[int])
 
 
-@pytest.mark.skipIf(sys.version_info.minor < 9, "Cannot subscript tuple in < Py3.9")
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Cannot subscript tuple in < Py3.9"
+)
 def test_generic_is_subclass4():
     class MyTuple(tuple):
         pass

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -523,7 +523,7 @@ def test_matches_type_tuple_ellipsis3():
 
 
 def test_matches_type_tuple_ellipsis4():
-    assert not TypeParser.matches_type(ty.Tuple[int, ...], ty.Tuple[int])
+    assert TypeParser.matches_type(ty.Tuple[int, ...], ty.Tuple[int])
 
 
 def test_matches_type_tuple_ellipsis5():

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -163,7 +163,7 @@ def test_type_check_nested8():
     with pytest.raises(TypeError, match="explicitly excluded"):
         TypeParser(
             ty.Tuple[int, ...],
-            not_coercible=[(ty.Sequence, ty.Tuple), (ty.Sequence, ty.List)],
+            not_coercible=[(ty.Sequence, ty.Tuple)],
         )(lz(ty.List[float]))
 
 

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -717,6 +717,32 @@ def test_generic_is_subclass3():
     assert not TypeParser.is_subclass(ty.List[float], ty.List[int])
 
 
+def test_generic_is_subclass4():
+    class MyTuple(tuple):
+        pass
+
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    assert TypeParser.is_subclass(MyTuple[A], ty.Tuple[A])
+    assert TypeParser.is_subclass(ty.Tuple[B], ty.Tuple[A])
+    assert TypeParser.is_subclass(MyTuple[B], ty.Tuple[A])
+    assert not TypeParser.is_subclass(ty.Tuple[A], ty.Tuple[B])
+    assert not TypeParser.is_subclass(ty.Tuple[A], MyTuple[A])
+    assert not TypeParser.is_subclass(MyTuple[A], ty.Tuple[B])
+    assert TypeParser.is_subclass(MyTuple[A, int], ty.Tuple[A, int])
+    assert TypeParser.is_subclass(ty.Tuple[B, int], ty.Tuple[A, int])
+    assert TypeParser.is_subclass(MyTuple[B, int], ty.Tuple[A, int])
+    assert TypeParser.is_subclass(MyTuple[int, B], ty.Tuple[int, A])
+    assert not TypeParser.is_subclass(MyTuple[B, int], ty.Tuple[int, A])
+    assert not TypeParser.is_subclass(MyTuple[int, B], ty.Tuple[A, int])
+    assert not TypeParser.is_subclass(MyTuple[B, int], ty.Tuple[A])
+    assert not TypeParser.is_subclass(MyTuple[B], ty.Tuple[A, int])
+
+
 def test_type_is_instance1():
     assert TypeParser.is_instance(File, ty.Type[File])
 

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -160,8 +160,20 @@ def test_type_check_nested8():
     with pytest.raises(TypeError, match="explicitly excluded"):
         TypeParser(
             ty.Tuple[int, ...],
-            not_coercible=[(ty.Sequence, ty.Tuple)],
+            not_coercible=[(ty.Sequence, ty.Tuple), (ty.Sequence, ty.List)],
         )(lz(ty.List[float]))
+
+
+def test_type_check_permit_superclass():
+    # Typical case as Json is subclass of File
+    TypeParser(ty.List[File])(lz(ty.List[Json]))
+    # Permissive super class, as File is superclass of Json
+    TypeParser(ty.List[Json], allow_lazy_super=True)(lz(ty.List[File]))
+    with pytest.raises(TypeError, match="Cannot coerce"):
+        TypeParser(ty.List[Json], allow_lazy_super=False)(lz(ty.List[File]))
+    # Fails because Yaml is neither sub or super class of Json
+    with pytest.raises(TypeError, match="Cannot coerce"):
+        TypeParser(ty.List[Json], allow_lazy_super=True)(lz(ty.List[Yaml]))
 
 
 def test_type_check_fail1():

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -156,8 +156,12 @@ def test_type_check_nested6():
 
 
 def test_type_check_nested7():
+    TypeParser(ty.Tuple[float, float, float])(lz(ty.List[int]))
+
+
+def test_type_check_nested7a():
     with pytest.raises(TypeError, match="Wrong number of type arguments"):
-        TypeParser(ty.Tuple[float, float, float])(lz(ty.List[int]))
+        TypeParser(ty.Tuple[float, float, float])(lz(ty.Tuple[int]))
 
 
 def test_type_check_nested8():
@@ -506,14 +510,29 @@ def test_matches_type_tuple():
     assert not TypeParser.matches_type(ty.Tuple[int], ty.Tuple[int, int])
 
 
-def test_matches_type_tuple_ellipsis():
+def test_matches_type_tuple_ellipsis1():
     assert TypeParser.matches_type(ty.Tuple[int], ty.Tuple[int, ...])
+
+
+def test_matches_type_tuple_ellipsis2():
     assert TypeParser.matches_type(ty.Tuple[int, int], ty.Tuple[int, ...])
+
+
+def test_matches_type_tuple_ellipsis3():
     assert not TypeParser.matches_type(ty.Tuple[int, float], ty.Tuple[int, ...])
+
+
+def test_matches_type_tuple_ellipsis4():
     assert not TypeParser.matches_type(ty.Tuple[int, ...], ty.Tuple[int])
+
+
+def test_matches_type_tuple_ellipsis5():
     assert TypeParser.matches_type(
         ty.Tuple[int], ty.List[int], coercible=[(tuple, list)]
     )
+
+
+def test_matches_type_tuple_ellipsis6():
     assert TypeParser.matches_type(
         ty.Tuple[int, ...], ty.List[int], coercible=[(tuple, list)]
     )

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -1,5 +1,6 @@
 import os
 import itertools
+import sys
 import typing as ty
 from pathlib import Path
 import tempfile
@@ -717,6 +718,7 @@ def test_generic_is_subclass3():
     assert not TypeParser.is_subclass(ty.List[float], ty.List[int])
 
 
+@pytest.mark.skipIf(sys.version_info.minor < 9, "Cannot subscript tuple in < Py3.9")
 def test_generic_is_subclass4():
     class MyTuple(tuple):
         pass

--- a/pydra/utils/tests/utils.py
+++ b/pydra/utils/tests/utils.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-import typing as ty
 from fileformats.generic import File
 from fileformats.core.mixin import WithSeparateHeader, WithMagicNumber
 from pydra import mark
@@ -24,28 +22,6 @@ class MyOtherFormatX(WithMagicNumber, WithSeparateHeader, File):
     magic_number = b"MYFORMAT"
     ext = ".my"
     header_type = MyHeader
-
-
-@File.generate_sample_data.register
-def my_format_x_generate_sample_data(
-    my_format_x: MyFormatX, dest_dir: Path
-) -> ty.List[Path]:
-    fspath = dest_dir / "file.my"
-    with open(fspath, "wb") as f:
-        f.write(b"MYFORMAT\nsome data goes here")
-    header_fspath = dest_dir / "file.hdr"
-    header_fspath.write_text("a: 1\nb: 2\nc: 3\n")
-    return [fspath, header_fspath]
-
-
-@File.generate_sample_data.register
-def my_other_format_generate_sample_data(
-    my_other_format: MyOtherFormatX, dest_dir: Path
-) -> ty.List[Path]:
-    fspath = dest_dir / "file.my"
-    with open(fspath, "wb") as f:
-        f.write(b"MYFORMAT\nsome data goes here")
-    return [fspath]
 
 
 @mark.task

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -449,6 +449,10 @@ class TypeParser(ty.Generic[T]):
                 for arg in tp_args:
                     expand_and_check(arg, pattern_args[0])
                 return
+            elif tp_args[-1] is Ellipsis:
+                for pattern_arg in pattern_args:
+                    expand_and_check(tp_args[0], pattern_arg)
+                return
             if len(tp_args) != len(pattern_args):
                 raise TypeError(
                     f"Wrong number of type arguments in tuple {tp_args}  compared to pattern "

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -649,7 +649,7 @@ class TypeParser(ty.Generic[T]):
                     else:
                         candidate_args = [candidate]
                     return all(
-                        any(cls.is_subclass(a, c) for a in args) for c in candidate_args
+                        any(cls.is_subclass(a, c) for c in candidate_args) for a in args
                     )
                 if origin is not None:
                     klass = origin


### PR DESCRIPTION
## Types of changes
- Enhancement

## Summary
Relaxes typing of lazy fields to allow super-classes to be passed to sub-class fields. Implements #682

## Checklist

- [x] I have added tests to cover my changes (if necessary)

