### PR TITLE
Add note instead of catching and raising unhashable exception

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -999,8 +999,8 @@ class LazyOutField(LazyField[T]):
                 "that don't return stable hash values for specific object "
                 "types across multiple processes (see bytes_repr() "
                 '"singledispatch "function in pydra/utils/hash.py).'
-                "You may need to write a specific `bytes_repr()` "
-                "implementation (see `pydra.utils.hash.register_serializer`) or a "
+                "You may need to write specific `bytes_repr()` "
+                "implementations (see `pydra.utils.hash.register_serializer`) or a "
                 "`__bytes_repr__()` dunder methods to handle one or more types in "
                 "your interface inputs."
             )

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -1000,8 +1000,8 @@ class LazyOutField(LazyField[T]):
                 "types across multiple processes (see bytes_repr() "
                 '"singledispatch "function in pydra/utils/hash.py).'
                 "You may need to implement a specific `bytes_repr()` "
-                '"singledispatch overload"s or `__bytes_repr__()` '
-                "dunder methods to handle one or more types in "
+                "implementations (see pydra.utils.hash.register_serializer) or a "
+                "`__bytes_repr__()` dunder methods to handle one or more types in "
                 "your interface inputs."
             )
         _, split_depth = TypeParser.strip_splits(self.type)

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -999,8 +999,8 @@ class LazyOutField(LazyField[T]):
                 "that don't return stable hash values for specific object "
                 "types across multiple processes (see bytes_repr() "
                 '"singledispatch "function in pydra/utils/hash.py).'
-                "You may need to implement a specific `bytes_repr()` "
-                "implementations (see pydra.utils.hash.register_serializer) or a "
+                "You may need to write a specific `bytes_repr()` "
+                "implementation (see `pydra.utils.hash.register_serializer`) or a "
                 "`__bytes_repr__()` dunder methods to handle one or more types in "
                 "your interface inputs."
             )

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -228,8 +228,8 @@ class Submitter:
                                 "that don't return stable hash values for specific object "
                                 "types across multiple processes (see bytes_repr() "
                                 '"singledispatch "function in pydra/utils/hash.py).'
-                                "You may need to write a specific `bytes_repr()` "
-                                "implementation (see `pydra.utils.hash.register_serializer`) "
+                                "You may need to write specific `bytes_repr()` "
+                                "implementations (see `pydra.utils.hash.register_serializer`) "
                                 "or `__bytes_repr__()` dunder methods to handle one "
                                 "or more types in your interface inputs."
                             )

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -229,9 +229,9 @@ class Submitter:
                                 "types across multiple processes (see bytes_repr() "
                                 '"singledispatch "function in pydra/utils/hash.py).'
                                 "You may need to implement a specific `bytes_repr()` "
-                                '"singledispatch overload"s or `__bytes_repr__()` '
-                                "dunder methods to handle one or more types in "
-                                "your interface inputs."
+                                "implementation (see pydra.utils.hash.register_serializer) "
+                                "s or `__bytes_repr__()` dunder methods to handle one "
+                                "or more types in your interface inputs."
                             )
                         raise RuntimeError(msg)
             for task in tasks:

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -228,9 +228,9 @@ class Submitter:
                                 "that don't return stable hash values for specific object "
                                 "types across multiple processes (see bytes_repr() "
                                 '"singledispatch "function in pydra/utils/hash.py).'
-                                "You may need to implement a specific `bytes_repr()` "
-                                "implementation (see pydra.utils.hash.register_serializer) "
-                                "s or `__bytes_repr__()` dunder methods to handle one "
+                                "You may need to write a specific `bytes_repr()` "
+                                "implementation (see `pydra.utils.hash.register_serializer`) "
+                                "or `__bytes_repr__()` dunder methods to handle one "
                                 "or more types in your interface inputs."
                             )
                         raise RuntimeError(msg)

