### PR TITLE
fixes issues with super->sub-class auto-cast and handles MultiInputObj coercion

### DIFF
--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -694,7 +694,8 @@ class LazyInterface:
             raise AttributeError(f"{name} hasn't been set yet")
         if name not in self._field_names:
             raise AttributeError(
-                f"Task {self._task.name} has no {self._attr_type} attribute {name}"
+                f"Task '{self._task.name}' has no {self._attr_type} attribute '{name}', "
+                "available: '" + "', '".join(self._field_names) + "'"
             )
         type_ = self._get_type(name)
         splits = self._get_task_splits()

--- a/pydra/engine/tests/test_specs.py
+++ b/pydra/engine/tests/test_specs.py
@@ -124,7 +124,10 @@ def test_lazy_getvale():
     lf = LazyIn(task=tn)
     with pytest.raises(Exception) as excinfo:
         lf.inp_c
-    assert str(excinfo.value) == "Task tn has no input attribute inp_c"
+    assert (
+        str(excinfo.value)
+        == "Task 'tn' has no input attribute 'inp_c', available: 'inp_a', 'inp_b'"
+    )
 
 
 def test_input_file_hash_1(tmp_path):

--- a/pydra/utils/__init__.py
+++ b/pydra/utils/__init__.py
@@ -1,1 +1,1 @@
-from .misc import user_cache_dir, add_exc_note  # noqa: F401
+from .misc import user_cache_dir, add_exc_note, exc_info_matches  # noqa: F401

--- a/pydra/utils/misc.py
+++ b/pydra/utils/misc.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import platformdirs
 from pydra._version import __version__
 
@@ -31,3 +32,14 @@ def add_exc_note(e: Exception, note: str) -> Exception:
     else:
         e.args = (e.args[0] + "\n" + note,)
     return e
+
+
+def exc_info_matches(exc_info, match, regex=False):
+    if exc_info.value.__cause__ is not None:
+        msg = str(exc_info.value.__cause__)
+    else:
+        msg = str(exc_info.value)
+    if regex:
+        return re.match(".*" + match, msg)
+    else:
+        return match in msg

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -1039,28 +1039,19 @@ def test_type_is_instance11a():
     assert not TypeParser.is_instance(None, int | str)
 
 
-def test_multi_input_obj_coerce1():
-    assert TypeParser(MultiInputObj[str])("a") == ["a"]
-
-
-def test_multi_input_obj_coerce2():
-    assert TypeParser(MultiInputObj[str])(["a"]) == ["a"]
-
-
-def test_multi_input_obj_coerce3():
-    assert TypeParser(MultiInputObj[ty.List[str]])(["a"]) == [["a"]]
-
-
-def test_multi_input_obj_coerce3a():
-    assert TypeParser(MultiInputObj[ty.Union[int, ty.List[str]]])(["a"]) == [["a"]]
-
-
-def test_multi_input_obj_coerce3b():
-    assert TypeParser(MultiInputObj[ty.Union[int, ty.List[str]]])([["a"]]) == [["a"]]
-
-
-def test_multi_input_obj_coerce4():
-    assert TypeParser(MultiInputObj[ty.Union[int, ty.List[str]]])([1]) == [1]
+@pytest.mark.parametrize(
+    ("typ", "obj", "result"),
+    [
+        (MultiInputObj[str], "a", ["a"]),
+        (MultiInputObj[str], ["a"], ["a"]),
+        (MultiInputObj[ty.List[str]], ["a"],  [["a"]]),
+        (MultiInputObj[ty.Union[int, ty.List[str]]], ["a"], [["a"]]),
+        (MultiInputObj[ty.Union[int, ty.List[str]]], [["a"]], [["a"]]),
+        (MultiInputObj[ty.Union[int, ty.List[str]]], [1], [1]),
+    ]
+)
+def test_multi_input_obj_coerce(typ, obj, result):
+    assert TypeParser(typ)(obj) == result
 
 
 def test_multi_input_obj_coerce4a():

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -1044,11 +1044,11 @@ def test_type_is_instance11a():
     [
         (MultiInputObj[str], "a", ["a"]),
         (MultiInputObj[str], ["a"], ["a"]),
-        (MultiInputObj[ty.List[str]], ["a"],  [["a"]]),
+        (MultiInputObj[ty.List[str]], ["a"], [["a"]]),
         (MultiInputObj[ty.Union[int, ty.List[str]]], ["a"], [["a"]]),
         (MultiInputObj[ty.Union[int, ty.List[str]]], [["a"]], [["a"]]),
         (MultiInputObj[ty.Union[int, ty.List[str]]], [1], [1]),
-    ]
+    ],
 )
 def test_multi_input_obj_coerce(typ, obj, result):
     assert TypeParser(typ)(obj) == result

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -70,6 +70,8 @@ class TypeParser(ty.Generic[T]):
     label : str
         the label to be used to identify the type parser in error messages. Especially
         useful when TypeParser is used as a converter in attrs.fields
