### PR TITLE
FIX: Add environment argument to TaskBase._run_task() and Workflow subclass

### DIFF
--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -380,7 +380,7 @@ class TaskBase:
         return self._can_resume
 
     @abc.abstractmethod
-    def _run_task(self):
+    def _run_task(self, environment=None):
         pass
 
     @property
@@ -1329,7 +1329,7 @@ class Workflow(TaskBase):
         self._check_for_hash_changes()
         return result
 
-    async def _run_task(self, submitter, rerun=False):
+    async def _run_task(self, submitter, rerun=False, environment=None):
         if not submitter:
             raise Exception("Submitter should already be set.")
         for nd in self.graph.nodes:

--- a/pydra/engine/submitter.py
+++ b/pydra/engine/submitter.py
@@ -90,7 +90,6 @@ class Submitter:
             # 2
             if runnable.state is None:
                 # run_el should always return a coroutine
-                print("in SUBM", environment)
                 await self.worker.run_el(runnable, rerun=rerun, environment=environment)
             # 3
             else:


### PR DESCRIPTION
## Types of changes
- Bug fix (non-breaking change which fixes an issue)


## Summary
I bumped the Pydra version used by Clinica to 0.23 and ran the test suite.

There are a few failures, but one caught my attention in particular:

```text
----------------------------- Captured stdout call -----------------------------
in SUBM None
_run_task() got an unexpected keyword argument 'environment'
```

The first line is a residual print statement (removed by the first commit).

The second one suggests an interface mismatch (fixed by the second commit).
