### PR TITLE
Adds check to parse_command_line_template to catch options that don't have trailing field

### DIFF
--- a/pydra/compose/shell/builder.py
+++ b/pydra/compose/shell/builder.py
@@ -512,6 +512,9 @@ def parse_command_line_template(
                 f"Found unknown token {token!r} in command line template: {template}"
             )
 
+    if option:
+        raise ValueError(f"Found an option without a field: {option!r}")
+
     remaining_pos = remaining_positions(arguments, len(arguments) + 1, 1)
 
     for argument in arguments:

--- a/pydra/compose/shell/tests/test_shell_fields.py
+++ b/pydra/compose/shell/tests/test_shell_fields.py
@@ -984,6 +984,13 @@ def test_shell_missing_executable_dynamic():
         )
 
 
+def test_shell_trailing_option_fail():
+
+    with pytest.raises(ValueError, match="Found an option without a field"):
+
+        shell.define("ls <directory:generic/directory> --unparameterized-option ")
+
+
 def test_shell_help1():
 
     Shelly = shell.define(


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary

Catches options passed to parse_command_line_template that don't have an associated variable with them

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
