### PR TITLE
Caching of file-set hashes by local path and mtimes

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -102,7 +102,7 @@ class BaseSpec:
             if "container_path" in field.metadata:
                 continue
             inp_dict[field.name] = getattr(self, field.name)
-        hash_cache = Cache({})
+        hash_cache = Cache()
         field_hashes = {
             k: hash_function(v, cache=hash_cache) for k, v in inp_dict.items()
         }

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from .workers import WORKERS
 from .core import is_workflow
 from .helpers import get_open_loop, load_and_run_async
+from ..utils.hash import PersistentCache
 
 import logging
 
@@ -43,6 +44,7 @@ class Submitter:
         self.loop.run_until_complete(
             self.submit_from_call(runnable, rerun, environment)
         )
+        PersistentCache.clean_up()
         return runnable.result()
 
     async def submit_from_call(self, runnable, rerun, environment):

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -44,7 +44,7 @@ class Submitter:
         self.loop.run_until_complete(
             self.submit_from_call(runnable, rerun, environment)
         )
-        PersistentCache.clean_up()
+        PersistentCache().clean_up()
         return runnable.result()
 
     async def submit_from_call(self, runnable, rerun, environment):

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -322,11 +322,10 @@ def test_task_init_7(tmp_path):
     output_dir1 = nn1.output_dir
 
     # changing the content of the file
+    time.sleep(2)  # need the mtime to be different
     file2 = tmp_path / "file2.txt"
-    with mock.patch("time.time") as t:
-        t.return_value = time.time() + 10  # mock mtime to ensure different
-        with open(file2, "w") as f:
-            f.write("from pydra")
+    with open(file2, "w") as f:
+        f.write("from pydra")
 
     nn2 = fun_file_list(name="NA", filename_list=[file1, file2])
     output_dir2 = nn2.output_dir

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -321,10 +321,13 @@ def test_task_init_7(tmp_path):
     output_dir1 = nn1.output_dir
 
     # changing the content of the file
-    time.sleep(2)  # need the mtime to be different
     file2 = tmp_path / "file2.txt"
-    with open(file2, "w") as f:
-        f.write("from pydra")
+    with mock.patch("time.time") as t:
+        t.return_value = (
+            time.time() + 10
+        )  # mock mtime writing to ensure it is different
+        with open(file2, "w") as f:
+            f.write("from pydra")
 
     nn2 = fun_file_list(name="NA", filename_list=[file1, file2])
     output_dir2 = nn2.output_dir

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -323,9 +323,7 @@ def test_task_init_7(tmp_path):
     # changing the content of the file
     file2 = tmp_path / "file2.txt"
     with mock.patch("time.time") as t:
-        t.return_value = (
-            time.time() + 10
-        )  # mock mtime writing to ensure it is different
+        t.return_value = time.time() + 10  # mock mtime to ensure different
         with open(file2, "w") as f:
             f.write("from pydra")
 

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import attr
 import numpy as np
+from unittest import mock
 import pytest
 import time
 

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -3,6 +3,7 @@ import shutil
 import attr
 import numpy as np
 import pytest
