### PR TITLE
[FIX] Assign recalculated node state to backing field in _create_graph (#845)

### DIFF
--- a/pydra/compose/tests/test_workflow_run.py
+++ b/pydra/compose/tests/test_workflow_run.py
@@ -867,6 +867,41 @@ def test_wf_ndst_9(worker: str, tmp_path: Path):
     assert outputs.out == [11, 12, 22, 24, 33, 36]
 
 
+def test_wf_ndst_combine_two_upstreams(worker: str, tmp_path: Path):
+    """Regression test for GH#845.
+
+    A node with no splitter of its own that takes inputs from two separate
+    upstream nodes which have each been split and combined used to raise
+    ``AttributeError: property 'state' of 'NodeExecution' object has no setter``
+    while building the execution graph (``Workflow._create_graph``).
+    """
+
+    @python.define
+    def Step1(a: int) -> int:
+        return a
+
+    @python.define
+    def Step2(a: int, b: int) -> int:
+        return a + b
+
+    @python.define
+    def Step3(a: list, b: list) -> list:
+        return a
+
+    @workflow.define
+    def Worky(a: list):
+        step1 = workflow.add(Step1().split(a=a).combine("a"))
+        step2 = workflow.add(Step2().split(("a", "b"), a=a, b=step1.out).combine("a"))
+        step3 = workflow.add(Step3(a=step2.out, b=step1.out))
+        return step3.out
+
+    worky = Worky(a=[1, 2, 3])
+
+    outputs = worky(worker=worker, cache_root=tmp_path)
+
+    assert outputs.out == [2, 4, 6]
+
+
 # workflows with structures A ->  B -> C
 
 

--- a/pydra/engine/workflow.py
+++ b/pydra/engine/workflow.py
@@ -388,7 +388,7 @@ class Workflow(ty.Generic[WorkflowOutputsType]):
                         new_other_states=other_states, new_combiner=combiner
                     )
                 else:
-                    node.state = state.State(
+                    node._state = state.State(
                         node.name,
                         splitter=None,
                         other_states=other_states,


### PR DESCRIPTION
Fixes #845

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Why

Running a workflow in which a node **without its own splitter** consumes the
**combined** outputs of *two separate* upstream `.split(...).combine(...)` nodes
crashes while the execution graph is being built:

```
File ".../pydra/engine/workflow.py", line 391, in _create_graph
    node.state = state.State(
AttributeError: property 'state' of 'NodeExecution' object has no setter
```

This is exactly the shape of the nested-workflow example in #845 (the inner
workflow's `step3` consumes `step1.out` and `step2.out`, both combined).

## Root cause / which object owns the state

`Workflow._create_graph(nodes)` is polymorphic — it is called with definition
`Node`s via `Workflow.graph()` (visualisation) and with `NodeExecution` wrappers
via `Workflow.execution_graph()` (to run). Both classes expose `state` as a
**read-only** property:

- `Node.state` returns its `self._state` backing field (the true owner of the state);
- `NodeExecution.state` merely *delegates* to `self.node.state`.

Neither has a setter, so the connection-state recalculation at the bottom of
`_create_graph`

```python
if node.state:
    node.state.update_connections(...)
else:
    node.state = state.State(...)   # <-- crashes
```

fails as soon as the `else` branch is reached with a `NodeExecution` — i.e. a
stateless node fed by (multiple) combined upstreams.

## What this changes

One line: assign to the `_state` backing field instead of the read-only `state`
property.

```diff
-                    node.state = state.State(
+                    node._state = state.State(
```

Why this is the correct target and not a new setter:

- The **state is owned by `Node._state`**. During execution the underlying
  `Node`'s state has *already been finalised* in `Workflow.construct()` (via
  `Node._set_state()`); the execution-graph pass must not overwrite it.
- `NodeExecution` is a transient execution wrapper with **no `_state` field** and
  a read-only-by-design `.state` (it mirrors its node). Writing `node._state` on
  it is therefore inert — exactly what we want during execution — while for a real
  definition `Node` (the `graph()` path) it sets the state as the original code
  intended. (Note: `Node.state` is *also* read-only, so the old line would have
  crashed the visualisation path too; this fixes that latent crash as well.)

I explicitly rejected the "obvious" alternative — adding a `@state.setter` to
`NodeExecution` delegating to `self.node.state`. It removes the crash but
**silently produces wrong results**: it forces the freshly re-derived `State` onto
the underlying node, which then mis-splits over its already-combined upstreams (the
#845 example returns an empty list instead of `[2, 4, 6]`). The `_state` fix keeps
the node's finalised state intact and yields correct output.

*Note on the call site:* reaching into `node._state` here is consistent with the
method's existing idiom (`_create_graph` already accesses `node._task`), but it is
admittedly a minimal fix. A cleaner long-term direction would let `NodeExecution`
own its recalculated state (or guard the assignment to definition `Node`s) so the
call site no longer touches a private field — happy to take that route if preferred.

## Tests

Added `test_wf_ndst_combine_two_upstreams` in
`pydra/compose/tests/test_workflow_run.py`, reproducing the reported nested
split/combine scenario (a stateless node consuming two combined upstreams).

- **Before:** `FAILED` — `AttributeError: property 'state' of 'NodeExecution'
  object has no setter` at `workflow.py:391`.
- **After:** `PASSED` on both `debug` and `cf` workers; `outputs.out == [2, 4, 6]`.

The original #845 script (nested `Outer`/`Inner`) now runs to completion and
returns `OuterOutputs(out=[2, 4, 6])`.

### Regression sweep (no new failures)
- `test_state.py` + `test_task_state.py` + `test_graph.py`: 303 passed, 1 xfailed (pre-existing)
- `test_workflow_run.py` + `test_workflow_fields.py` + `test_lazy.py`: 287 passed, 2 skipped, 4 xfailed (pre-existing)
- `ndst` split/combine slice + new test: 84 passed
- `black --check` clean on both changed files

## Checklist
- [x] I have added tests to cover my changes
- [ ] I have updated documentation (not necessary)
