### PR TITLE
Hash change guards

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -281,9 +281,9 @@ class TaskBase:
 
         """
         if is_workflow(self) and self.inputs._graph_checksums is attr.NOTHING:
-            self.inputs._graph_checksums = [
-                (nd.name, nd.checksum) for nd in self.graph_sorted
-            ]
+            self.inputs._graph_checksums = {
+                nd.name: nd.checksum for nd in self.graph_sorted
+            }
 
         if state_index is not None:
             inputs_copy = copy(self.inputs)
@@ -1142,9 +1142,9 @@ class Workflow(TaskBase):
         """
         # if checksum is called before run the _graph_checksums is not ready
         if is_workflow(self) and self.inputs._graph_checksums is attr.NOTHING:
-            self.inputs._graph_checksums = [
-                (nd.name, nd.checksum) for nd in self.graph_sorted
-            ]
+            self.inputs._graph_checksums = {
+                nd.name: nd.checksum for nd in self.graph_sorted
+            }
 
         input_hash = self.inputs.hash
         if not self.state:

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -915,6 +915,13 @@ class TaskBase:
                 f"Input field hashes have changed during the execution of the "
                 f"'{self.name}' {type(self).__name__}.\n{details}"
             )
+        logger.debug(
+            "Input values and hashes for '%s' %s node:\n%s\n%s",
+            self.name,
+            type(self).__name__,
+            self.inputs,
+            self.inputs._hashes,
+        )
 
     SUPPORTED_COPY_MODES = FileSet.CopyMode.any
     DEFAULT_COPY_COLLATION = FileSet.CopyCollation.any

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -1266,6 +1266,15 @@ class Workflow(TaskBase):
                 (self.cache_dir / f"{self.uid}_info.json").unlink()
                 os.chdir(cwd)
         self.hooks.post_run(self, result)
+        # Check for any changes to the input hashes that have occurred during the execution
+        # of the task
+        hash_changes = self.inputs.hash_changes()
+        if hash_changes:
+            raise RuntimeError(
+                f"Hashes have changed for {hash_changes} input fields during the "
+                f"execution of {self} workflow. Please check all output files/directories are "
+                "typed with `pathlib.Path` instead of `fileformats` classes"
+            )
         if result is None:
             raise Exception("This should never happen, please open new issue")
         return result

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -9,7 +9,7 @@ import os
 import sys
 from pathlib import Path
 import typing as ty
-from copy import deepcopy
+from copy import deepcopy, copy
 from uuid import uuid4
 from filelock import SoftFileLock
 import shutil
@@ -286,10 +286,10 @@ class TaskBase:
             ]
 
         if state_index is not None:
-            inputs_copy = deepcopy(self.inputs)
+            inputs_copy = copy(self.inputs)
             for key, ind in self.state.inputs_ind[state_index].items():
                 val = self._extract_input_el(
-                    inputs=inputs_copy, inp_nm=key.split(".")[1], ind=ind
+                    inputs=self.inputs, inp_nm=key.split(".")[1], ind=ind
                 )
                 setattr(inputs_copy, key.split(".")[1], val)
             # setting files_hash again in case it was cleaned by setting specific element

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -1301,8 +1301,6 @@ class Workflow(TaskBase):
         # Check for any changes to the input hashes that have occurred during the execution
         # of the task
         self._check_for_hash_changes()
