### PR TITLE
[BUG] Remove pdb breakpoint and make single-op-splits robust to 1d shape

### DIFF
--- a/pydra/engine/state.py
+++ b/pydra/engine/state.py
@@ -1193,10 +1193,9 @@ class State:
         )
         val_ind = range(reduce(lambda x, y: x * y, shape))
         if op_single in self.inner_inputs:
-            if len(shape) == 1:
-                breakpoint()
             # TODO: have to be changed if differ length
-            inner_len = [shape[-1]] * reduce(lambda x, y: x * y, shape[:-1])
+            inner_len = [shape[-1]] * reduce(lambda x, y: x * y, shape[:-1], 1)
+
             # this come from the previous node
             outer_ind = self.inner_inputs[op_single].ind_l
             op_out = itertools.chain.from_iterable(


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
<!--- What does your code do? -->
Removes a stray pdb breakpoint and makes the splitter functionality robust to 1D inputs for singleton splitters.

## Checklist
<!--- Please, let us know if you need help-->
I will add a test for this case.
- [ ] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
