### PR TITLE
added guard against missing implicit helps in custom compose packages

### DIFF
--- a/pydra/compose/base/builder.py
+++ b/pydra/compose/base/builder.py
@@ -2,7 +2,6 @@ import typing as ty
 import types
 from pathlib import Path
 from copy import copy
-import attrs.validators
 from pydra.utils.typing import TypeParser, is_optional, is_fileset_or_union
 import attrs
 from .task import Task, Outputs

--- a/pydra/compose/base/helpers.py
+++ b/pydra/compose/base/helpers.py
@@ -66,7 +66,7 @@ def ensure_field_objects(
                 )
             else:
                 arg.name = input_name
-            if not arg.help:
+            if not arg.help and input_helps:
                 arg.help = input_helps.get(input_name, "")
         elif is_type(arg):
             inputs[input_name] = arg_type(
@@ -100,7 +100,7 @@ def ensure_field_objects(
                 )
             else:
                 out.name = output_name
-            if not out.help:
+            if not out.help and output_helps:
                 out.help = output_helps.get(output_name, "")
         elif is_type(out):
             outputs[output_name] = out_type(

--- a/pydra/compose/base/helpers.py
+++ b/pydra/compose/base/helpers.py
@@ -66,8 +66,8 @@ def ensure_field_objects(
                 )
             else:
                 arg.name = input_name
-            if not arg.help and input_helps:
-                arg.help = input_helps.get(input_name, "")
+            if not arg.help:
+                arg.help = input_helps.get(input_name, "") if input_helps else ""
         elif is_type(arg):
             inputs[input_name] = arg_type(
                 type=arg,
@@ -100,8 +100,8 @@ def ensure_field_objects(
                 )
             else:
                 out.name = output_name
-            if not out.help and output_helps:
-                out.help = output_helps.get(output_name, "")
+            if not out.help:
+                out.help = output_helps.get(output_name, "") if output_helps else ""
         elif is_type(out):
             outputs[output_name] = out_type(
                 type=out,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- Bug fix (non-breaking change which fixes an issue)

## Summary
In custom `compose` plugins, there may not be a way to implicitly pull out help strings, in which case they will be None by default in `ensure_field_objects`, but this was not being checked.

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