+    match_any_of_union : bool
+        match if any of the options in the union are a subclass (but not necessarily all)
     """
 
     tp: ty.Type[T]
@@ -77,6 +79,7 @@ class TypeParser(ty.Generic[T]):
     not_coercible: ty.List[ty.Tuple[TypeOrAny, TypeOrAny]]
     superclass_auto_cast: bool
     label: str
+    match_any_of_union: bool
 
     COERCIBLE_DEFAULT: ty.Tuple[ty.Tuple[type, type], ...] = (
         (
@@ -121,6 +124,7 @@ class TypeParser(ty.Generic[T]):
         ] = NOT_COERCIBLE_DEFAULT,
         superclass_auto_cast: bool = False,
         label: str = "",
+        match_any_of_union: bool = False,
     ):
         def expand_pattern(t):
             """Recursively expand the type arguments of the target type in nested tuples"""
@@ -151,6 +155,7 @@ class TypeParser(ty.Generic[T]):
         self.not_coercible = list(not_coercible) if not_coercible is not None else []
         self.pattern = expand_pattern(tp)
         self.superclass_auto_cast = superclass_auto_cast
+        self.match_any_of_union = match_any_of_union
 
     def __call__(self, obj: ty.Any) -> ty.Union[T, LazyField[T]]:
         """Attempts to coerce the object to the specified type, unless the value is
@@ -185,9 +190,15 @@ class TypeParser(ty.Generic[T]):
                         # Check whether the type of the lazy field isn't a superclass of
                         # the type to check against, and if so, allow it due to permissive
                         # typing rules.
-                        TypeParser(obj.type).check_type(self.tp)
+                        TypeParser(obj.type, match_any_of_union=True).check_type(
+                            self.tp
+                        )
                     except TypeError:
-                        raise e
+                        raise TypeError(
+                            f"Incorrect type for lazy field{self.label_str}: {obj.type!r} "
+                            f"is not a subclass or superclass of {self.tp} (and will not "
+                            "be able to be coerced to one that is)"
+                        ) from e
                     else:
                         logger.info(
                             "Connecting lazy field %s to %s%s via permissive typing that "
@@ -197,12 +208,22 @@ class TypeParser(ty.Generic[T]):
                             self.label_str,
                         )
                 else:
-                    raise e
+                    raise TypeError(
+                        f"Incorrect type for lazy field{self.label_str}: {obj.type!r} "
+                        f"is not a subclass of {self.tp} (and will not be able to be "
+                        "coerced to one that is)"
+                    ) from e
             coerced = obj  # type: ignore
         elif isinstance(obj, StateArray):
             coerced = StateArray(self(o) for o in obj)  # type: ignore[assignment]
         else:
-            coerced = self.coerce(obj)
+            try:
+                coerced = self.coerce(obj)
+            except TypeError as e:
+                raise TypeError(
+                    f"Incorrect type for field{self.label_str}: {obj!r} is not of type "
+                    f"{self.tp} (and cannot be coerced to it)"
+                ) from e
         return coerced
 
     def coerce(self, object_: ty.Any) -> T:
