### PR TITLE
Update CI to use build-and-inspect-python-package and tox-uv

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-branch = True

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions-infrastructure:
+        patterns:
+          - "actions/*"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -340,20 +340,14 @@ jobs:
   deploy-docs:
     needs: [build-docs, deploy]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release'
     steps:
     - name: Download docs
       uses: actions/download-artifact@v4
       with:
         name: docs
         path: docs-build
-    - name: Check for GHPAGES_DEPLOY_KEY token
-      id: deployable
-      if: github.event_name == 'release'
-      env:
-        GHPAGES_DEPLOY_KEY: "${{ secrets.GHPAGES_DEPLOY_KEY }}"
-      run: if [ -n "$GHPAGES_DEPLOY_KEY" ]; then echo "DEPLOY=true" >> $GITHUB_OUTPUT; fi
     - name: Deploy Docs to GitHub Pages
-      if: steps.deployable.outputs.DEPLOY
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GHPAGES_DEPLOY_KEY }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,18 +121,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Update build tools
-        run: python -m pip install --upgrade pip
-      - name: Checkout Pydra repo
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository }}
-      - name: Fetch tags
-        run: git fetch --prune --unshallow
-      - name: Install pydra (test)
-        run: pip install -e ".[test]"
-      - name: Pytest
-        run: pytest pydra/environments/tests/test_singularity.py pydra/environments/tests/test_environments.py
+      - name: Install tox
+        run: |
+          uv tool install tox --with=tox-uv --with=tox-gh-actions
+      - name: Show tox config
+        run: tox c
+      - name: Run tox
+        # Run test files with singularity tests; re-add the overridable "-n auto"
+        run: |
+          tox -v --exit-and-dump-after 1200 -- -n auto \
+            pydra/environments/tests/test_singularity.py pydra/environments/tests/test_environments.py
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,6 +117,11 @@ jobs:
         run: |
           echo ${{ github.ref }}
           singularity --version
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,8 +20,11 @@ concurrency:
 permissions:
   contents: read
 
-jobs:
+env:
+  # Force tox and pytest to use color
+  FORCE_COLOR: true
 
+jobs:
   build:
     name: Build & verify package
     runs-on: ubuntu-latest
@@ -37,33 +40,40 @@ jobs:
           attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
 
   test:
-    needs: ['build']
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.11', '3.12', '3.13']
+        dependencies: [latest] # , pre]
+        include:
+          # Test minimum dependencies on oldest supported Python
+          - os: ubuntu-latest
+            python-version: "3.11"
+            dependencies: min
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+
+    env:
+      DEPENDS: ${{ matrix.dependencies }}
+
     steps:
       - name: Fetch repository
         uses: actions/checkout@v4
-      - name: Fetch tags
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Update pip
-        run: python -m pip install --upgrade pip
-      - name: Install Pydra
-        run: pip install .[test]
-      - name: Print version
-        run: python -c "import pydra.engine; print(pydra.utils.__version__)"
-      - name: Disable etelemetry
-        run:  echo "NO_ET=TRUE" >> $GITHUB_ENV
-      - name: Pytest
+      - name: Install tox
         run: |
-          pytest -vs -n auto pydra --doctest-modules --import-mode=importlib --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --rootdir pydra
+          uv tool install tox --with=tox-uv --with=tox-gh-actions
+      - name: Show tox config
+        run: tox c
+      - name: Run tox
+        run: tox -v --exit-and-dump-after 1200
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,30 +23,18 @@ permissions:
 jobs:
 
   build:
+    name: Build & verify package
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: hynek/build-and-inspect-python-package@v2
         with:
