### PR TITLE
use exist_ok instead of explicit check for path exists when creating hash cache so it is multiprocess safe

### DIFF
--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -60,8 +60,7 @@ def location_converter(path: ty.Union[Path, str, None]) -> Path:
     if path is None:
         path = PersistentCache.location_default()
     path = Path(path)
-    if not path.exists():
-        path.mkdir(parents=True)
+    path.mkdir(parents=True, exist_ok=True)
     return path
 
 

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -105,13 +105,6 @@ class PersistentCache:
     def _location_default(self):
         return self.location_default()
 
-    @location.validator
-    def location_validator(self, _, location):
-        if not os.path.isdir(location):
-            raise ValueError(
-                f"Persistent cache location '{location}' is not a directory"
-            )
-
     @cleanup_period.default
     def cleanup_period_default(self):
         return int(os.environ.get(self.CLEANUP_ENV_VAR, 30))

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -60,7 +60,12 @@ def location_converter(path: ty.Union[Path, str, None]) -> Path:
     if path is None:
         path = PersistentCache.location_default()
     path = Path(path)
-    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except FileExistsError:
+        raise ValueError(
+            f"provided path to persistent cache {path} is a file not a directory"
+        ) from None
     return path
 
 

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -384,5 +384,5 @@ def test_persistent_hash_cache_not_dir(text_file):
     """
     Test that an error is raised if the provided cache path is not a directory
     """
-    with pytest.raises(ValueError, match="is not a directory"):
+    with pytest.raises(FileExistsError):
         PersistentCache(text_file.fspath)

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -384,5 +384,5 @@ def test_persistent_hash_cache_not_dir(text_file):
     """
     Test that an error is raised if the provided cache path is not a directory
     """
-    with pytest.raises(FileExistsError):
+    with pytest.raises(ValueError, match="not a directory"):
         PersistentCache(text_file.fspath)


### PR DESCRIPTION
## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Summary

Avoid race-condition problem where two processes try to create the user hash cache directory at the same time, by switching to `exists_ok=True` kwarg of `mkdir` instead of explicit check that path exists beforehand

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
