### PR TITLE
Add `flux` executor support for `PsijWorker`

### DIFF
--- a/.github/workflows/testflux.yml
+++ b/.github/workflows/testflux.yml
@@ -11,16 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
-    strategy:
-      fail-fast: false
-      matrix:
-        container: ['fluxrm/flux-sched:focal-v0.28.0']
 
     container:
-      image: ${{ matrix.container }}
+      image: fluxrm/flux-sched:focal-v0.28.0
       options: "--platform=linux/amd64 --user root -it --init"
 
-    name: ${{ matrix.container }}
     steps:
       - name: Make Space
         run: |
@@ -36,7 +31,7 @@ jobs:
           ln -s /usr/bin/python3 /usr/bin/python
           python -m pip install --upgrade pip && pip install -e ".[test]" && python -c 'import pydra; print(pydra.__version__)'
           pip install -e "git+https://github.com/adi611/psij-python.git@adi611-patch-2#egg=psij-python"
-      - name: Start Flux and Run Test
+      - name: Run pytest
         run: |
           export PATH=$PWD/bin:$PATH
           flux start python -V

--- a/.github/workflows/testflux.yml
+++ b/.github/workflows/testflux.yml
@@ -34,7 +34,7 @@ jobs:
           apt-get update && apt-get install -y python3-venv
           export PATH=$PWD/bin:$PATH
           ln -s /usr/bin/python3 /usr/bin/python
-          python3 -m pip install --upgrade pip && pip install -e ".[test]" && python -c 'import pydra; print(pydra.__version__)'
+          python -m pip install --upgrade pip && pip install -e ".[test]" && python -c 'import pydra; print(pydra.__version__)'
           pip install -e "git+https://github.com/adi611/psij-python.git@adi611-patch-2#egg=psij-python"
       - name: Start Flux and Run Test
         run: |

--- a/.github/workflows/testflux.yml
+++ b/.github/workflows/testflux.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Start Docker container
       run: |
-        docker run -d --name flux -v `pwd`:/pydra fluxrm/flux-sched:focal-v0.28.0 flux start
+        docker run -itd --name flux -v `pwd`:/pydra fluxrm/flux-sched:focal-v0.28.0 flux start
         sleep 5 # Give the container some time to start
 
     - name: Run necessary changes in container

--- a/.github/workflows/testflux.yml
+++ b/.github/workflows/testflux.yml
@@ -9,38 +9,35 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        container: ['fluxrm/flux-sched:focal-v0.28.0']
 
