### PR TITLE
Test with Python 3.12

### DIFF
--- a/.github/workflows/testdask.yml
+++ b/.github/workflows/testdask.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/testpydra.yml
+++ b/.github/workflows/testpydra.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         install: ['wheel']
         include:
           - os: 'ubuntu-latest'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_scm:buildapi"
 name = "pydra"
 description = "Pydra dataflow engine"
 readme = "README.rst"
-requires-python = ">=3.8, !=3.11.1"
+requires-python = ">=3.8"
 dependencies = [
     "attrs >=19.1.0",
     "cloudpickle >=2.0.0",


### PR DESCRIPTION
This PR enables testing by CI with Python 3.12.

~~I took this opportunity to enable caching of pip dependencies,
to save setup time and bandwidth.~~

It also drops exclusion of Python 3.11.1 from `requires-python`.

This is not a good practice as it can mess up with dependency
resolution for downstream projects depending on Pydra.

Instead, if such exclusion really is necessary, version guards      
should be put in place where the specific feature impacted by     
a regression _in the language_.