+import time
 
 from .utils import (
     fun_addtwo,
@@ -320,6 +321,7 @@ def test_task_init_7(tmp_path):
     output_dir1 = nn1.output_dir
 
     # changing the content of the file
+    time.sleep(2)  # need the mtime to be different
     file2 = tmp_path / "file2.txt"
     with open(file2, "w") as f:
         f.write("from pydra")

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -3,7 +3,6 @@ import typing as ty
 import os
 import attrs
 from copy import deepcopy
-from unittest import mock
 import time
 
 from ..specs import (
@@ -165,11 +164,10 @@ def test_input_file_hash_2(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    with mock.patch("time.time") as t:
-        t.return_value = time.time() + 10  # mock mtime to ensure different
-        with open(file_diffcontent, "w") as f:
-            f.write("hi")
+    with open(file_diffcontent, "w") as f:
+        f.write("hi")
     hash3 = inputs(in_file=file_diffcontent).hash
     assert hash1 != hash3
 
@@ -197,12 +195,10 @@ def test_input_file_hash_2a(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    # Ensure that the mtime will be incremented by mocking time.time
-    with mock.patch("time.time") as t:
-        t.return_value = time.time() + 10
-        with open(file_diffcontent, "w") as f:
-            f.write("hi")
+    with open(file_diffcontent, "w") as f:
+        f.write("hi")
     hash3 = inputs(in_file=file_diffcontent).hash
     assert hash1 != hash3
 
@@ -241,10 +237,9 @@ def test_input_file_hash_3(tmp_path):
     # assert id(files_hash1["in_file"][filename]) == id(files_hash2["in_file"][filename])
 
     # recreating the file
-    with mock.patch("time.time") as t:
-        t.return_value = time.time() + 10  # mock mtime to ensure different
-        with open(file, "w") as f:
-            f.write("hello")
+    time.sleep(2)  # ensure mtime is different
+    with open(file, "w") as f:
+        f.write("hello")
 
     hash3 = my_inp.hash
     # files_hash3 = deepcopy(my_inp.files_hash)
@@ -297,11 +292,10 @@ def test_input_file_hash_4(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # need the mtime to be different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    with mock.patch("time.time") as t:
-        t.return_value = time.time() + 10  # mock mtime to ensure different
-        with open(file_diffcontent, "w") as f:
-            f.write("hi")
+    with open(file_diffcontent, "w") as f:
+        f.write("hi")
     hash3 = inputs(in_file=[[file_diffcontent, 3]]).hash
     assert hash1 != hash3
 
@@ -335,11 +329,10 @@ def test_input_file_hash_5(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    with mock.patch("time.time") as t:
-        t.return_value = time.time() + 10  # mock mtime to ensure different
-        with open(file_diffcontent, "w") as f:
-            f.write("hi")
+    with open(file_diffcontent, "w") as f:
+        f.write("hi")
     hash3 = inputs(in_file=[{"file": file_diffcontent, "int": 3}]).hash
     assert hash1 != hash3
 

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -164,6 +164,7 @@ def test_input_file_hash_2(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
     with open(file_diffcontent, "w") as f:
         f.write("hi")
@@ -194,6 +195,7 @@ def test_input_file_hash_2a(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
     with open(file_diffcontent, "w") as f:
         f.write("hi")
@@ -235,6 +237,7 @@ def test_input_file_hash_3(tmp_path):
     # assert id(files_hash1["in_file"][filename]) == id(files_hash2["in_file"][filename])
 
     # recreating the file
+    time.sleep(2)  # ensure mtime is different
     with open(file, "w") as f:
         f.write("hello")
 
@@ -326,6 +329,7 @@ def test_input_file_hash_5(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
     with open(file_diffcontent, "w") as f:
         f.write("hi")

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -3,6 +3,7 @@ import typing as ty
 import os
 import attrs
 from copy import deepcopy
+from unittest import mock
 import time
 
 from ..specs import (
@@ -164,10 +165,13 @@ def test_input_file_hash_2(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
-    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    with open(file_diffcontent, "w") as f:
-        f.write("hi")
+    with mock.patch("time.time") as t:
+        t.return_value = (
+            time.time() + 10
+        )  # mock mtime writing to ensure it is different
+        with open(file_diffcontent, "w") as f:
+            f.write("hi")
     hash3 = inputs(in_file=file_diffcontent).hash
     assert hash1 != hash3
 
@@ -195,10 +199,12 @@ def test_input_file_hash_2a(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
-    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    with open(file_diffcontent, "w") as f:
-        f.write("hi")
+    # Ensure that the mtime will be incremented by mocking time.time
+    with mock.patch("time.time") as t:
+        t.return_value = time.time() + 10
+        with open(file_diffcontent, "w") as f:
+            f.write("hi")
     hash3 = inputs(in_file=file_diffcontent).hash
     assert hash1 != hash3
 
@@ -237,9 +243,12 @@ def test_input_file_hash_3(tmp_path):
     # assert id(files_hash1["in_file"][filename]) == id(files_hash2["in_file"][filename])
 
     # recreating the file
-    time.sleep(2)  # ensure mtime is different
-    with open(file, "w") as f:
-        f.write("hello")
+    with mock.patch("time.time") as t:
+        t.return_value = (
+            time.time() + 10
+        )  # mock mtime writing to ensure it is different
+        with open(file, "w") as f:
+            f.write("hello")
 
     hash3 = my_inp.hash
     # files_hash3 = deepcopy(my_inp.files_hash)
@@ -292,10 +301,13 @@ def test_input_file_hash_4(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
-    time.sleep(2)  # need the mtime to be different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    with open(file_diffcontent, "w") as f:
-        f.write("hi")
+    with mock.patch("time.time") as t:
+        t.return_value = (
+            time.time() + 10
+        )  # mock mtime writing to ensure it is different
+        with open(file_diffcontent, "w") as f:
+            f.write("hi")
     hash3 = inputs(in_file=[[file_diffcontent, 3]]).hash
     assert hash1 != hash3
 
@@ -329,10 +341,13 @@ def test_input_file_hash_5(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
-    time.sleep(2)  # ensure mtime is different
     file_diffcontent = tmp_path / "in_file_1.txt"
-    with open(file_diffcontent, "w") as f:
-        f.write("hi")
+    with mock.patch("time.time") as t:
+        t.return_value = (
+            time.time() + 10
+        )  # mock mtime writing to ensure it is different
+        with open(file_diffcontent, "w") as f:
+            f.write("hi")
     hash3 = inputs(in_file=[{"file": file_diffcontent, "int": 3}]).hash
     assert hash1 != hash3
 

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -167,9 +167,7 @@ def test_input_file_hash_2(tmp_path):
     # checking if different content (the same name) affects the hash
     file_diffcontent = tmp_path / "in_file_1.txt"
     with mock.patch("time.time") as t:
-        t.return_value = (
-            time.time() + 10
-        )  # mock mtime writing to ensure it is different
+        t.return_value = time.time() + 10  # mock mtime to ensure different
         with open(file_diffcontent, "w") as f:
             f.write("hi")
     hash3 = inputs(in_file=file_diffcontent).hash
@@ -244,9 +242,7 @@ def test_input_file_hash_3(tmp_path):
 
     # recreating the file
     with mock.patch("time.time") as t:
-        t.return_value = (
-            time.time() + 10
-        )  # mock mtime writing to ensure it is different
+        t.return_value = time.time() + 10  # mock mtime to ensure different
         with open(file, "w") as f:
             f.write("hello")
 
@@ -303,9 +299,7 @@ def test_input_file_hash_4(tmp_path):
     # checking if different content (the same name) affects the hash
     file_diffcontent = tmp_path / "in_file_1.txt"
     with mock.patch("time.time") as t:
-        t.return_value = (
-            time.time() + 10
-        )  # mock mtime writing to ensure it is different
+        t.return_value = time.time() + 10  # mock mtime to ensure different
         with open(file_diffcontent, "w") as f:
             f.write("hi")
     hash3 = inputs(in_file=[[file_diffcontent, 3]]).hash
@@ -343,9 +337,7 @@ def test_input_file_hash_5(tmp_path):
     # checking if different content (the same name) affects the hash
     file_diffcontent = tmp_path / "in_file_1.txt"
     with mock.patch("time.time") as t:
-        t.return_value = (
-            time.time() + 10
-        )  # mock mtime writing to ensure it is different
+        t.return_value = time.time() + 10  # mock mtime to ensure different
         with open(file_diffcontent, "w") as f:
             f.write("hi")
     hash3 = inputs(in_file=[{"file": file_diffcontent, "int": 3}]).hash

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -3,6 +3,7 @@ import typing as ty
 import os
 import attrs
 from copy import deepcopy
+import time
 
 from ..specs import (
     BaseSpec,
@@ -288,6 +289,7 @@ def test_input_file_hash_4(tmp_path):
     assert hash1 == hash2
 
     # checking if different content (the same name) affects the hash
+    time.sleep(2)  # need the mtime to be different
     file_diffcontent = tmp_path / "in_file_1.txt"
     with open(file_diffcontent, "w") as f:
         f.write("hi")

--- a/pydra/utils/__init__.py
+++ b/pydra/utils/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import platformdirs
-from pydra import __version__
+from pydra._version import __version__
 
 user_cache_dir = Path(
     platformdirs.user_cache_dir(

--- a/pydra/utils/__init__.py
+++ b/pydra/utils/__init__.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import platformdirs
+from pydra import __version__
+
+user_cache_dir = Path(
+    platformdirs.user_cache_dir(
+        appname="pydra",
+        appauthor="nipype",
+        version=__version__,
+    )
+)

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -192,7 +192,9 @@ def hash_function(obj, **kwargs):
 
 
 def hash_object(
-    obj: object, cache: ty.Optional[Cache] = None, persistent_cache: ty.Union[PersistentCache, Path, None] = None
+    obj: object,
+    cache: ty.Optional[Cache] = None,
+    persistent_cache: ty.Union[PersistentCache, Path, None] = None,
 ) -> Hash:
     """Hash an object
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -377,7 +377,7 @@ def bytes_repr_fileset(
     fspaths = sorted(fileset.fspaths)
     yield CacheKey(
         tuple(repr(p) for p in fspaths)  # type: ignore[arg-type]
-        + tuple(p.lstat().st_mtime for p in fspaths)
+        + tuple(p.lstat().st_mtime_ns for p in fspaths)
     )
     yield from fileset.__bytes_repr__(cache)
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -98,7 +98,7 @@ class PersistentCache:
         try:
             location = os.environ[cls.LOCATION_ENV_VAR]
         except KeyError:
-            location = user_cache_dir / "hash_cache"
+            location = user_cache_dir / "hashes"
         return location
 
     # the default needs to be an instance method

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -7,7 +7,7 @@ import typing as ty
 from pathlib import Path
 from collections.abc import Mapping
 from functools import singledispatch
-from hashlib import blake2b, blake2s
+from hashlib import blake2b
 import logging
 from typing import (
     Dict,
@@ -136,7 +136,7 @@ class PersistentCache:
             return self._hashes[key]
         except KeyError:
             pass
-        key_path = self.location / blake2s(str(key).encode()).hexdigest()
+        key_path = self.location / blake2b(str(key).encode()).hexdigest()
         with SoftFileLock(key_path.with_suffix(".lock")):
             if key_path.exists():
                 return Hash(key_path.read_bytes())

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -147,7 +147,7 @@ class PersistentCache:
         """Cleans up old hash caches that haven't been accessed in the last 30 days"""
         now = datetime.now()
         for path in self.location.iterdir():
-            if path.endswith(".lock"):
+            if path.name.endswith(".lock"):
                 continue
             days = (now - datetime.fromtimestamp(path.lstat().st_atime)).days
             if days > self.cleanup_period:

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -60,7 +60,9 @@ CacheKey = NewType("CacheKey", ty.Tuple[ty.Hashable, ty.Hashable])
 def location_converter(path: ty.Union[Path, str, None]) -> Path:
     if path is None:
         path = PersistentCache.location_default()
-    return Path(path)
+    path = Path(path)
+    path.mkdir(parents=True)
+    return path
 
 
 @attrs.define

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -190,7 +190,7 @@ def hash_single(obj: object, cache: Cache) -> Hash:
             h = blake2b(digest_size=16, person=b"pydra-hash")
             if first is not None:
                 h.update(first)
-            for chunk in bytes_it:  # NB: bytes_it is in outer scope
+            for chunk in bytes_it:  # Note that `bytes_it` is in outer scope
                 h.update(chunk)
             return Hash(h.digest())
 
@@ -406,7 +406,7 @@ def bytes_repr_mapping_contents(mapping: Mapping, cache: Cache) -> Iterator[byte
     .. code-block:: python
 
         >>> from pydra.utils.hash import bytes_repr_mapping_contents, Cache
-        >>> generator = bytes_repr_mapping_contents({"a": 1, "b": 2}, Cache({}))
+        >>> generator = bytes_repr_mapping_contents({"a": 1, "b": 2}, Cache())
         >>> b''.join(generator)
         b'str:1:a=...str:1:b=...'
     """
@@ -424,7 +424,7 @@ def bytes_repr_sequence_contents(seq: Sequence, cache: Cache) -> Iterator[bytes]
     .. code-block:: python
 
         >>> from pydra.utils.hash import bytes_repr_sequence_contents, Cache
-        >>> generator = bytes_repr_sequence_contents([1, 2], Cache({}))
+        >>> generator = bytes_repr_sequence_contents([1, 2], Cache())
         >>> list(generator)
         [b'\x6d...', b'\xa3...']
     """

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -129,7 +129,8 @@ class PersistentCache:
         Returns
         -------
         Hash
-            _description_
+            the hash corresponding to the key, which is either retrieved from the persistent
+            store or calculated using `calculate_hash` if not present
         """
         try:
             return self._hashes[key]
@@ -141,6 +142,7 @@ class PersistentCache:
                 return Hash(key_path.read_bytes())
             hsh = calculate_hash()
             key_path.write_bytes(hsh)
+            self._hashes[key] = Hash(hsh)
         return Hash(hsh)
 
     def clean_up(self):

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -524,39 +524,3 @@ if HAVE_NUMPY:
 
 
 NUMPY_CHUNK_LEN = 8192
-
-
-# class MtimeCachingHash:
-#     """Hashing object that stores a cache of hash values for PathLikes
-
-#     The cache only stores values for PathLikes pointing to existing files,
-#     and the mtime is checked to validate the cache. If the mtime differs,
-#     the old hash is discarded and a new mtime-tagged hash is stored.
-
-#     The cache can grow without bound; we may want to consider using an LRU
-#     cache.
-#     """
-
-#     def __init__(self) -> None:
-#         self.cache: ty.Dict[os.PathLike, ty.Tuple[float, Hash]] = {}
-
-#     def __call__(self, obj: object) -> Hash:
-#         if isinstance(obj, os.PathLike):
-#             path = Path(obj)
-#             try:
-#                 stat_res = path.stat()
-#                 mode, mtime = stat_res.st_mode, stat_res.st_mtime
-#             except FileNotFoundError:
-#                 # Only attempt to cache existing files
-#                 pass
-#             else:
-#                 if stat.S_ISREG(mode) and obj in self.cache:
-#                     # Cache (and hash) the actual object, as different pathlikes will have
-#                     # different serializations
-#                     save_mtime, save_hash = self.cache[obj]
-#                     if mtime == save_mtime:
-#                         return save_hash
-#                     new_hash = hash_object(obj)
-#                     self.cache[obj] = (mtime, new_hash)
-#                     return new_hash
-#         return hash_object(obj)

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -242,12 +242,12 @@ def hash_single(obj: object, cache: Cache) -> Hash:
                 h.update(chunk)
             return Hash(h.digest())
 
-        # Read the first item of the bytes_repr iterator, check to see whether it returns
+        # Read the first item of the bytes_repr iterator and check to see whether it returns
         # a "cache-key" tuple instead of a bytes chunk for the type of the object to be cached
-        # (i.e. file objects). If it does use that key to check the persistent cache for
-        # a precomputed hash and return it if it is, otherwise calculate the hash and
-        # store it in the persistent cache with that hash of that key (not to be confused
-        # with the hash of the object that is saved/retrieved).
+        # (e.g. fileformats.core.FileSet objects). If it does use that key to check the
+        # persistent cache for a precomputed hash and return it if it is, otherwise
+        # calculate the hash and store it in the persistent cache with that hash of
+        # that key (not to be confused with the hash of the object that is saved/retrieved).
         first = next(bytes_it)
         if isinstance(first, tuple):
             tp = type(obj)

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -61,7 +61,8 @@ def location_converter(path: ty.Union[Path, str, None]) -> Path:
     if path is None:
         path = PersistentCache.location_default()
     path = Path(path)
-    path.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.mkdir(parents=True)
     return path
 
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -242,14 +242,12 @@ def hash_single(obj: object, cache: Cache) -> Hash:
                 h.update(chunk)
             return Hash(h.digest())
 
-        # Read the first chunk of the bytes_repr iterator, check to see whether it returns
-        # a "cache-key" tuple instead of a bytes chunk for the type of the object to cache
+        # Read the first item of the bytes_repr iterator, check to see whether it returns
+        # a "cache-key" tuple instead of a bytes chunk for the type of the object to be cached
         # (i.e. file objects). If it does use that key to check the persistent cache for
-        # a precomputed hash and otherwise calculate the hash and store it in the
-        # persistent cache with that key.
-
-        # If the first chunk is a bytes chunk (i.e. the object type doesn't have an associated
-        # 'cache-key'), then simply calculate the hash of the object.
+        # a precomputed hash and return it if it is, otherwise calculate the hash and
+        # store it in the persistent cache with that hash of that key (not to be confused
+        # with the hash of the object that is saved/retrieved).
         first = next(bytes_it)
         if isinstance(first, tuple):
             tp = type(obj)
@@ -259,6 +257,10 @@ def hash_single(obj: object, cache: Cache) -> Hash:
             ) + first
             hsh = cache.persistent.get_or_calculate_hash(key, calc_hash)
         else:
+            # If the first item is a bytes chunk (i.e. the object type doesn't have an
+            # associated 'cache-key'), then simply calculate the hash of the object,
+            # passing the first chunk to the `calc_hash` function so it can be included
+            # in the hash calculation
             hsh = calc_hash(first=first)
         logger.debug("Hash of %s object is %s", obj, hsh)
         cache[objid] = hsh

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -18,8 +18,10 @@ from typing import (
     Set,
 )
 from filelock import SoftFileLock
+import platformdirs
 import attrs.exceptions
 from fileformats.core import FileSet
+from pydra._version import __version__
 
 logger = logging.getLogger("pydra")
 
@@ -128,12 +130,12 @@ class PersistentCache:
             path = Path(path)
             if not path.exists():
                 try:
-                    Path(path).mkdir()
+                    Path(path).mkdir(parents=True)
                 except Exception as e:
                     raise RuntimeError(
                         f"Could not create cache directory for file hashes at {path}, "
-                        "please use 'PYDRA_HASH_CACHE' environment variable to control "
-                        "where it is created by default"
+                        "please use 'PYDRA_HASH_CACHE' environment variable to manually "
+                        "set where it is created"
                     ) from e
         return PersistentCache(path)
 
@@ -142,10 +144,17 @@ class PersistentCache:
     # of the code, so just dumping in the home directory instead by default. In any case,
     # this needs to be documented
     DEFAULT_LOCATION = Path(
-        os.environ.get("PYDRA_HASH_CACHE", Path("~").expanduser() / ".pydra-hash-cache")
+        os.environ.get(
+            "PYDRA_HASH_CACHE",
+            platformdirs.user_cache_dir(
+                appname="pydra",
+                appauthor="nipype",
+                version=__version__,
+            ),
+        )
     )
     # Set the period after which old hash cache files are cleaned up in days
-    CLEAN_UP_PERIOD = os.environ.get("PYDRA_HASH_CACHE_CLEAN_UP_PERIOD", 30)
+    CLEAN_UP_PERIOD = os.environ.get("PYDRA_HASH_CACHE_CLEANUP_PERIOD", 30)
 
 
 @attrs.define

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -61,7 +61,7 @@ def location_converter(path: ty.Union[Path, str, None]) -> Path:
     if path is None:
         path = PersistentCache.location_default()
     path = Path(path)
-    path.mkdir(parents=True)
+    path.mkdir(parents=True, exist_ok=True)
     return path
 
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -242,12 +242,13 @@ def hash_single(obj: object, cache: Cache) -> Hash:
                 h.update(chunk)
             return Hash(h.digest())
 
-        # Read the first item of the bytes_repr iterator and check to see whether it returns
+        # Read the first item of the bytes_repr iterator and check to see whether it yields
         # a "cache-key" tuple instead of a bytes chunk for the type of the object to be cached
-        # (e.g. fileformats.core.FileSet objects). If it does use that key to check the
-        # persistent cache for a precomputed hash and return it if it is, otherwise
-        # calculate the hash and store it in the persistent cache with that hash of
-        # that key (not to be confused with the hash of the object that is saved/retrieved).
+        # (e.g. file-system path + mtime for fileformats.core.FileSet objects). If it
+        # does, use that key to check the persistent cache for a precomputed hash and
+        # return it if it is, otherwise calculate the hash and store it in the persistent
+        # cache with that hash of that key (not to be confused with the hash of the
+        # object that is saved/retrieved).
         first = next(bytes_it)
         if isinstance(first, tuple):
             tp = type(obj)

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -17,10 +17,9 @@ from typing import (
     Set,
 )
 from filelock import SoftFileLock
-import platformdirs
 import attrs.exceptions
 from fileformats.core import FileSet
-from pydra._version import __version__
+from . import user_cache_dir
 
 logger = logging.getLogger("pydra")
 
@@ -99,11 +98,7 @@ class PersistentCache:
         try:
             location = os.environ[cls.LOCATION_ENV_VAR]
         except KeyError:
-            location = platformdirs.user_cache_dir(
-                appname="pydra",
-                appauthor="nipype",
-                version=__version__,
-            )
+            location = user_cache_dir / "hash_cache"
         return location
 
     # the default needs to be an instance method

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -341,10 +341,13 @@ def test_persistent_hash_cache(cache_path, text_file):
     assert len(list(cache_path.iterdir())) == 2
 
 
-def test_persistent_hash_cache_cleanup(cache_path, text_file):
+def test_persistent_hash_cache_cleanup1(cache_path, text_file):
     with mock.patch.dict(
         os.environ,
-        {"PYDRA_HASH_CACHE": str(cache_path), "PYDRA_HASH_CACHE_CLEANUP_PERIOD": "-1"},
+        {
+            "PYDRA_HASH_CACHE": str(cache_path),
+            "PYDRA_HASH_CACHE_CLEANUP_PERIOD": "-100",
+        },
     ):
         persistent_cache = PersistentCache()
     hsh = hash_object(text_file, persistent_cache=persistent_cache)
@@ -353,10 +356,11 @@ def test_persistent_hash_cache_cleanup(cache_path, text_file):
     assert len(list(cache_path.iterdir())) == 0
 
 
-def test_persistent_hash_cache_badpath(cache_path, text_file):
-    persistent_cache = PersistentCache(cache_path, cleanup_period=-1)
+def test_persistent_hash_cache_cleanup2(cache_path, text_file):
+    persistent_cache = PersistentCache(cache_path, cleanup_period=-100)
     hsh = hash_object(text_file, persistent_cache=persistent_cache)
     assert len(list(cache_path.iterdir())) == 1
+    time.sleep(2)
     persistent_cache.clean_up()
     assert len(list(cache_path.iterdir())) == 0
 

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -3,7 +3,6 @@ import os
 from hashlib import blake2b
 from pathlib import Path
 import time
-from unittest import mock
 import attrs
 import pytest
 import typing as ty

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -320,3 +320,4 @@ def test_persistent_hash_cache(tmp_path):
     # Test that changes to the text file result in new hash
     text_file_path.write_text("bar")
     assert hash_object(text_file, persistent_cache=cache_path) != modified_hash
+    assert len(list(cache_path.iterdir())) == 2

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -16,7 +16,7 @@ def hasher():
 
 
 def join_bytes_repr(obj):
-    return b"".join(bytes_repr(obj, Cache({})))
+    return b"".join(bytes_repr(obj, Cache()))
 
 
 def test_bytes_repr_builtins():

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -2,7 +2,7 @@ import re
 from hashlib import blake2b
 from pathlib import Path
 import time
-
+from unittest import mock
 import attrs
 import pytest
 import typing as ty
@@ -319,7 +319,9 @@ def test_persistent_hash_cache(tmp_path):
     assert hash_object(text_file, persistent_cache=cache_path) == modified_hash
 
     # Test that changes to the text file result in new hash
-    time.sleep(2)  # Need to ensure that the mtimes will be different
     text_file_path.write_text("bar")
-    assert hash_object(text_file, persistent_cache=cache_path) != modified_hash
+    # Ensure that the mtime will be incremented by mocking time.time
+    with mock.patch("time.time") as t:
+        t.return_value = time.time() + 10
+        assert hash_object(text_file, persistent_cache=cache_path) != modified_hash
     assert len(list(cache_path.iterdir())) == 2

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -1,6 +1,7 @@
 import re
 from hashlib import blake2b
 from pathlib import Path
+import time
 
 import attrs
 import pytest
@@ -318,6 +319,7 @@ def test_persistent_hash_cache(tmp_path):
     assert hash_object(text_file, persistent_cache=cache_path) == modified_hash
 
     # Test that changes to the text file result in new hash
+    time.sleep(2)  # Need to ensure that the mtimes will be different
     text_file_path.write_text("bar")
     assert hash_object(text_file, persistent_cache=cache_path) != modified_hash
     assert len(list(cache_path.iterdir())) == 2

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -3,6 +3,7 @@ import os
 from hashlib import blake2b
 from pathlib import Path
 import time
+from unittest import mock
 import attrs
 import pytest
 import typing as ty

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -335,11 +335,9 @@ def test_persistent_hash_cache(cache_path, text_file):
     assert hash_object(text_file, persistent_cache=cache_path) == modified_hash
 
     # Test that changes to the text file result in new hash
+    time.sleep(2)  # Need to ensure that the mtimes will be different
     text_file.fspath.write_text("bar")
-    # Ensure that the mtime will be incremented by mocking time.time
-    with mock.patch("time.time") as t:
-        t.return_value = time.time() + 10
-        assert hash_object(text_file, persistent_cache=cache_path) != modified_hash
+    assert hash_object(text_file, persistent_cache=cache_path) != modified_hash
     assert len(list(cache_path.iterdir())) == 2
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "filelock >=3.0.0",
     "fileformats >=0.8",
     "importlib_resources >=5.7; python_version < '3.11'",
+    "platformdirs >=2",
     "typing_extensions >=4.6.3; python_version < '3.10'",
     "typing_utils >=0.1.0; python_version < '3.10'",
 ]


### PR DESCRIPTION
## Types of changes

- New feature (non-breaking change which adds functionality)

## Summary

Will address #683 by

- [x] `bytes_repr()` overloads for FileSets to yield a "time-stamp" object consisting of a key (file path) and modification time as the first item in the generator.
- [x] `hash_single()` checks for these key/mtime pairs in a global "local hashes cache" dict
    - returns cached hash, if present
    - otherwise it proceeds through the remaining byte chunks, and calculates the hash
- [x] calculated hashes are saved into/loaded from the cache directory using a hash of the key/mtime 


## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)

## Notes
I'm pretty happy with how this turned out with the exception of a few of wrinkles. Any suggestions would be most welcome
- There isn't a clean way to specify the location of the persistent hash cache in the top-level code or put it in the `cache_location` path (my original plan) given that `checksum` and `hash` are object properties instead of methods
    - I have therefore just dumped it in `~/.pydra-hash-cache`
    - not ideal to have to (effectively) hard-code this and having it user dependent
    - Having it in the user directory does mean that if the same cache directory is accessed from different machines (e.g. shared network drive) then local paths won't clash (although chance of mtimes being the same would be vanishingly small)
- The keys of the caches themselves are hashed and stored as files in the persistent cache directory, and will therefore never be cleaned up.
    - This could be ok as they are very small files so if it grows as time goes on it probably won't have much impact
    - This is how pydra caches work in general
- The resolution of mtime differs depending on OS, with Ubuntu and Windows having quite low resolution, i.e. order of seconds
    - I have had to put a sleep call inside the hash test to ensure the mtimes are different
    - Could cause issues if you were updating the contents of files within a loop and spinning off different workflows (not sure whether this would ever happen in practice)
    - No easy way to disable the mtime caching behaviour if this does become a problem
