### PR TITLE
generalize is_fileset_or_union utility to is_subclass_or_union

### DIFF
--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -1122,16 +1122,42 @@ def is_fileset_or_union(type_: type, allow_none: bool | None = None) -> bool:
     is_fileset : bool
         whether the type is a FileSet or a Union containing a FileSet
     """
+    return is_subclass_or_union(type_, core.FileSet, allow_none=allow_none)
+
+
+def is_subclass_or_union(
+    type_: type, reference: type, allow_none: bool | None = None
+) -> bool:
+    """Check if the type is a subclass of given reference or a Union containing
+    that reference type
+
+    Parameters
+    ----------
+    type_ : type
+        the type to check
+    reference : type
+        the reference type to check whether the type is a sub-class of or not
+    allow_none : bool, optional
+        whether to allow None as a valid type, by default None. If None, then None
+        is not allowed at the outer layer, but is allowed within a Union
+
+    Returns
+    -------
+    bool
+        whether the type is a FileSet or a Union containing a FileSet
+    """
     if type_ is None and allow_none:
         return True
     if is_union(type_):
         return any(
-            is_fileset_or_union(t, allow_none=allow_none or allow_none is None)
+            is_subclass_or_union(
+                t, reference, allow_none=allow_none or allow_none is None
+            )
             for t in ty.get_args(type_)
         )
     elif not inspect.isclass(type_):
         return False
-    return issubclass(type_, core.FileSet)
+    return issubclass(type_, reference)
 
 
 def is_type(*args: ty.Any) -> bool:


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Keep only relevant points: -->
- New feature (non-breaking change which adds functionality)

## Summary

Generalises a small typing union `is_fileset_or_union` to `is_subclass_or_union`. `is_fileset_or_union` is still there but simply calls `is_subclass_or_union`

## Checklist
<!--- Please, let us know if you need help-->
- [ ] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
