### PR TITLE
Bugfix for optional output template files (i.e. of type Union[Path, bool]) when set to False

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -452,9 +452,14 @@ class ShellOutSpec:
             input_value = getattr(inputs, fld.name, attr.NOTHING)
             if input_value is not attr.NOTHING:
                 if TypeParser.contains_type(FileSet, fld.type):
-                    label = f"output field '{fld.name}' of {self}"
-                    input_value = TypeParser(fld.type, label=label).coerce(input_value)
-                additional_out[fld.name] = input_value
+                    if input_value is not False:
+                        label = f"output field '{fld.name}' of {self}"
+                        input_value = TypeParser(fld.type, label=label).coerce(
+                            input_value
+                        )
+                        additional_out[fld.name] = input_value
+                else:
+                    additional_out[fld.name] = input_value
             elif (
                 fld.default is None or fld.default == attr.NOTHING
             ) and not fld.metadata:  # TODO: is it right?

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -458,8 +458,6 @@ class ShellOutSpec:
                             input_value
                         )
                         additional_out[fld.name] = input_value
-                else:
-                    additional_out[fld.name] = input_value
             elif (
                 fld.default is None or fld.default == attr.NOTHING
             ) and not fld.metadata:  # TODO: is it right?

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -4347,6 +4347,57 @@ def test_fsl(data_tests_dir):
     # res = shelly(plugin="cf")
 
 
+def test_shell_cmd_optional_output_file(tmp_path):
+    """
+    Test to see that 'unused' doesn't complain about not having an output passed to it
+    """
+    my_cp_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "input",
+                attr.ib(
+                    type=File, metadata={"argstr": "", "help_string": "input file"}
+                ),
+            ),
+            (
+                "output",
+                attr.ib(
+                    type=Path,
+                    metadata={
+                        "argstr": "",
+                        "output_file_template": "out.txt",
+                        "help_string": "output file",
+                    },
+                ),
+            ),
+            (
+                "unused",
+                attr.ib(
+                    type=ty.Union[Path, bool],
+                    default=False,
+                    metadata={
+                        "argstr": "--not-used",
+                        "output_file_template": "out.txt",
+                        "help_string": "dummy output",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    my_cp = ShellCommandTask(
+        name="my_cp",
+        executable="cp",
+        input_spec=my_cp_spec,
+    )
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("foo")
+    result = my_cp(input=file1, unused=False)
+    assert result.output.output.read_text() == "foo"
+
+
 def test_shell_cmd_non_existing_outputs_1(tmp_path):
     """Checking that non existing output files do not return a phantom path,
     but return NOTHING instead"""

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -4347,7 +4347,7 @@ def test_fsl(data_tests_dir):
     # res = shelly(plugin="cf")
 
 
-def test_shell_cmd_optional_output_file(tmp_path):
+def test_shell_cmd_optional_output_file1(tmp_path):
     """
     Test to see that 'unused' doesn't complain about not having an output passed to it
     """
@@ -4395,7 +4395,52 @@ def test_shell_cmd_optional_output_file(tmp_path):
     file1 = tmp_path / "file1.txt"
     file1.write_text("foo")
     result = my_cp(input=file1, unused=False)
-    assert result.output.output.read_text() == "foo"
+    assert result.output.output.fspath.read_text() == "foo"
+
+
+def test_shell_cmd_optional_output_file2(tmp_path):
+    """
+    Test to see that 'unused' doesn't complain about not having an output passed to it
+    """
+    my_cp_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "input",
+                attr.ib(
+                    type=File, metadata={"argstr": "", "help_string": "input file"}
+                ),
+            ),
+            (
+                "output",
+                attr.ib(
+                    type=ty.Union[Path, bool],
+                    default=False,
+                    metadata={
+                        "argstr": "",
+                        "output_file_template": "out.txt",
+                        "help_string": "dummy output",
+                    },
+                ),
+            ),
+        ],
+        bases=(ShellSpec,),
+    )
+
+    my_cp = ShellCommandTask(
+        name="my_cp",
+        executable="cp",
+        input_spec=my_cp_spec,
+    )
+    file1 = tmp_path / "file1.txt"
+    file1.write_text("foo")
+    result = my_cp(input=file1, output=True)
+    assert result.output.output.fspath.read_text() == "foo"
+
+    file2 = tmp_path / "file2.txt"
+    file2.write_text("bar")
+    with pytest.raises(RuntimeError):
+        my_cp(input=file2, output=False)
 
 
 def test_shell_cmd_non_existing_outputs_1(tmp_path):


### PR DESCRIPTION
## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Summary

For options such as the following where an optional output file (with a template) type Union[Path, bool], where the value is set to False, the collection of outputs was failing when attempting to coerce the boolean to a File

```
(
    "unused",
    attr.ib(
        type=ty.Union[Path, bool],
        default=False,
        metadata={
            "argstr": "--not-used",
            "output_file_template": "out.txt",
            "help_string": "dummy output",
        },
    ),
),

```

This bug-fix omits these fields from the collected outputs

## Checklist
- [ x ] I have added tests to cover my changes (if necessary)