--- a/pydra/utils/__init__.py
+++ b/pydra/utils/__init__.py
@@ -1,11 +1,1 @@
-from pathlib import Path
-import platformdirs
-from pydra._version import __version__
-
-user_cache_dir = Path(
-    platformdirs.user_cache_dir(
-        appname="pydra",
-        appauthor="nipype",
-        version=__version__,
-    )
-)
+from .misc import user_cache_dir, add_exc_note  # noqa: F401

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -220,7 +220,16 @@ def hash_object(
     try:
         return hash_single(obj, cache)
     except Exception as e:
-        add_exc_note(e, f"Therefore cannot hash object {obj!r}")
+        tp = type(obj)
+        add_exc_note(
+            e,
+            (
+                f"and therefore cannot hash `{obj!r}` of type "
+                f"`{tp.__module__}.{tp.__name__}`. Consider implementing a "
+                "specific `bytes_repr()`(see pydra.utils.hash.register_serializer) "
+                "or a `__bytes_repr__()` dunder methods for this type"
+            ),
+        )
         raise e
 
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -19,7 +19,7 @@ from typing import (
 from filelock import SoftFileLock
 import attrs.exceptions
 from fileformats.core import FileSet
-from . import user_cache_dir
+from . import user_cache_dir, add_exc_note
 
 logger = logging.getLogger("pydra")
 
@@ -197,10 +197,6 @@ class Cache:
         return object_id in self._hashes
 
 
-class UnhashableError(ValueError):
-    """Error for objects that cannot be hashed"""
-
-
 def hash_function(obj, **kwargs):
     """Generate hash of object."""
     return hash_object(obj, **kwargs).hex()
@@ -224,7 +220,8 @@ def hash_object(
     try:
         return hash_single(obj, cache)
     except Exception as e:
-        raise UnhashableError(f"Cannot hash object {obj!r} due to '{e}'") from e
+        add_exc_note(e, f"Therefore cannot hash object {obj!r}")
+        raise e
 
 
 def hash_single(obj: object, cache: Cache) -> Hash:

--- a/pydra/utils/misc.py
+++ b/pydra/utils/misc.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import platformdirs
+from pydra._version import __version__
+
+user_cache_dir = Path(
+    platformdirs.user_cache_dir(
+        appname="pydra",
+        appauthor="nipype",
+        version=__version__,
+    )
+)
+
+
+def add_exc_note(e: Exception, note: str) -> Exception:
+    """Adds a note to an exception in a Python <3.11 compatible way
+
+    Parameters
+    ----------
+    e : Exception
+        the exception to add the note to
+    note : str
+        the note to add
+
+    Returns
+    -------
+    Exception
+        returns the exception again
+    """
+    if hasattr(e, "add_note"):
+        e.add_note(note)
+    else:
+        e.args = (e.args[0] + "\n" + note,)
+    return e

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -11,7 +11,6 @@ from fileformats.application import Zip, Json
 from fileformats.text import TextFile
 from ..hash import (
     Cache,
-    UnhashableError,
     bytes_repr,
     hash_object,
     register_serializer,

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -385,3 +385,28 @@ def test_persistent_hash_cache_not_dir(text_file):
     """
     with pytest.raises(ValueError, match="is not a directory"):
         PersistentCache(text_file.fspath)
+
+
+def test_unhashable():
+    """
+    Test that an error is raised if an unhashable object is provided
+    """
+
+    class A:
+
+        def __bytes_repr__(self, cache: Cache) -> ty.Generator[bytes, None, None]:
+            raise TypeError("unhashable")
+
+        def __repr__(self):
+            return "A()"
+
+    # hash_object(A())
+
+    with pytest.raises(
+        TypeError,
+        match=(
+            "unhashable\nand therefore cannot hash `A\(\)` of type "
+            "`pydra.utils.tests.test_hash.A`"
+        ),
+    ):
+        hash_object(A())


### PR DESCRIPTION
## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)

## Summary

This is minor change to stop catching specific exceptions and re-raising generic UnhashbleExceptions, in favour of adding a note to the original exception to aid debugging in an editor. Currently, when debugging in an editor, the execution breaks at the UnhashableException rather than the underlying cause of the exception.

The only change in functionality is that of the type of exception raised

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
