### PR TITLE
Registered serializer for common classes of additional array-like objects

### DIFF
--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -585,6 +585,7 @@ if HAVE_NUMPY:
         else:
             yield obj.tobytes(order="C")
 
+
 if HAVE_PYTORCH:
 
     @register_serializer(torch.Tensor)
@@ -607,5 +608,6 @@ if HAVE_PANDAS:
     def bytes_repr_pandas(obj: pandas.DataFrame, cache: Cache) -> Iterator[bytes]:
         yield f"{obj.__class__.__module__}{obj.__class__.__name__}:".encode()
         yield from bytes_repr_numpy(obj.to_numpy(), cache)
+
 
 NUMPY_CHUNK_LEN = 8192

--- a/pydra/utils/hash.py
+++ b/pydra/utils/hash.py
@@ -43,6 +43,27 @@ except ImportError:
 else:
     HAVE_NUMPY = True
 
+try:
+    import pandas
+except ImportError:
+    HAVE_PANDAS = False
+else:
+    HAVE_PANDAS = True
+
+try:
+    import torch
+except ImportError:
+    HAVE_PYTORCH = False
+else:
+    HAVE_PYTORCH = True
+
+try:
+    import tensorflow
+except ImportError:
+    HAVE_TENSORFLOW = False
+else:
+    HAVE_TENSORFLOW = True
+
 __all__ = (
     "hash_function",
     "hash_object",
@@ -564,5 +585,27 @@ if HAVE_NUMPY:
         else:
             yield obj.tobytes(order="C")
 
+if HAVE_PYTORCH:
+
+    @register_serializer(torch.Tensor)
+    def bytes_repr_torch(obj: torch.Tensor, cache: Cache) -> Iterator[bytes]:
+        yield f"{obj.__class__.__module__}{obj.__class__.__name__}:".encode()
+        yield from bytes_repr_numpy(obj.numpy(), cache)
+
+
+if HAVE_TENSORFLOW:
+
+    @register_serializer(tensorflow.Tensor)
+    def bytes_repr_tensorflow(obj: tensorflow.Tensor, cache: Cache) -> Iterator[bytes]:
+        yield f"{obj.__class__.__module__}{obj.__class__.__name__}:".encode()
+        yield from bytes_repr_numpy(obj.numpy(), cache)
+
+
+if HAVE_PANDAS:
+
+    @register_serializer(pandas.DataFrame)
+    def bytes_repr_pandas(obj: pandas.DataFrame, cache: Cache) -> Iterator[bytes]:
+        yield f"{obj.__class__.__module__}{obj.__class__.__name__}:".encode()
+        yield from bytes_repr_numpy(obj.to_numpy(), cache)
 
 NUMPY_CHUNK_LEN = 8192


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue), see #761 

## Summary
<!--- What does your code do? -->
- Registers serializers for 3 common array-like packages: torch, tensorflow, and pandas
- Copies existing methodology for serializing numpy in `bytes_repr_numpy`

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
  - No tests exist for `bytes_repr_numpy` which all changes are based off of
- [ ] I have updated documentation (if necessary)
  - No, let me know if there is a specific place that references this hash code that needs updating