@@ -406,12 +427,31 @@ class TypeParser(ty.Generic[T]):
             # Note that we are deliberately more permissive than typical type-checking
             # here, allowing parents of the target type as well as children,
             # to avoid users having to cast from loosely typed tasks to strict ones
+            if self.match_any_of_union and get_origin(tp) is ty.Union:
+                reasons = []
+                tp_args = get_args(tp)
+                for tp_arg in tp_args:
+                    if self.is_subclass(tp_arg, target):
+                        return
+                    try:
+                        self.check_coercible(tp_arg, target)
+                    except TypeError as e:
+                        reasons.append(e)
+                    else:
+                        return
+                if reasons:
+                    raise TypeError(
+                        f"Cannot coerce any union args {tp_arg} to {target}"
+                        f"{self.label_str}:\n\n"
+                        + "\n\n".join(f"{a} -> {e}" for a, e in zip(tp_args, reasons))
+                    )
             if not self.is_subclass(tp, target):
                 self.check_coercible(tp, target)
 
         def check_union(tp, pattern_args):
             if get_origin(tp) in UNION_TYPES:
-                for tp_arg in get_args(tp):
+                tp_args = get_args(tp)
+                for tp_arg in tp_args:
                     reasons = []
                     for pattern_arg in pattern_args:
                         try:
@@ -421,11 +461,15 @@ class TypeParser(ty.Generic[T]):
                         else:
                             reasons = None
                             break
+                    if self.match_any_of_union and len(reasons) < len(tp_args):
+                        # Just need one of the union args to match
+                        return
                     if reasons:
+                        determiner = "any" if self.match_any_of_union else "all"
                         raise TypeError(
-                            f"Cannot coerce {tp} to "
-                            f"ty.Union[{', '.join(str(a) for a in pattern_args)}]{self.label_str}, "
-                            f"because {tp_arg} cannot be coerced to any of its args:\n\n"
+                            f"Cannot coerce {tp} to ty.Union["
+                            f"{', '.join(str(a) for a in pattern_args)}]{self.label_str}, "
+                            f"because {tp_arg} cannot be coerced to {determiner} of its args:\n\n"
                             + "\n\n".join(
                                 f"{a} -> {e}" for a, e in zip(pattern_args, reasons)
                             )

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -551,21 +551,20 @@ class TypeParser(ty.Generic[T]):
             return expand_and_check(type_, self.pattern)
         except TypeError as e:
             # Special handling for MultiInputObjects (which are annoying)
-            if isinstance(self.pattern, tuple) and self.pattern[0] == MultiInputObj:
-                # Attempt to coerce the object into arg type of the MultiInputObj first,
-                # and if that fails, try to coerce it into a list of the arg type
-                inner_type_parser = copy(self)
-                inner_type_parser.pattern = self.pattern[1][0]
-                try:
-                    inner_type_parser.check_type(type_)
-                except TypeError:
-                    add_exc_note(
-                        e,
-                        "Also failed to coerce to the arg-type of the MultiInputObj "
-                        f"({self.pattern[1][0]})",
-                    )
-                    raise e
-            else:
+            if not isinstance(self.pattern, tuple) or self.pattern[0] != MultiInputObj:
+                raise e
+            # Attempt to coerce the object into arg type of the MultiInputObj first,
+            # and if that fails, try to coerce it into a list of the arg type
+            inner_type_parser = copy(self)
+            inner_type_parser.pattern = self.pattern[1][0]
+            try:
+                inner_type_parser.check_type(type_)
+            except TypeError:
+                add_exc_note(
+                    e,
+                    "Also failed to coerce to the arg-type of the MultiInputObj "
+                    f"({self.pattern[1][0]})",
+                )
                 raise e
 
     def check_coercible(self, source: ty.Any, target: ty.Union[type, ty.Any]):


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
* fixes bugs with super->sub-class auto-casting, including when the sub-classes are part of a union. If the super class is a super class of any of the union args then it passes the check.
* adds handling for MultiInputObj
* streamlines typing error messages

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)