-        if result is None:
-            raise Exception("This should never happen, please open new issue")
         return result
 
     async def _run_task(self, submitter, rerun=False):

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -896,12 +896,13 @@ class TaskBase:
             field = getattr(attr.fields(type(self.inputs)), changed)
             if issubclass(field.type, FileSet):
                 details += (
-                    f"- '{changed}' field is of type {field.type}. If it is intended to "
-                    "contain output data then the type of the field it should be changed to "
-                    "`pathlib.Path`. Otherwise, if it is an input field that gets "
-                    "altered by the task, the 'copyfile' flag should be set to 'copy' "
-                    "in the task interface metadata to ensure a copy of "
-                    "the files/directories are created before the task is run\n"
+                    f"- '{changed}' field is of file-type {field.type}. If it "
+                    "is intended to contain output data then the type of the field in "
+                    "the interface class should be changed to `pathlib.Path`. Otherwise, "
+                    "if the field is intended to be an input field but it gets altered by "
+                    "the task in some way, then the 'copyfile' flag should be set to "
+                    "'copy' in the field metadata of the task interface class so copies of "
+                    "the files/directories in it are passed to the task instead\n"
                 )
             else:
                 details += (

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -281,7 +281,9 @@ class TaskBase:
 
         """
         if is_workflow(self) and self.inputs._graph_checksums is attr.NOTHING:
-            self.inputs._graph_checksums = [nd.checksum for nd in self.graph_sorted]
+            self.inputs._graph_checksums = [
+                (nd.name, nd.checksum) for nd in self.graph_sorted
+            ]
 
         if state_index is not None:
             inputs_copy = deepcopy(self.inputs)
@@ -1086,7 +1088,9 @@ class Workflow(TaskBase):
         """
         # if checksum is called before run the _graph_checksums is not ready
         if is_workflow(self) and self.inputs._graph_checksums is attr.NOTHING:
-            self.inputs._graph_checksums = [nd.checksum for nd in self.graph_sorted]
+            self.inputs._graph_checksums = [
+                (nd.name, nd.checksum) for nd in self.graph_sorted
+            ]
 
         input_hash = self.inputs.hash
         if not self.state:

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -556,10 +556,9 @@ class TaskBase:
                     if not field_name.startswith("_"):
                         setattr(self.inputs, field_name, field_value)
                 os.chdir(cwd)
+        self.hooks.post_run(self, result)
         # Check for any changes to the input hashes that have occurred during the execution
         # of the task
-
-        self.hooks.post_run(self, result)
         self._check_for_hash_changes()
         return result
 

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -909,7 +909,7 @@ class TaskBase:
                     f"- the {field.type} object passed to '{changed}' field appears to "
                     f"have an unstable hash. The {field.type}.__bytes_repr__() method "
                     "can be implemented to provide stable hashes for this type. "
-                    "See pydra/utils.hash.py for examples.\n"
+                    "See pydra/utils/hash.py for examples.\n"
                 )
         if hash_changes:
             raise RuntimeError(

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -985,8 +985,21 @@ class LazyOutField(LazyField[T]):
         if result is None:
             raise RuntimeError(
                 f"Could not find results of '{node.name}' node in a sub-directory "
-                f"named '{node.checksum}' in any of the cache locations:\n"
+                f"named '{node.checksum}' in any of the cache locations.\n"
                 + "\n".join(str(p) for p in set(node.cache_locations))
+                + f"\n\nThis is likely due to hash changes in '{self.name}' node inputs. "
+                f"Current values and hashes: {self.inputs}, "
+                f"{self.inputs._hashes}\n\n"
+                "Set loglevel to 'debug' in order to track hash changes "
+                "throughout the execution of the workflow.\n\n "
+                "These issues may have been caused by `bytes_repr()` methods "
+                "that don't return stable hash values for specific object "
+                "types across multiple processes (see bytes_repr() "
+                '"singledispatch "function in pydra/utils/hash.py).'
+                "You may need to implement a specific `bytes_repr()` "
+                '"singledispatch overload"s or `__bytes_repr__()` '
+                "dunder methods to handle one or more types in "
+                "your interface inputs."
             )
         _, split_depth = TypeParser.strip_splits(self.type)
 

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -216,6 +216,7 @@ class Submitter:
                                 "You may need to implement a specific `bytes_repr()` "
                                 '"singledispatch overload"s or `__bytes_repr__()` '
                                 "dunder methods to handle one or more types in "
+                                "your interface inputs."
                             )
                         raise RuntimeError(msg)
             for task in tasks:

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -192,7 +192,11 @@ class Submitter:
                             msg += f"- '{task.name}' node blocked due to\n"
                             for pred in waiting_on:
                                 if pred.checksum != graph_checksums[pred.name]:
