### PR TITLE
implemented "with-timeout" plugin for testing the startup phase of lo…

### DIFF
--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -17,6 +17,7 @@ from ..submitter import Submitter
 from ... import mark
 from pathlib import Path
 from datetime import datetime
+from ..task import ShellCommandTask
 
 
 @mark.task
@@ -612,3 +613,19 @@ def alter_input(x):
 @mark.task
 def to_tuple(x, y):
     return (x, y)
+
+
+def test_serial_with_untriggered_timeout():
+    sleeper = ShellCommandTask(name="sleeper", executable=["sleep", "0.5"])
+    with Submitter(plugin="with-timeout", timeout=1) as sub:
+        result = sleeper(submitter=sub)
+
+    assert result.output.return_code == 0
+
+
+def test_serial_with_triggered_timeout():
+    sleeper = ShellCommandTask(name="sleeper", executable=["sleep", "1.5"])
+    with Submitter(plugin="with-timeout", timeout=1) as sub:
+        result = sleeper(submitter=sub)
+
+    assert result is None


### PR DESCRIPTION
…ng-running shell-command tasks

## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- New feature (non-breaking change which adds functionality)

## Summary
This PR adds a new worker to be used solely for testing of interfaces (in particularly the auto-converted interfaces from nipype). Given it is to be used purely for test purposes, it isn't ideal to have to add it in globally into the `WORKERS` dict but there doesn't seem a way to "bring your own" worker. Perhaps this would be better

## Checklist
<!--- Please, let us know if you need help-->
- [ x ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