-          python-version: 3
-      - run: pip install --upgrade build twine
-      - run: python -m build
-      - run: twine check dist/*
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-      - name: Build archive
-        run: |
-          git clean -fxd
-          mkdir archive
-          git archive -o archive/pydra.zip HEAD
-      - uses: actions/upload-artifact@v4
-        with:
-          name: archive
-          path: archive/
+          attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
 
   test:
     needs: ['build']
@@ -342,13 +330,13 @@ jobs:
         path: docs/build/html
 
   deploy:
-    needs: [build-docs, test, test-singularity, test-slurm]
+    needs: [build, build-docs, test, test-singularity, test-slurm]
     runs-on: ubuntu-latest
     steps:
     - name: Download dist
       uses: actions/download-artifact@v4
       with:
-        name: dist
+        name: Packages
         path: dist
     - name: Check for PyPI token on tag
       id: deployable

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,7 +81,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-singularity:
-    needs: ['build']
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -133,7 +132,7 @@ jobs:
       - name: Install pydra (test)
         run: pip install -e ".[test]"
       - name: Pytest
-        run: pytest -vs --import-mode=importlib --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml pydra/environments/tests/test_singularity.py pydra/environments/tests/test_environments.py --rootdir pydra
+        run: pytest pydra/environments/tests/test_singularity.py pydra/environments/tests/test_environments.py
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -141,7 +140,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-slurm:
-    needs: ['build']
     strategy:
       matrix:
         python-version: [3.11.5]
@@ -174,20 +172,17 @@ jobs:
         docker exec slurm bash -c "echo $NO_ET"
         docker exec slurm bash -c "ls -la && echo list top level dir"
         docker exec slurm bash -c "ls -la /pydra && echo list pydra dir"
-        if [[ "${{ matrix.python-version }}" == "3.11.5" ]]; then
-            docker exec slurm bash -c "CONFIGURE_OPTS=\"-with-openssl=/opt/openssl\" pyenv install -v 3.11.5"
-        fi
+        docker exec slurm bash -c "CONFIGURE_OPTS=\"-with-openssl=/opt/openssl\" pyenv install -v ${{ matrix.python-version }}"
         docker exec slurm bash -c "pyenv global ${{ matrix.python-version }}"
         docker exec slurm bash -c "pip install --upgrade pip && pip install -e /pydra[test,psij] && python -c 'import pydra.engine; print(pydra.utils.__version__)'"
     - name: Run pytest
       run: |
-        docker exec slurm bash -c "pytest /pydra/pydra/workers/tests/test_worker.py --import-mode=importlib --rootdir /pydra/pydra --only-worker=slurm --color=yes -vs --cov pydra --cov-config /pydra/.coveragerc --cov-report xml:/pydra/cov.xml"
+        docker exec slurm bash -c "cd /pydra; pytest pydra/workers/tests/test_worker.py --only-worker=slurm --color=yes"
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./cov.xml
 
   # test-sge:
   #   needs: ['build']

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -324,24 +324,18 @@ jobs:
   deploy:
     needs: [build, build-docs, test, test-singularity, test-slurm]
     runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      attestations: write
+      id-token: write
     steps:
     - name: Download dist
       uses: actions/download-artifact@v4
       with:
         name: Packages
         path: dist
-    - name: Check for PyPI token on tag
-      id: deployable
-      if: github.event_name == 'release'
-      env:
-        PYPI_API_TOKEN: "${{ secrets.PYPI_API_TOKEN }}"
-      run: if [ -n "$PYPI_API_TOKEN" ]; then echo "DEPLOY=true" >> $GITHUB_OUTPUT; fi
     - name: Upload to PyPI
-      if: steps.deployable.outputs.DEPLOY
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
 
   deploy-docs:
     needs: [build-docs, deploy]

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -260,7 +260,6 @@ jobs:
   #       files: ./cov.xml
 
   build-docs:
-    needs: ['build']
     runs-on: ubuntu-latest
     # Set up the environment so that it finds conda
     defaults:
@@ -296,8 +295,8 @@ jobs:
         dbus-monitor --session &
         sleep 3
     - uses: actions/checkout@v4
-    - name: Fetch tags
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
     - name: Install Minconda
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -311,19 +310,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
     - name: Install package
       run: pip install .[doc]
     - name: Install Python3 kernel
       run: python -m ipykernel install --user
     - name: Build docs
-      run: |
-        cd docs
-        make html
-        cd ..
+      run: make -C docs html
     - uses: actions/upload-artifact@v4
       with:
         name: docs

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.11', '3.12', '3.13']
-        dependencies: [latest] # , pre]
+        dependencies: [latest, pre]
         include:
           # Test minimum dependencies on oldest supported Python
           - os: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,8 +149,8 @@ jobs:
     - name: Disable etelemetry
       run: echo "NO_ET=TRUE" >> $GITHUB_ENV
     - uses: actions/checkout@v4
-    - name: Fetch tags
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
     - name: Pull docker image
       run: |
         docker pull $DOCKER_IMAGE

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,8 +8,10 @@ on:
     types: [published]
   push:
     branches:
-      - master
+      - main
   pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -85,7 +85,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']
+        dependencies: [latest]
       fail-fast: False
+
+    env:
+      DEPENDS: ${{ matrix.dependencies }}
+
     steps:
       - name: Set env
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   # ATM, this is the closest trigger to a PR merging
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@ __pycache__
 .vscode/
 
 .coverage*
-!.coveragerc
-cov.xml
+coverage.xml
 
 .*.swp
 *~
@@ -20,6 +19,8 @@ cov.xml
 
 .DS_Store
 .ipynb_checkpoints
+
+.tox
 
 # This can be generated in-tree. We never want to commit it.
 pydra/utils/_version.py

--- a/README.rst
+++ b/README.rst
@@ -73,21 +73,20 @@ which can be installed similarly
 Developer installation
 ======================
 
-Pydra requires Python 3.11+. To install in developer mode:
-
-::
+Pydra requires Python 3.11+. To install in developer mode::
 
     git clone git@github.com:nipype/pydra.git
     cd pydra
     pip install -e ".[dev]"
 
+In order to run pydra's test locally::
 
-In order to run pydra's test locally:
+    pytest pydra
 
-::
+We use `tox <https://tox.wiki/>`_ to test versions and dependency sets.
+For example, to test on the minimum and latest dependencies, run::
 
-    pytest -vs pydra
-
+    tox -e py311-min -e py313-latest
 
 It is also useful to install pre-commit:
 

--- a/pydra/compose/shell/tests/test_shell_run.py
+++ b/pydra/compose/shell/tests/test_shell_run.py
@@ -2847,7 +2847,7 @@ def test_shell_cmd_inputspec_outputspec_5(tmp_path):
     """
     customised input_spec and output_spec, output_spec uses input_spec fields in the requires
     requires is a list of list so it is treated as OR list (i.e. el[0] OR el[1] OR...)
-    the firs element of the requires list has all the fields set
+    the first element of the requires list has all the fields set
     """
     cmd = ["touch", "newfile_tmp.txt"]
 

--- a/pydra/compose/shell/tests/test_shell_run.py
+++ b/pydra/compose/shell/tests/test_shell_run.py
@@ -2250,13 +2250,6 @@ def test_shell_cmd_outputspec_6a(tmp_path):
     assert outputs.out1.fspath.exists()
 
 
-@pytest.mark.xfail(
-    sys.version_info >= (3, 11),
-    reason=(
-        "Fails on Python 3.11 in some cases (presumably a typing thing with that specific "
-        "version of Python)"
-    ),
-)
 @pytest.mark.parametrize("results_function", [run_no_submitter, run_submitter])
 def test_shell_cmd_outputspec_7(tmp_path, worker, results_function):
     """

--- a/pydra/engine/result.py
+++ b/pydra/engine/result.py
@@ -237,7 +237,9 @@ def copyfile_workflow(
         value = getattr(outputs, field.name)
         # if the field is a path or it can contain a path _copyfile_single_value is run
         # to move all files and directories to the workflow directory
-        new_value = copy_nested_files(value, wf_path, mode=FileSet.CopyMode.hardlink)
+        new_value = copy_nested_files(
+            value, wf_path, mode=FileSet.CopyMode.hardlink_or_copy
+        )
         setattr(outputs, field.name, new_value)
     return outputs
 

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -18,7 +18,8 @@ if ty.TYPE_CHECKING:
 
 
 need_docker = pytest.mark.skipif(
-    shutil.which("docker") is None or sp.call(["docker", "info"]),
+    shutil.which("docker") is None
+    or sp.run(["docker", "info"], capture_output=True).returncode,
     reason="no docker within the container",
 )
 need_singularity = pytest.mark.skipif(

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -75,11 +75,7 @@ def run_submitter(
     return results.outputs
 
 
-dot_check = sp.run(["which", "dot"], stdout=sp.PIPE, stderr=sp.PIPE)
-if dot_check.stdout:
-    DOT_FLAG = True
-else:
-    DOT_FLAG = False
+DOT_FLAG = bool(shutil.which("dot"))
 
 
 @python.define

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,6 @@ version-file = "pydra/utils/_version.py"
 allow-direct-references = true
 
 [tool.black]
-target-version = ['py38']
 exclude = "pydra/utils/_version.py"
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ readme = "README.rst"
 requires-python = ">=3.11"
 dependencies = [
     "attrs >=24.2.0",
-    "cloudpickle >=2.0.0",
-    "etelemetry >=0.2.2",
+    "cloudpickle >=3.0.0",
+    "etelemetry >=0.3.1",
     "filelock >=3.0.0",
-    "fileformats >=0.15a4",
+    "fileformats >=0.15.0a7",
     "platformdirs >=2",
 ]
 license = { file = "LICENSE" }
@@ -67,21 +67,20 @@ doc = [
     "sphinxcontrib-versioning",
 ]
 test = [
-    "pytest >=6.2.5",
-    "pytest-cov",
-    "pytest-env",
-    "pytest-xdist <2.0",
-    "pytest-rerunfailures",
-    "pytest-timeout",
-    "pympler",
-    "codecov",
-    "fileformats-extras >=0.15.0a6",
-    "numpy",
-    "pyld",
-    "psutil",
-    "python-dateutil",
-    "tornado",
-    "pympler",
+    "coverage[toml] >=5.2.1",
+    "pytest >=8.3.5",
+    "pytest-cov >=6.1",
+    "pytest-env >=1.1",
+    "pytest-xdist >=3.6",
+    "pytest-rerunfailures >=15.0",
+    "pytest-timeout >=2.3",
+    "pympler >=1.1",
+    "fileformats-extras >=0.15.0a7",
+    "numpy >=1.26",
+    "pyld >=2.0",
+    "psutil >=5.9.0",
+    "python-dateutil >=2.8.2",
+    "tornado >=6.1",
 ]
 tutorial = [
     "fileformats-extras >= v0.15.0a6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,28 @@ exclude = "pydra/utils/_version.py"
 
 [tool.codespell]
 ignore-words-list = "nd,afile,inpt,fpr"
+
+[tool.pytest.ini_options]
+minversion = "6"
+testpaths = ["pydra"]
+log_cli_level = "INFO"
+xfail_strict = true
+addopts = [
+  "-svx",
+  "-ra",
+  "--strict-config",
+  "--strict-markers",
+  "--doctest-modules",
+  "--import-mode=importlib",
+  # Config pytest-cov
+  "--cov=pydra",
+  "--cov-report=xml",
+  "--cov-config=pyproject.toml",
+]
+doctest_optionflags = "ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS"
+env = "PYTHONHASHSEED=0"
+filterwarnings = ["ignore::DeprecationWarning"]
+junit_family = "xunit2"
+
+[tool.coverage.run]
+branch = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --import-mode=importlib -vv

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,104 @@
+[tox]
+requires =
+  tox>=4
+envlist =
+  py3{11,12,13}-{latest,pre}
+  py311-min
+skip_missing_interpreters = true
+
+# Configuration that allows us to split tests across GitHub runners effectively
+[gh-actions]
+python =
+  3.11: py311
+  3.12: py312
+  3.13: py313
+
+[gh-actions:env]
+DEPENDS =
+  min: min
+  latest: latest
+  pre: pre
+
+[testenv]
+description = Pytest with coverage
+labels = test
+pip_pre =
+  pre: true
+pass_env =
+  # getpass.getuser() sources for Windows:
+  LOGNAME
+  USER
+  LNAME
+  USERNAME
+  # Pass user color preferences through
+  PY_COLORS
+  FORCE_COLOR
+  NO_COLOR
+  CLICOLOR
+  CLICOLOR_FORCE
+  PYTHON_GIL
+extras = test
+setenv =
+  pre: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+  pre: UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+  pre: UV_INDEX_STRATEGY=unsafe-best-match
+uv_resolution =
+  min: lowest-direct
+
+commands =
+  pytest --cov-report term-missing --durations=20 --durations-min=1.0 {posargs:-n auto}
+
+[testenv:style]
+description = Check our style guide
+labels = check
+deps =
+  ruff
+skip_install = true
+commands =
+  ruff check --diff
+  ruff format --diff
+
+[testenv:style-fix]
+description = Auto-apply style guide to the extent possible
+labels = pre-release
+deps =
+  ruff
+skip_install = true
+commands =
+  ruff check --fix
+  ruff format
+
+[testenv:spellcheck]
+description = Check spelling
+labels = check
+deps =
+  codespell[toml]
+skip_install = true
+commands =
+  codespell . {posargs}
+
+[testenv:build{,-strict}]
+labels =
+  check
+  pre-release
+deps =
+  build
+  twine
+skip_install = true
+set_env =
+  # Ignore specific known warnings:
+  # https://github.com/pypa/pip/issues/11684
+  # https://github.com/pypa/pip/issues/12243
+  strict: PYTHONWARNINGS=error,once:pkg_resources is deprecated as an API.:DeprecationWarning:pip._internal.metadata.importlib._envs,once:Unimplemented abstract methods {'locate_file'}:DeprecationWarning:pip._internal.metadata.importlib._dists
+commands =
+  python -m build --installer uv
+  python -m twine check dist/*
+
+[testenv:publish]
+depends = build
+labels = release
+deps =
+  twine
+skip_install = true
+commands =
+  python -m twine upload dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ pass_env =
   PYTHON_GIL
 extras = test
 setenv =
+  NO_ET: '1'
   pre: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
   pre: UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
   pre: UV_INDEX_STRATEGY=unsafe-best-match

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 requires =
   tox>=4
+  tox-uv
 envlist =
   py3{11,12,13}-{latest,pre}
   py311-min


### PR DESCRIPTION
This PR is aimed at centralizing testing and modernizing the CI workflow. It:

1) Adds a `tox.ini` that allows testing on the latest versions of all dependencies (`py*-latest`), the lowest stated dependencies (`py*-min`) and pre-releases (`py*-pre`).
2) Builds the packages with https://github.com/hynek/build-and-inspect-python-package, an action that encapsulates current best practices, including cryptographic attestation and listing package contents to the CI summary.
3) Uploads using PyPI's [trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/), which removes the need for a token and permits uploading cryptographic attestations.
4) Uses `tox-uv` to run the tests on CI, making it easier to reproduce issues seen in CI locally and vice-versa.

Some small issues were fixed in the process, including updating minimum versions based on running the `py311-min` environment. Apart from numpy, which I set at `>=1.26` so we don't become unintentionally incompatible with 1.x, the test dependencies are mostly quite recent.