-                                    msg += f"    - hash changes in '{pred.name}' node inputs\n"
+                                    msg += (
+                                        f"    - hash changes in '{pred.name}' node inputs. "
+                                        f"Current values and hashes: {pred.inputs}, "
+                                        f"{pred.inputs._hashes}\n"
+                                    )
                                 elif pred not in outstanding:
                                     msg += (
                                         f"    - undiagnosed issues in '{pred.name}' node "

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -199,6 +199,7 @@ class Submitter:
                                         "(potentially related to the file-system)"
                                     )
                             msg += "\n"
+                        msg += "Set loglevel to 'debug' in order to track hash changes"
                         raise RuntimeError(msg)
             for task in tasks:
                 # grab inputs if needed

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -184,7 +184,6 @@ class Submitter:
                             ]
                             for t in graph_copy.sorted_nodes
                         }
-                        graph_checksums = dict(wf.inputs._graph_checksums)
 
                         hashes_have_changed = False
                         for task, waiting_on in outstanding.items():
@@ -192,7 +191,10 @@ class Submitter:
                                 continue
                             msg += f"- '{task.name}' node blocked due to\n"
                             for pred in waiting_on:
-                                if pred.checksum != graph_checksums[pred.name]:
+                                if (
+                                    pred.checksum
+                                    != wf.inputs._graph_checksums[pred.name]
+                                ):
                                     msg += (
                                         f"    - hash changes in '{pred.name}' node inputs. "
                                         f"Current values and hashes: {pred.inputs}, "

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -337,8 +337,8 @@ class ShellCommandTask(TaskBase):
             raise NotImplementedError
 
         modified_inputs = template_update(self.inputs, output_dir=self.output_dir)
-        if modified_inputs is not None:
-            self.inputs = attr.evolve(self.inputs, **modified_inputs)
+        for field_name, field_value in modified_inputs.items():
+            setattr(self.inputs, field_name, field_value)
 
         pos_args = []  # list for (position, command arg)
         self._positions_provided = []

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -25,7 +25,7 @@ import pytest
 
 def test_basespec():
     spec = BaseSpec()
-    assert spec.hash == "06fe829a5dca34cc5f0710b454c24808"
+    assert spec.hash == "0b1d98df22ecd1733562711c205abca2"
 
 
 def test_runtime():
@@ -132,14 +132,14 @@ def test_input_file_hash_1(tmp_path):
     fields = [("in_file", ty.Any)]
     input_spec = SpecInfo(name="Inputs", fields=fields, bases=(BaseSpec,))
     inputs = make_klass(input_spec)
-    assert inputs(in_file=outfile).hash == "02e248cb7ca3628af6b97aa27723b623"
+    assert inputs(in_file=outfile).hash == "9a106eb2830850834d9b5bf098d5fa85"
 
     with open(outfile, "w") as fp:
         fp.write("test")
     fields = [("in_file", File)]
     input_spec = SpecInfo(name="Inputs", fields=fields, bases=(BaseSpec,))
     inputs = make_klass(input_spec)
-    assert inputs(in_file=outfile).hash == "c1156e9576b0266f23c30771bf59482a"
+    assert inputs(in_file=outfile).hash == "0e9306e5cae1de1b4dff1f27cca03bce"
 
 
 def test_input_file_hash_2(tmp_path):
@@ -153,7 +153,7 @@ def test_input_file_hash_2(tmp_path):
 
     # checking specific hash value
     hash1 = inputs(in_file=file).hash
-    assert hash1 == "73745b60b45052d6020918fce5801581"
+    assert hash1 == "17e4e2b4d8ce8f36bf3fd65804958dbb"
 
     # checking if different name doesn't affect the hash
     file_diffname = tmp_path / "in_file_2.txt"
@@ -183,7 +183,7 @@ def test_input_file_hash_2a(tmp_path):
 
     # checking specific hash value
     hash1 = inputs(in_file=file).hash
-    assert hash1 == "73745b60b45052d6020918fce5801581"
+    assert hash1 == "17e4e2b4d8ce8f36bf3fd65804958dbb"
 
     # checking if different name doesn't affect the hash
     file_diffname = tmp_path / "in_file_2.txt"
@@ -201,7 +201,7 @@ def test_input_file_hash_2a(tmp_path):
 
     # checking if string is also accepted
     hash4 = inputs(in_file=str(file)).hash
-    assert hash4 == "aaee75d79f1bc492619fabfa68cb3c69"
+    assert hash4 == "aee7c7ae25509fb4c92a081d58d17a67"
 
 
 def test_input_file_hash_3(tmp_path):
@@ -274,7 +274,7 @@ def test_input_file_hash_4(tmp_path):
 
     # checking specific hash value
     hash1 = inputs(in_file=[[file, 3]]).hash
-    assert hash1 == "b8d8255b923b7bb8817da16e6ec57fae"
+    assert hash1 == "11b7e9c90bc8d9dc5ccfc8d4526ba091"
 
     # the same file, but int field changes
     hash1a = inputs(in_file=[[file, 5]]).hash
@@ -310,7 +310,7 @@ def test_input_file_hash_5(tmp_path):
 
     # checking specific hash value
     hash1 = inputs(in_file=[{"file": file, "int": 3}]).hash
-    assert hash1 == "dedaf3899cce99d19238c2efb1b19a89"
+    assert hash1 == "5fd53b79e55bbf62a4bb3027eb753a2c"
 
     # the same file, but int field changes
     hash1a = inputs(in_file=[{"file": file, "int": 5}]).hash

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -669,6 +669,7 @@ def test_hash_changes_in_workflow_graph(tmpdir):
         with Submitter("cf") as sub:
             result = sub(wf)
 
+
 @mark.task
 def to_tuple(x, y):
     return (x, y)

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -1,4 +1,5 @@
 from dateutil import parser
+import random
 import re
 import subprocess as sp
 import struct

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -599,7 +599,9 @@ def test_hash_changes_in_workflow_inputs(tmp_path):
         wf()
 
 
-@pytest.mark.flaky(reruns=3)  # need for travis
+@pytest.mark.flaky(
+    reruns=2
+)  # chance of race-condition where alter_x completes before identity
 def test_hash_changes_in_workflow_graph(tmpdir):
     class X:
         """Dummy class with unstable hash (i.e. which isn't altered in a node in which

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -622,7 +622,7 @@ def test_hash_changes_in_workflow_graph(tmpdir):
 
     @mark.task
     def alter_x(y):
-        time.sleep(5)
+        time.sleep(2)
         X.x = 2
         return y
 

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -1,8 +1,7 @@
 from dateutil import parser
-import random
+import secrets
 import re
 import subprocess as sp
-import struct
 import time
 import attrs
 import typing as ty
@@ -595,11 +594,10 @@ def test_hash_changes_in_task_inputs_unstable(tmp_path):
 
         def __bytes_repr__(self, cache) -> ty.Iterator[bytes]:
             """Random 128-bit bytestring"""
-            yield random.randbytes(16)
+            yield secrets.token_bytes(16)
 
     @mark.task
     def unstable_input(unstable: Unstable) -> int:
-        time.sleep(1)  # Ensure the timestamp changes during the task run
         return unstable.value
 
     task = unstable_input(unstable=Unstable(1))

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -3,6 +3,7 @@ import re
 import subprocess as sp
 import time
 import typing as ty
+from random import randint
 import pytest
 from fileformats.generic import Directory
 from .utils import (
@@ -599,9 +600,9 @@ def test_hash_changes_in_workflow_inputs(tmp_path):
         wf()
 
 
-@pytest.mark.flaky(
-    reruns=2
-)  # chance of race-condition where alter_x completes before identity
+# @pytest.mark.flaky(
+#     reruns=2
+# )  # chance of race-condition where alter_x completes before identity
 def test_hash_changes_in_workflow_graph(tmpdir):
     class X:
         """Dummy class with unstable hash (i.e. which isn't altered in a node in which
@@ -620,11 +621,11 @@ def test_hash_changes_in_workflow_graph(tmpdir):
     @mark.task
     @mark.annotate({"return": {"x": X, "y": int}})
     def identity(x) -> ty.Tuple[X, int]:
-        return x, 3
+        return x, randint(0, 10)
 
     @mark.task
     def alter_x(y):
-        time.sleep(10)
+        # time.sleep(10)
         X.x = 2
         return y
 

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -593,8 +593,8 @@ def test_hash_changes_in_task_inputs_unstable(tmp_path):
         value: int  # type: ignore
 
         def __bytes_repr__(self, cache) -> ty.Iterator[bytes]:
-            """Bytes repr based on time-stamp -> inherently unstable"""
-            yield struct.pack("!I", int(time.time()))
+            """Random 128-bit bytestring"""
+            yield random.randbytes(16)
 
     @mark.task
     def unstable_input(unstable: Unstable) -> int:

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -600,9 +600,9 @@ def test_hash_changes_in_workflow_inputs(tmp_path):
         wf()
 
 
-# @pytest.mark.flaky(
-#     reruns=2
-# )  # chance of race-condition where alter_x completes before identity
+@pytest.mark.flaky(
+    reruns=5
+)  # chance of race-condition where alter_x completes before identity
 def test_hash_changes_in_workflow_graph(tmpdir):
     class X:
         """Dummy class with unstable hash (i.e. which isn't altered in a node in which

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -580,7 +580,7 @@ def test_hash_changes_in_task_inputs(tmp_path):
         return out_dir
 
     task = output_dir_as_input(out_dir=tmp_path)
-    with pytest.raises(RuntimeError, match="Hashes have changed"):
+    with pytest.raises(RuntimeError, match="Input field hashes have changed"):
         task()
 
 
@@ -595,7 +595,7 @@ def test_hash_changes_in_workflow_inputs(tmp_path):
     )
     wf.add(output_dir_as_output(out_dir=wf.lzin.in_dir, name="task"))
     wf.set_output(("out_dir", wf.task.lzout.out))
-    with pytest.raises(RuntimeError, match="Hashes have changed.*workflow\."):
+    with pytest.raises(RuntimeError, match="Input field hashes have changed.*Workflow"):
         wf()
 
 

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -624,7 +624,7 @@ def test_hash_changes_in_workflow_graph(tmpdir):
 
     @mark.task
     def alter_x(y):
-        time.sleep(2)
+        time.sleep(10)
         X.x = 2
         return y
 

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -599,6 +599,7 @@ def test_hash_changes_in_workflow_inputs(tmp_path):
         wf()
 
 
+@pytest.mark.flaky(reruns=3)  # need for travis
 def test_hash_changes_in_workflow_graph(tmpdir):
     class X:
         """Dummy class with unstable hash (i.e. which isn't altered in a node in which
@@ -621,6 +622,7 @@ def test_hash_changes_in_workflow_graph(tmpdir):
 
     @mark.task
     def alter_x(y):
+        time.sleep(5)
         X.x = 2
         return y
 

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -5,6 +5,8 @@ import pytest
 import cloudpickle as cp
 from pathlib import Path
 import json
+import glob as glob
+from fileformats.generic import Directory
 from ... import mark
 from ..core import Workflow
 from ..task import AuditFlag, ShellCommandTask
@@ -1581,3 +1583,16 @@ def test_object_input():
 
     result = testfunc(a=A(x=7))()
     assert result.output.out == 7
+
+
+@mark.task
+def output_dir_as_input(out_dir: Directory) -> Directory:
+    (out_dir.fspath / "new-file.txt").touch()
+    return out_dir
+
+
+# @pytest.mark.xfail(reason="Not sure")
+def test_hash_changes(tmp_path):
+    task = output_dir_as_input(out_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="Hashes have changed"):
+        task()

--- a/pydra/engine/tests/test_task.py
+++ b/pydra/engine/tests/test_task.py
@@ -6,7 +6,6 @@ import cloudpickle as cp
 from pathlib import Path
 import json
 import glob as glob
-from fileformats.generic import Directory
 from ... import mark
 from ..core import Workflow
 from ..task import AuditFlag, ShellCommandTask
@@ -1583,16 +1582,3 @@ def test_object_input():
 
     result = testfunc(a=A(x=7))()
     assert result.output.out == 7
-
-
-@mark.task
-def output_dir_as_input(out_dir: Directory) -> Directory:
-    (out_dir.fspath / "new-file.txt").touch()
-    return out_dir
-
-
-# @pytest.mark.xfail(reason="Not sure")
-def test_hash_changes(tmp_path):
-    task = output_dir_as_input(out_dir=tmp_path)
-    with pytest.raises(RuntimeError, match="Hashes have changed"):
-        task()

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -64,7 +64,7 @@ def hash_function(obj, cache=None):
     return hash_object(obj, cache=cache).hex()
 
 
-def hash_object(obj: object, cache: Cache | None = None) -> Hash:
+def hash_object(obj: object, cache: ty.Optional[Cache] = None) -> Hash:
     """Hash an object
 
     Constructs a byte string that uniquely identifies the object,

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -59,12 +59,12 @@ class UnhashableError(ValueError):
     """Error for objects that cannot be hashed"""
 
 
-def hash_function(obj):
+def hash_function(obj, cache=None):
     """Generate hash of object."""
-    return hash_object(obj).hex()
+    return hash_object(obj, cache=cache).hex()
 
 
-def hash_object(obj: object) -> Hash:
+def hash_object(obj: object, cache=None) -> Hash:
     """Hash an object
 
     Constructs a byte string that uniquely identifies the object,
@@ -73,8 +73,10 @@ def hash_object(obj: object) -> Hash:
     Base Python types are implemented, including recursive lists and
     dicts. Custom types can be registered with :func:`register_serializer`.
     """
+    if cache is None:
+        cache = Cache({})
     try:
-        return hash_single(obj, Cache({}))
+        return hash_single(obj, cache)
     except Exception as e:
         raise UnhashableError(f"Cannot hash object {obj!r}") from e
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -107,6 +107,17 @@ class HasBytesRepr(Protocol):
 
 @singledispatch
 def bytes_repr(obj: object, cache: Cache) -> Iterator[bytes]:
+    """Default implementation of hashing for generic objects. Single dispatch is used
+    to provide hooks for class-specific implementations
+
+    Parameters
+    ----------
+    obj: object
+        the object to hash
+    cache : Cache
+        a dictionary object used to store a cache of previously cached objects to
+        handle circular object references
+    """
     cls = obj.__class__
     yield f"{cls.__module__}.{cls.__name__}:{{".encode()
     dct: Dict[str, ty.Any]

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -64,7 +64,7 @@ def hash_function(obj, cache=None):
     return hash_object(obj, cache=cache).hex()
 
 
-def hash_object(obj: object, cache=None) -> Hash:
+def hash_object(obj: object, cache: Cache | None = None) -> Hash:
     """Hash an object
 
     Constructs a byte string that uniquely identifies the object,

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -117,6 +117,11 @@ def bytes_repr(obj: object, cache: Cache) -> Iterator[bytes]:
     cache : Cache
         a dictionary object used to store a cache of previously cached objects to
         handle circular object references
+
+    Yields
+    -------
+    bytes
+        unique representation of the object in a series of bytes
     """
     cls = obj.__class__
     yield f"{cls.__module__}.{cls.__name__}:{{".encode()


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- New feature (non-breaking change which adds functionality)

## Summary

Addresses #681 issue

* Detects changes in the hashes of task/workflow inputs and raises informative error messages identifying which fields have changed
* Reinstates behaviour of "blocked tasks" unittest, so it once again triggers "graph is not empty" exception
* On "graph not empty" exception, check Workflow.inputs._graph_checksums to determine which task's checksums have changed and raise informative message

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