+    container:
+      image: ${{ matrix.container }}
+      options: "--platform=linux/amd64 --user root -it --init"
+
+    name: ${{ matrix.container }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Make Space
+        run: |
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Start Docker container
-      run: |
-        docker run -itd --name flux -v `pwd`:/pydra fluxrm/flux-sched:focal-v0.28.0 flux start
-        sleep 5 # Give the container some time to start
-
-    - name: Run necessary changes in container
-      run: |
-        # Install Python 3 (if not already installed)
-        docker exec flux apt-get update
-        docker exec flux apt-get install -y python3
-
-        # Add Python to PATH
-        docker exec flux echo 'export PATH="/home/fluxuser/.local/bin:$PATH"' >> ~/.bashrc
-
-        # Create an alias for 'python' (pointing to 'python3')
-        docker exec flux echo 'alias python=python3' >> ~/.bashrc
-
-        # Source the updated .bashrc to apply changes
-        docker exec flux source ~/.bashrc
-
-    - name: Run pytest
-      run: |
-        docker exec flux bash -c "pytest --psij=flux --color=yes -vs -n auto --psij=slurm --cov pydra --cov-config /pydra/.coveragerc --cov-report xml:/pydra/cov.xml --doctest-modules /pydra/pydra/"
-  
-    - name: Upload to codecov
-      run: |
-        docker exec flux bash -c "codecov --root /pydra -f /pydra/cov.xml -F unittests"
-  
-    - name: Stop and remove Docker container
-      run: docker stop flux && docker rm flux
+      - name: Install
+        run: |
+          apt-get update && apt-get install -y python3-venv
+          export PATH=$PWD/bin:$PATH
+          ln -s /usr/bin/python3 /usr/bin/python
+          python3 -m pip install --upgrade pip && pip install -e ".[test]" && python -c 'import pydra; print(pydra.__version__)'
+          pip install -e "git+https://github.com/adi611/psij-python.git@adi611-patch-2#egg=psij-python"
+      - name: Start Flux and Run Test
+        run: |
+          export PATH=$PWD/bin:$PATH
+          flux start python -V
+          flux start pytest --psij=flux --color=yes -vs --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra/

--- a/.github/workflows/testflux.yml
+++ b/.github/workflows/testflux.yml
@@ -1,0 +1,46 @@
+name: Flux
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Start Docker container
+      run: |
+        docker run -d --name flux -v `pwd`:/pydra fluxrm/flux-sched:focal-v0.28.0 flux start
+        sleep 5 # Give the container some time to start
+
+    - name: Run necessary changes in container
+      run: |
+        # Install Python 3 (if not already installed)
+        docker exec flux apt-get update
+        docker exec flux apt-get install -y python3
+
+        # Add Python to PATH
+        docker exec flux echo 'export PATH="/home/fluxuser/.local/bin:$PATH"' >> ~/.bashrc
+
+        # Create an alias for 'python' (pointing to 'python3')
+        docker exec flux echo 'alias python=python3' >> ~/.bashrc
+
+        # Source the updated .bashrc to apply changes
+        docker exec flux source ~/.bashrc
+
+    - name: Run pytest
+      run: |
+        docker exec flux bash -c "pytest --psij=flux --color=yes -vs -n auto --psij=slurm --cov pydra --cov-config /pydra/.coveragerc --cov-report xml:/pydra/cov.xml --doctest-modules /pydra/pydra/"
+  
+    - name: Upload to codecov
+      run: |
+        docker exec flux bash -c "codecov --root /pydra -f /pydra/cov.xml -F unittests"
+  
+    - name: Stop and remove Docker container
+      run: docker stop flux && docker rm flux

--- a/.github/workflows/testflux.yml
+++ b/.github/workflows/testflux.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install
+      - name: Setup Python
         run: |
-          apt-get update && apt-get install -y python3-venv
+          apt-get update && apt-get install -y python3-venv && apt-get install less
           export PATH=$PWD/bin:$PATH
           ln -s /usr/bin/python3 /usr/bin/python
           python -m pip install --upgrade pip && pip install -e ".[test]" && python -c 'import pydra; print(pydra.__version__)'

--- a/.github/workflows/testflux.yml
+++ b/.github/workflows/testflux.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     permissions:
       packages: read

--- a/.github/workflows/testpsijflux.yml
+++ b/.github/workflows/testpsijflux.yml
@@ -30,7 +30,7 @@ jobs:
           export PATH=$PWD/bin:$PATH
           ln -s /usr/bin/python3 /usr/bin/python
           python -m pip install --upgrade pip && pip install -e ".[test]" && python -c 'import pydra; print(pydra.__version__)'
-          pip install -e "git+https://github.com/adi611/psij-python.git@adi611-patch-2#egg=psij-python"
+          pip install -e "git+https://github.com/ExaWorks/psij-python.git@main#egg=psij-python"
       - name: Run pytest
         run: |
           export PATH=$PWD/bin:$PATH

--- a/.github/workflows/testpsijflux.yml
+++ b/.github/workflows/testpsijflux.yml
@@ -1,4 +1,4 @@
-name: Flux
+name: PSI/J-Flux
 
 on:
   push:

--- a/pydra/conftest.py
+++ b/pydra/conftest.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser):
         "--psij",
         action="store",
         help="run with psij subtype plugin",
-        choices=["local", "slurm"],
+        choices=["local", "slurm", "flux"],
     )
 
 

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -1066,8 +1066,8 @@ class PsijFluxWorker(PsijWorker):
     """A worker to execute tasks using PSI/J using SLURM."""
 
     subtype = "flux"
-    plugin_name = f"psij-{subtype}"    
-    
+    plugin_name = f"psij-{subtype}"
+
 
 WORKERS = {
     w.plugin_name: w

--- a/pydra/engine/workers.py
+++ b/pydra/engine/workers.py
@@ -1016,18 +1016,18 @@ class PsijWorker(Worker):
             spec.arguments.append("--rerun")
 
         spec.stdout_path = cache_dir / "demo.stdout"
-        # spec.stderr_path = cache_dir / "demo.stderr"
+        spec.stderr_path = cache_dir / "demo.stderr"
 
         job = self.make_job(spec, None)
         jex.submit(job)
         job.wait()
 
-        # if spec.stderr_path.stat().st_size > 0:
-        #     with open(spec.stderr_path, "r") as stderr_file:
-        #         stderr_contents = stderr_file.read()
-        #     raise Exception(
-        #         f"stderr_path '{spec.stderr_path}' is not empty. Contents:\n{stderr_contents}"
-        #     )
+        if spec.stderr_path.stat().st_size > 0:
+            with open(spec.stderr_path, "r") as stderr_file:
+                stderr_contents = stderr_file.read()
+            raise Exception(
+                f"stderr_path '{spec.stderr_path}' is not empty. Contents:\n{stderr_contents}"
+            )
 
         return
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- New feature (non-breaking change which adds functionality)

## Summary
<!--- What does your code do? -->
Adds `flux` executor support for `PsijWorker` and a GitHub Actions workflow `testflux.yml` for testing

## Known issues
- jobtap errors: (non-breaking; tests still pass)
```
jobtap: job.new: callback returned error
jobtap: job.inactive.add: callback returned error
```
Reference issues https://github.com/flux-framework/flux-core/issues/5475 and https://github.com/flux-framework/flux-core/issues/4991

- `test_task.py::test_audit_shellcommandtask_version` fails - `IndexError: list index out of range`