### PR TITLE
WIP - BEP 028 prov 

### DIFF
--- a/pydra/engine/audit.py
+++ b/pydra/engine/audit.py
@@ -62,8 +62,7 @@ class Audit:
             start_message = {
                 "@id": self.aid,
                 "@type": "task",
-                "startedAtTime": now(),
-                "executedBy": user_id,
+                "StartedAtTime": now(),
             }
 
         os.chdir(self.odir)
@@ -84,7 +83,7 @@ class Audit:
                     {
                         "@id": self.mid,
                         "@type": "monitor",
-                        "startedAtTime": now(),
+                        "StartedAtTime": now(),
                         "wasStartedBy": self.aid,
                     },
                     AuditFlag.PROV,
@@ -97,7 +96,7 @@ class Audit:
             result.runtime = gather_runtime_info(self.resource_monitor.fname)
             if self.audit_check(AuditFlag.PROV):
                 self.audit_message(
-                    {"@id": self.mid, "endedAtTime": now(), "wasEndedBy": self.aid},
+                    {"@id": self.mid, "EndedAtTime": now(), "wasEndedBy": self.aid},
                     AuditFlag.PROV,
                 )
                 # audit resources/runtime information
@@ -107,14 +106,14 @@ class Audit:
                     **{
                         "@id": self.eid,
                         "@type": "runtime",
-                        "prov:wasGeneratedBy": self.aid,
+                        "GeneratedBy": self.aid,
                     }
                 )
                 self.audit_message(entity, AuditFlag.PROV)
                 self.audit_message(
                     {
                         "@type": "prov:Generation",
-                        "entity_generated": self.eid,
+                        "runtime": self.eid,
                         "hadActivity": self.mid,
                     },
                     AuditFlag.PROV,
@@ -123,7 +122,7 @@ class Audit:
         if self.audit_check(AuditFlag.PROV):
             # audit outputs
             self.audit_message(
-                {"@id": self.aid, "endedAtTime": now(), "errored": result.errored},
+                {"@id": self.aid, "EndedAtTime": now(), "errored": result.errored},
                 AuditFlag.PROV,
             )
 
@@ -181,6 +180,8 @@ class Audit:
 
         label = task.name
 
+        # YC: currently command only support shellcommand task
+        # we can make function itself a command too
         command = task.cmdline if hasattr(task.inputs, "executable") else None
         attr_list = attr_fields(task.inputs)
         for attrs in attr_list:
@@ -224,7 +225,15 @@ class Audit:
             "Label": label,
             "Command": command,
             "StartedAtTime": now(),
-            "AssociatedWith": version_cmd,
+            "AssociatedWith": 
+                {
+                    "@id": self.aid,
+                    # YC: need to add Label, which should be 
+                    # the software name in a shellcommand task
+                    # the function's package in a function task
+                    # else be python
+                    "Version": version_cmd
+                 },
         }
 
         self.audit_message(start_message, AuditFlag.PROV)

--- a/pydra/schema/context.jsonld
+++ b/pydra/schema/context.jsonld
@@ -36,6 +36,15 @@
         "@id": "pydra:cpu_peak_percent",
         "@type": "xsd:float"
       },
+      "wasStartedBy": {
+        "@id": "uid"
+      },
+      "wasEndedBy": {
+        "@id": "uid"
+      },
+      "hadActivity": {
+        "@id": "uid"
+      },
       "errored": {
         "@id": "pydra:errored",
         "@type": "xsd:boolean"

--- a/pydra/schema/context.jsonld
+++ b/pydra/schema/context.jsonld
@@ -8,7 +8,7 @@
         "@container": "@type"
       }
     },
-    "https://raw.githubusercontent.com/openprov/prov-jsonld/69964ed16818f78dc5f71bdf97add026288291d4/context.json",
+    "https://raw.githubusercontent.com/bids-standard/BEP028_BIDSprov/master/context.json",
     {
       "pydra": "http://s.pydra.org/",
       "uid": "pydra:id/",
@@ -22,10 +22,6 @@
       },
       "runtime": {
         "@id": "pydra:runtimeInformation",
-        "@type": "@vocab"
-      },
-      "prov:wasGeneratedBy": {
-        "@id": "prov:wasGeneratedBy",
         "@type": "@vocab"
       },
       "rss_peak_gb": {


### PR DESCRIPTION
This PR was made during the 2024 BIDS meeting in Seattle after discussions with @effigies, some other discussions can be found here #https://github.com/bids-standard/BEP028_BIDSprov/issues/129
BEP028_prov doc see [here](https://docs.google.com/document/d/1vw3VNDof5cecv2PkFp7Lw_pNUTUo8-m8V4SIdtGJVKs/edit) 
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
`context.json`file
- replace [openprov context](https://raw.githubusercontent.com/openprov/prov-jsonld/69964ed16818f78dc5f71bdf97add026288291d4/context.json) with [BEP028 prov context](https://raw.githubusercontent.com/bids-standard/BEP028_BIDSprov/master/context.json)
- adding customized fields `wasStartedBy`, `wasEndedBy`, and `hadActivity`. 
    - Those three were used in `audit.py` but not defined in the prov context. Those are important for connecting `audit_start`, `monitor`, and `finalize_audit`. 
    - If we view `audit_start`, `monitor`, and `finalize_audit` as subactivities of the activity of a given task, the current BEP028 doesn't define the connection between activities but only allows connecting two activities through entities. 

`audit.py`
- fixed typos such as updating `startedAtTime` as `StartedAtTime`
- dropped `entity_generated`, replaced it with a more specific field; in this case is `runtime` but it can be something else depending on the situation. `entity_generated` can be confused with `entity` in the prov doc, which is supposed to be either input files or output files related to an activity.
- changing [`"AssociatedWith": version_cmd`](https://github.com/nipype/pydra/blob/e52e32b05816df9908b612fbc8425faed9ead86b/pydra/engine/audit.py#L227) to 
a dictionary, which is supposed to be an `Agent`, but I couldn't get the `Label`, which is `Name of the software`
    - I put a comment about [`command`](https://github.com/nipype/pydra/blob/e52e32b05816df9908b612fbc8425faed9ead86b/pydra/engine/audit.py#L184C9-L184C16), currently we only get command when the task is a shell command task. If we want to be consistent with the prov, we probably should enable command for function tasks too. See the anonymous (that's Chris) comment on the prov doc.

## Summary
<!--- What does your code do? -->
so the above changes are based on what we have in the prov doc, we probably need to dive deeper into `audit.py` and `messenger.py` (worth discussing in the next pydra meeting @djarecka)
@effigies suggested we collect messages for a workflow to generate prov records. 
for example, we can collect all messages at `finalize_audit` level into [`FileMessenger`](https://github.com/nipype/pydra/blob/e52e32b05816df9908b612fbc8425faed9ead86b/pydra/utils/messenger.py#L78C7-L78C20) using [`collect_messages`](https://github.com/nipype/pydra/blob/e52e32b05816df9908b612fbc8425faed9ead86b/pydra/utils/messenger.py#L174)

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
