### PR TITLE
Fixes tests after refactor of `fileformats.generic.File` into `BinaryFile` and `UnicodeFile`

### DIFF
--- a/pydra/utils/tests/utils.py
+++ b/pydra/utils/tests/utils.py
@@ -1,16 +1,16 @@
-from fileformats.generic import File
+from fileformats.generic import BinaryFile, File
 from fileformats.core.mixin import WithSeparateHeader, WithMagicNumber
 from pydra import mark
 from pydra.engine.task import ShellCommandTask
 from pydra.engine import specs
 
 
-class MyFormat(WithMagicNumber, File):
+class MyFormat(WithMagicNumber, BinaryFile):
     ext = ".my"
     magic_number = b"MYFORMAT"
 
 
-class MyHeader(File):
+class MyHeader(BinaryFile):
     ext = ".hdr"
 
 
@@ -18,7 +18,7 @@ class MyFormatX(WithSeparateHeader, MyFormat):
     header_type = MyHeader
 
 
-class MyOtherFormatX(WithMagicNumber, WithSeparateHeader, File):
+class MyOtherFormatX(WithMagicNumber, WithSeparateHeader, BinaryFile):
     magic_number = b"MYFORMAT"
     ext = ".my"
     header_type = MyHeader


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary

Update to the `fileformats` dependency to add support for static type checking broke a couple of tests (not the code-base itself). This PR fixes those tests.

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [x] I have updated documentation (if necessary)
