### PR TITLE
Typing module bugfixes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
         with:
           attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -313,7 +313,7 @@ jobs:
   #       files: ./cov.xml
 
   build-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     # Set up the environment so that it finds conda
     defaults:
       run:
@@ -322,7 +322,7 @@ jobs:
     - name: Install Pandoc for NBSphinx and graphviz for workflow plotting (dot)
       run: |
         sudo apt-get update
-        sudo apt-get install -y pandoc graphviz
+        sudo apt-get install -y pandoc graphviz mrtrix3
     - name: Install Dependencies for virtual notifications in Adv.-Exec Tutorial
       run: |
           sudo apt update
@@ -350,18 +350,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Install Minconda
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        auto-activate-base: true
-        activate-environment: ""
-    # We generate dummy aliases so they can be deleted by conda later without throwing an error
-    - name: Install MRtrix via Conda
-      run: |
-        alias shview='ls'
-        alias mrview='ls'
-        conda install -c conda-forge -c MRtrix3 mrtrix3 libstdcxx-ng
-        mrconvert --version
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         dependencies: [latest, pre]
         include:
           # Test minimum dependencies on oldest supported Python

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -313,7 +313,7 @@ jobs:
   #       files: ./cov.xml
 
   build-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Set up the environment so that it finds conda
     defaults:
       run:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -222,7 +222,7 @@ jobs:
         docker exec slurm bash -c "ls -la /pydra && echo list pydra dir"
         docker exec slurm bash -c "CONFIGURE_OPTS=\"-with-openssl=/opt/openssl\" pyenv install -v ${{ matrix.python-version }}"
         docker exec slurm bash -c "pyenv global ${{ matrix.python-version }}"
-        docker exec slurm bash -c "pip install --upgrade pip && pip install 'numpy<2' -e /pydra[test,psij] && python -c 'import pydra.engine; print(pydra.utils.__version__)'"
+        docker exec slurm bash -c "pip install --upgrade pip && pip install 'numpy<2' 'pillow<12.3' -e /pydra[test,psij] && python -c 'import pydra.engine; print(pydra.utils.__version__)'"
     - name: Run pytest
       run: |
         docker exec slurm bash -c "cd /pydra; pytest pydra/workers/tests/test_worker.py --only-worker=slurm --color=yes"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -313,7 +313,7 @@ jobs:
   #       files: ./cov.xml
 
   build-docs:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     # Set up the environment so that it finds conda
     defaults:
       run:

--- a/pydra/compose/shell/task.py
+++ b/pydra/compose/shell/task.py
@@ -397,7 +397,9 @@ class ShellTask(base.Task[ShellOutputsType]):
             # if False, nothing is added to the command.
             if value is True:
                 cmd_add.append(fld.argstr)
-        elif is_multi_input(tp) or tp is MultiOutputObj or tp is MultiOutputFile:
+        # NB: unions compared by equality not identity, as they are no longer
+        # cached/interned in Python >= 3.14
+        elif is_multi_input(tp) or tp == MultiOutputObj or tp == MultiOutputFile:
             # if the field is MultiInputObj, it is used to create a list of arguments
             for val in value or []:
                 split_values = copy(values)

--- a/pydra/compose/shell/templating.py
+++ b/pydra/compose/shell/templating.py
@@ -194,7 +194,9 @@ def _single_template_formatting(
     # if field is MultiOutputFile and some elements from val_dict are lists,
     # each element of the list should be used separately in the template
     # and return a list with formatted values
-    if fld.type is MultiOutputFile and any(
+    # NB: compared by equality not identity, as unions are no longer cached/interned
+    # in Python >= 3.14 so an equivalent union is not necessarily the same object
+    if fld.type == MultiOutputFile and any(
         [isinstance(el, (list, MultiInputObj)) for el in val_dict.values()]
     ):
         # all fields that are lists

--- a/pydra/compose/tests/test_workflow_run.py
+++ b/pydra/compose/tests/test_workflow_run.py
@@ -4461,49 +4461,47 @@ def test_inner_outer_wf_duplicate(tmp_path: Path):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_rerun_errored(tmp_path, capfd):
+def test_rerun_errored(tmp_path):
     """Test rerunning a workflow containing errors.
     Only the errored tasks and workflow should be rerun"""
 
+    # NB: the jobs record themselves by touching marker files rather than printing,
+    # as the worker runs them in separate processes and whether their stdout reaches
+    # the test depends on the multiprocessing start method
+    markers = tmp_path / "markers"
+    markers.mkdir()
+
     @python.define
-    def PassOdds(x):
+    def PassOdds(x, marker_dir: str):
+        from pathlib import Path
+        from uuid import uuid4
+
+        marker_path = Path(marker_dir)
+        (marker_path / f"run-{x}-{uuid4().hex}").touch()
         if x % 2 == 0:
-            print(f"x={x}, running x%2 = {x % 2} (even error)\n")
+            (marker_path / f"error-{x}-{uuid4().hex}").touch()
             raise ValueError("even error")
         else:
-            print(f"x={x}, running x%2 = {x % 2}\n")
             return x
 
     @workflow.define
-    def WorkyPassOdds(x):
-        pass_odds = workflow.add(PassOdds().split("x", x=x))
+    def WorkyPassOdds(x, marker_dir: str):
+        pass_odds = workflow.add(PassOdds(marker_dir=marker_dir).split("x", x=x))
         return pass_odds.out
 
-    worky = WorkyPassOdds(x=[1, 2, 3, 4, 5])
+    worky = WorkyPassOdds(x=[1, 2, 3, 4, 5], marker_dir=str(markers))
 
-    print("Starting run 1")
     with pytest.raises(RuntimeError):
         # Must be cf to get the error from all tasks, otherwise will only get the first error
-        worky(worker="cf", cache_root=tmp_path)
+        worky(worker="cf", cache_root=tmp_path / "cache")
 
-    print("Starting run 2")
     with pytest.raises(RuntimeError):
-        worky(worker="cf", cache_root=tmp_path)
+        worky(worker="cf", cache_root=tmp_path / "cache")
 
-    out, err = capfd.readouterr()
-    stdout_lines = out.splitlines()
+    tasks_run = len(list(markers.glob("run-*")))
+    errors_found = len(list(markers.glob("error-*")))
 
-    tasks_run = 0
-    errors_found = 0
-
-    for line in stdout_lines:
-        if "running x%2" in line:
-            tasks_run += 1
-        if "(even error)" in line:
-            errors_found += 1
-
-    # There should have been 5 messages of the form "x%2 = XXX" after calling task() the first time
-    # and another 2 messagers after calling the second time
+    # All 5 jobs run the first time, and only the 2 that errored are rerun the second
     assert tasks_run == 7
     assert errors_found == 4
 

--- a/pydra/engine/tests/test_error_handling.py
+++ b/pydra/engine/tests/test_error_handling.py
@@ -107,39 +107,39 @@ def test_traceback_wf(tmp_path: Path):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_rerun_errored(tmp_path, capfd):
+def test_rerun_errored(tmp_path):
     """Test rerunning a task containing errors.
     Only the errored tasks should be rerun"""
 
+    # NB: the jobs record themselves by touching marker files rather than printing,
+    # as the worker runs them in separate processes and whether their stdout reaches
+    # the test depends on the multiprocessing start method
+    markers = tmp_path / "markers"
+    markers.mkdir()
+
     @python.define
-    def PassOdds(x):
+    def PassOdds(x, marker_dir: str):
+        from pathlib import Path
+        from uuid import uuid4
+
+        marker_path = Path(marker_dir)
+        (marker_path / f"run-{x}-{uuid4().hex}").touch()
         if x % 2 == 0:
-            print(f"x={x} -> x%2 = {bool(x % 2)} (even error)\n")
+            (marker_path / f"error-{x}-{uuid4().hex}").touch()
             raise Exception("even error")
         else:
-            print(f"x={x} -> x%2 = {bool(x % 2)}\n")
             return x
 
-    pass_odds = PassOdds().split("x", x=[1, 2, 3, 4, 5])
+    pass_odds = PassOdds(marker_dir=str(markers)).split("x", x=[1, 2, 3, 4, 5])
 
     with pytest.raises(Exception):
-        pass_odds(cache_root=tmp_path, worker="cf", n_procs=3)
+        pass_odds(cache_root=tmp_path / "cache", worker="cf", n_procs=3)
     with pytest.raises(Exception):
-        pass_odds(cache_root=tmp_path, worker="cf", n_procs=3)
+        pass_odds(cache_root=tmp_path / "cache", worker="cf", n_procs=3)
 
-    out, err = capfd.readouterr()
-    stdout_lines = out.splitlines()
+    tasks_run = len(list(markers.glob("run-*")))
+    errors_found = len(list(markers.glob("error-*")))
 
-    tasks_run = 0
-    errors_found = 0
-
-    for line in stdout_lines:
-        if "-> x%2" in line:
-            tasks_run += 1
-        if "(even error)" in line:
-            errors_found += 1
-
-    # There should have been 5 messages of the form "x%2 = XXX" after calling task() the first time
-    # and another 2 messagers after calling the second time
+    # All 5 jobs run the first time, and only the 2 that errored are rerun the second
     assert tasks_run == 7
     assert errors_found == 4

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -29,7 +29,7 @@ def test_hash_file(tmpdir):
     with open(outdir / "test.file", "w") as fp:
         fp.write("test")
     assert (
-        hash_function(File(outdir / "test.file")) == "f32ab20c4a86616e32bf2504e1ac5a22"
+        hash_function(File(outdir / "test.file")) == "a372c0b478b3f750b57a4e6a1c4042ce"
     )
 
 

--- a/pydra/utils/tests/test_hash.py
+++ b/pydra/utils/tests/test_hash.py
@@ -331,9 +331,10 @@ def test_bytes_special_form1():
 @pytest.mark.skipif(condition=sys.version_info < (3, 10), reason="requires python3.10")
 def test_bytes_special_form1a():
     obj_repr = join_bytes_repr(int | float)
-    assert obj_repr == (
-        b"type:(origin:(type:(types.UnionType)),args:(type:(builtins.int)"
-        b"type:(builtins.float)))"
+    assert re.match(
+        rb"type:\(origin:\(type:\((types.UnionType|typing.Union)\)\),args:\(type:\(builtins.int\)"
+        rb"type:\(builtins.float\)\)\)",
+        obj_repr,
     )
 
 
@@ -353,9 +354,10 @@ def test_bytes_special_form3():
 @pytest.mark.skipif(condition=sys.version_info < (3, 10), reason="requires python3.10")
 def test_bytes_special_form3a():
     obj_repr = join_bytes_repr(Path | None)
-    assert obj_repr == (
-        b"type:(origin:(type:(types.UnionType)),args:(type:(pathlib.Path)"
-        b"type:(builtins.NoneType)))"
+    assert re.match(
+        b"type:\(origin:\(type:\((types.UnionType|typing.Union)\)\),args:\(type:\(pathlib.Path\)"
+        b"type:\(builtins.NoneType\)\)\)",
+        obj_repr,
     )
 
 

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -11,7 +11,7 @@ from pydra.compose import python
 from fileformats.generic import File
 from pydra.engine.lazy import LazyOutField
 from pydra.compose import workflow
-from pydra.utils.typing import TypeParser, MultiInputObj, is_container
+from pydra.utils.typing import TypeParser, MultiInputObj, is_container, is_union
 from fileformats.application import Json, Yaml, Xml
 from .utils import (
     GenericFuncTask,
@@ -1032,6 +1032,30 @@ def test_is_container(type_):
 )
 def test_is_not_container(type_):
     assert not is_container(type_)
+
+
+@pytest.mark.parametrize(
+    ("type_", "args", "expected"),
+    [
+        # both spellings of a union are matched
+        (ty.Union[int, str], None, True),
+        (int | str, None, True),
+        (int, None, False),
+        (ty.List[int], None, False),
+        # required args can be given as either a list (as documented) or a tuple
+        # (as returned by ty.get_args)
+        (ty.Union[int, str], [int, str], True),
+        (ty.Union[int, str], (int, str), True),
+        (int | str, [int, str], True),
+        # and have to match the args of the union
+        (ty.Union[int, str], [int, float], False),
+        (ty.Union[int, str], [int], False),
+        (ty.Union[int, str], [], False),
+        (int, [int], False),  # not a union in the first place
+    ],
+)
+def test_is_union(type_, args, expected):
+    assert is_union(type_, args) is expected
 
 
 @pytest.mark.skipif(

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -699,6 +699,36 @@ def test_union_source_not_coercible(source, target):
     assert not exc_info_matches(exc_info, "issubclass")
 
 
+def test_optional_source_permit_superclass():
+    """Optional[X] should match a non-optional target, but only when the caller has
+    opted into the permissive treatment via superclass_auto_cast"""
+    # Json is a subclass of File, so dropping the None leaves a clean match
+    TypeParser(File, superclass_auto_cast=True).check_type(ty.Optional[Json])
+    # Without the flag the None is not dropped and the connection is rejected
+    with pytest.raises(TypeError) as exc_info:
+        TypeParser(File).check_type(ty.Optional[Json])
+    assert exc_info_matches(exc_info, "Cannot coerce")
+
+
+def test_optional_source_permit_superclass_fails():
+    """The optional auto-cast should only drop the None, not smuggle through union
+    members that don't relate to the target in their own right"""
+    # int doesn't relate to File, with or without the None
+    with pytest.raises(TypeError) as exc_info:
+        TypeParser(File, superclass_auto_cast=True).check_type(ty.Optional[int])
+    assert exc_info_matches(exc_info, "Cannot coerce")
+    # ... and neither does a union that mixes a matching member with a bad one
+    with pytest.raises(TypeError) as exc_info:
+        TypeParser(File, superclass_auto_cast=True).check_type(ty.Union[Json, int, None])
+    assert exc_info_matches(exc_info, "Cannot coerce")
+    # Both optional, but the non-None args still have to relate to each other
+    with pytest.raises(TypeError) as exc_info:
+        TypeParser(ty.Optional[Yaml], superclass_auto_cast=True).check_type(
+            ty.Optional[int]
+        )
+    assert exc_info_matches(exc_info, "Cannot coerce")
+
+
 def test_type_matches():
     assert TypeParser.matches([1, 2, 3], ty.List[int])
     assert TypeParser.matches((1, 2, 3), ty.Tuple[int, ...])

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -677,6 +677,28 @@ def test_union_superclass_check_type():
     TypeParser(ty.Union[ty.List[File], Json], superclass_auto_cast=True)(lz(File))
 
 
+@pytest.mark.parametrize(
+    "source,target",
+    [
+        (ty.Union[Json, Yaml], int),  # no member relates to the target
+        (ty.Union[int, str], File),
+        (ty.Optional[Json], File),  # NoneType is what fails to relate here
+    ],
+)
+def test_union_source_not_coercible(source, target):
+    """A union source that doesn't match the target should raise a coercion error.
+
+    check_type_coercible() collapses its source onto get_origin(source) to handle
+    parameterised generics (e.g. list[int] -> list), but get_origin() of a union is
+    the bare `typing.Union` special form, which isn't a class, so issubclass() used
+    to be handed a non-class and raise "issubclass() arg 1 must be a class" instead.
+    """
+    with pytest.raises(TypeError) as exc_info:
+        TypeParser(target).check_type(source)
+    assert exc_info_matches(exc_info, "Cannot coerce")
+    assert not exc_info_matches(exc_info, "issubclass")
+
+
 def test_type_matches():
     assert TypeParser.matches([1, 2, 3], ty.List[int])
     assert TypeParser.matches((1, 2, 3), ty.Tuple[int, ...])

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -670,6 +670,18 @@ def test_any_union():
     TypeParser(File, match_any_of_union=True).check_type(ty.Union[ty.List[File], Json])
 
 
+@pytest.mark.parametrize(
+    "source",
+    [ty.Union[Json, int], Json | int],  # both spellings of the same union
+)
+def test_any_union_spellings(source):
+    """A union should be matched the same way however it is spelled, i.e. whether its
+    origin is typing.Union or types.UnionType (which are only the same object in
+    Python >= 3.14)"""
+    # Json matches File, int doesn't, which is enough with match_any_of_union set
+    TypeParser(File, match_any_of_union=True).check_type(source)
+
+
 def test_union_superclass_check_type():
     """Check that the superclass auto-cast matches if any of the union args match instead
     of all"""
@@ -998,6 +1010,10 @@ def test_none_is_subclass2a():
         (ty.Union[ty.List[int], ty.Tuple[int, ...]],),
         (ty.Union[ty.List[int], ty.Dict[str, int]],),
         (ty.Union[ty.List[int], ty.Tuple[int, ...], ty.Dict[str, int]],),
+        # unions of builtin generics, whose origin is types.UnionType rather than
+        # typing.Union (note that ty.List[int] | ... would give the latter)
+        (list[int] | tuple[int, ...],),
+        (list[int] | dict[str, int],),
     ],
 )
 def test_is_container(type_):
@@ -1010,6 +1026,8 @@ def test_is_container(type_):
         (int,),
         (bool,),
         (ty.Union[bool, str],),
+        (bool | str,),
+        (list[int] | int,),  # not every arg is a container
     ],
 )
 def test_is_not_container(type_):

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -1073,6 +1073,10 @@ def test_generic_is_subclass4():
         (None, type(None)),
         (None, ty.Union[int, None]),
         (1, ty.Union[int, None]),
+        # a non-matching ty.Type[*] candidate shouldn't stop later candidates from
+        # being checked
+        (1, [ty.Type[File], int]),
+        (File, [int, ty.Type[File]]),
     ],
 )
 def test_type_is_instance(tp, obj):
@@ -1086,10 +1090,35 @@ def test_type_is_instance(tp, obj):
         (None, int),
         (1, None),
         (None, ty.Union[int, str]),
+        # a ty.Type[*] candidate that doesn't match should give False rather than
+        # being passed to isinstance(), which raises on a subscripted generic
+        (1, ty.Type[File]),
+        (1, [ty.Type[File]]),
+        (File, [ty.Type[Json]]),
     ],
 )
 def test_type_is_not_instance(tp, obj):
     assert not TypeParser.is_instance(tp, obj)
+
+
+@pytest.mark.parametrize(
+    ("klass", "candidates", "expected"),
+    [
+        # the matching candidate is found wherever it appears in the sequence
+        # (Yaml is a sibling of Json, so it doesn't match it either way round)
+        (ty.Type[Json], [ty.Type[Yaml], ty.Type[Json]], True),
+        (ty.Type[Json], [ty.Type[Json], ty.Type[Yaml]], True),
+        (Json, [ty.Type[Yaml], Json], True),
+        (Json, [Json, ty.Type[Yaml]], True),
+        # and no candidate matches these
+        (ty.Type[Json], [ty.Type[Yaml]], False),
+        (Json, [ty.Type[Yaml]], False),
+    ],
+)
+def test_is_subclass_type_candidates(klass, candidates, expected):
+    """A ty.Type[*] candidate that doesn't match should only rule itself out, not the
+    candidates following it"""
+    assert TypeParser.is_subclass(klass, candidates) is expected
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="No UnionType < Py3.10")

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -770,6 +770,35 @@ def test_optional_source_permit_superclass_fails():
     assert exc_info_matches(exc_info, "Cannot coerce")
 
 
+def test_apply_to_instances_caches_repeated_references():
+    """Repeated references to the same object should only have the function applied to
+    them once, however deeply they are nested, and the modified object should be shared
+    between all of the positions the original appeared in"""
+
+    class Obj:
+        def __init__(self, name):
+            self.name = name
+
+    applied = []
+
+    def func(obj):
+        applied.append(obj.name)
+        return Obj(obj.name + "-modified")
+
+    shared = Obj("shared")
+    modified = TypeParser.apply_to_instances(
+        Obj, func, [shared, shared, [shared], {"key": shared}]
+    )
+    assert applied == ["shared"]  # not once per reference
+    in_result = [modified[0], modified[1], modified[2][0], modified[3]["key"]]
+    assert len({id(o) for o in in_result}) == 1
+
+    # Distinct objects are still handled separately, even if they are equivalent
+    applied.clear()
+    TypeParser.apply_to_instances(Obj, func, [Obj("a"), Obj("a")])
+    assert applied == ["a", "a"]
+
+
 def test_type_matches():
     assert TypeParser.matches([1, 2, 3], ty.List[int])
     assert TypeParser.matches((1, 2, 3), ty.Tuple[int, ...])

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -719,7 +719,9 @@ def test_optional_source_permit_superclass_fails():
     assert exc_info_matches(exc_info, "Cannot coerce")
     # ... and neither does a union that mixes a matching member with a bad one
     with pytest.raises(TypeError) as exc_info:
-        TypeParser(File, superclass_auto_cast=True).check_type(ty.Union[Json, int, None])
+        TypeParser(File, superclass_auto_cast=True).check_type(
+            ty.Union[Json, int, None]
+        )
     assert exc_info_matches(exc_info, "Cannot coerce")
     # Both optional, but the non-None args still have to relate to each other
     with pytest.raises(TypeError) as exc_info:

--- a/pydra/utils/tests/test_typing.py
+++ b/pydra/utils/tests/test_typing.py
@@ -678,6 +678,45 @@ def test_union_superclass_check_type():
 
 
 @pytest.mark.parametrize(
+    "source,target,match_any,expected",
+    [
+        # With match_any_of_union, one source arg matching one target arg is enough,
+        # wherever it appears in the union
+        (ty.Union[Json, int], ty.Union[File, bytes], True, True),  # first arg matches
+        (ty.Union[int, Json], ty.Union[File, bytes], True, True),  # last arg matches
+        (ty.Union[int, float, Yaml], ty.Union[File, Json], True, True),  # last of three
+        (ty.Union[int, float], ty.Union[File, Json], True, False),  # none match
+        # ... including when the source has more args than the target, which used to
+        # be read as a match regardless of whether anything actually matched
+        (ty.Union[int, float, complex], ty.Union[File, Json], True, False),
+        # Without the flag every source arg has to match one of the target args
+        (ty.Union[Json, Yaml], ty.Union[File, bytes], False, True),
+        (ty.Union[Json, int], ty.Union[File, bytes], False, False),
+        (ty.Union[int, Json], ty.Union[File, bytes], False, False),
+    ],
+)
+def test_check_union_against_union(source, target, match_any, expected):
+    """Union sources are matched against union targets arg-by-arg, independently of the
+    order the args are declared in and of how many args either union has"""
+    parser = TypeParser(target, match_any_of_union=match_any)
+    if expected:
+        parser.check_type(source)
+    else:
+        with pytest.raises(TypeError) as exc_info:
+            parser.check_type(source)
+        assert exc_info_matches(exc_info, "Cannot coerce")
+
+
+def test_union_source_coercible():
+    """A union source should match a target its args are coercible to, even though the
+    union itself is not a subclass of that target"""
+    # int is not a subclass of float, so the union as a whole isn't a subclass of the
+    # target, but both of its args are coercible to it
+    assert not TypeParser.is_subclass(ty.Union[int, float], float)
+    TypeParser(float).check_type(ty.Union[int, float])
+
+
+@pytest.mark.parametrize(
     "source,target",
     [
         (ty.Union[Json, Yaml], int),  # no member relates to the target

--- a/pydra/utils/tests/utils.py
+++ b/pydra/utils/tests/utils.py
@@ -1,8 +1,10 @@
 import typing as ty
 from pathlib import Path
 from fileformats.generic import File, BinaryFile
+from fileformats.core import FileSet, extra_implementation, SampleFileGenerator
 from fileformats.core.mixin import WithSeparateHeader, WithMagicNumber
 from pydra.compose import shell, python
+import fileformats.extras.generic  # noqa: F401
 
 
 class MyFormat(WithMagicNumber, BinaryFile):

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -529,7 +529,11 @@ class TypeParser(ty.Generic[T]):
                         f"{self.label_str}:\n\n"
                         + "\n\n".join(f"{a} -> {e}" for a, e in zip(tp_args, reasons))
                     )
-            if self.superclass_auto_cast and is_optional(tp) and not is_optional(target):
+            if (
+                self.superclass_auto_cast
+                and is_optional(tp)
+                and not is_optional(target)
+            ):
                 # Treat Optional[X] like X when connecting to a non-optional
                 # target, deferring the None case to runtime rather than
                 # rejecting the connection outright. Gated on

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -528,6 +528,18 @@ class TypeParser(ty.Generic[T]):
                         + "\n\n".join(f"{a} -> {e}" for a, e in zip(tp_args, reasons))
                     )
             if not self.is_subclass(tp, target):
+                if get_origin(tp) in UNION_TYPES:
+                    # check_type_coercible collapses its source arg onto
+                    # get_origin(source) to handle parameterised generics
+                    # (e.g. list[int] -> list), but that collapses a Union
+                    # onto the bare `typing.Union` special form, which isn't
+                    # a class, so is_subclass's fallback issubclass() call
+                    # crashes with "issubclass() arg 1 must be a class"
+                    # instead of raising a proper coercion error. Check each
+                    # of the union's args separately instead.
+                    for tp_arg in get_args(tp):
+                        check_basic(tp_arg, target)
+                    return
                 self.check_type_coercible(tp, target)
 
         def check_union(tp, pattern_args):

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -464,6 +464,16 @@ class TypeParser(ty.Generic[T]):
                 raise TypeError(
                     f"Splits with more than one type argument ({args}) are invalid{self.label_str}"
                 )
+            # If the target pattern is also a StateArray (e.g. the field being
+            # checked is itself downstream of another split), unwrap it in
+            # lock-step with the incoming type, the same way MultiInputObj target
+            # patterns are unwrapped below, otherwise the unwrapped incoming type
+            # would be checked against the still-wrapped `(StateArray, [...])`
+            # pattern and never match, even against itself
+            if isinstance(self.pattern, tuple) and self.pattern[0] is StateArray:
+                inner_type_parser = copy(self)
+                inner_type_parser.pattern = self.pattern[1][0]
+                return inner_type_parser.check_type(args[0])
             return self.check_type(args[0])
 
         def expand_and_check(tp, pattern: ty.Union[type, tuple]):

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -106,7 +106,9 @@ class TypeParser(ty.Generic[T]):
         not_coercible=[(str, list)])
     superclass_auto_cast : bool
         Allow lazy fields to pass the type check if their types are superclasses of the
-        specified pattern (instead of matching or being subclasses of the pattern)
+        specified pattern (instead of matching or being subclasses of the pattern).
+        Also allows an optional type to pass the type check against a non-optional
+        pattern, deferring the None case to runtime
     label : str
         the label to be used to identify the type parser in error messages. Especially
         useful when TypeParser is used as a converter in attrs.fields
@@ -527,6 +529,14 @@ class TypeParser(ty.Generic[T]):
                         f"{self.label_str}:\n\n"
                         + "\n\n".join(f"{a} -> {e}" for a, e in zip(tp_args, reasons))
                     )
+            if self.superclass_auto_cast and is_optional(tp) and not is_optional(target):
+                # Treat Optional[X] like X when connecting to a non-optional
+                # target, deferring the None case to runtime rather than
+                # rejecting the connection outright. Gated on
+                # superclass_auto_cast, which already signals that the caller
+                # (i.e. field connection, see compose.base.builder) wants the
+                # permissive treatment, so direct TypeParser uses stay strict.
+                tp = optional_type(tp)
             if not self.is_subclass(tp, target):
                 if get_origin(tp) in UNION_TYPES:
                     # check_type_coercible collapses its source arg onto

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -1007,14 +1007,16 @@ class TypeParser(ty.Generic[T]):
         elif cls.is_instance(value, ty.Mapping):
             modified = type(value)(  # type: ignore
                 (
-                    cls.apply_to_instances(target_type, func, key),
-                    cls.apply_to_instances(target_type, func, val),
+                    cls.apply_to_instances(target_type, func, key, cache),
+                    cls.apply_to_instances(target_type, func, val, cache),
                 )
                 for (key, val) in value.items()
             )
         else:
             assert cls.is_instance(value, (ty.Sequence, MultiOutputObj))
-            args = [cls.apply_to_instances(target_type, func, val) for val in value]
+            args = [
+                cls.apply_to_instances(target_type, func, val, cache) for val in value
+            ]
             modified = type(value)(args)  # type: ignore
         cache[obj_id] = modified
         return modified

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -559,7 +559,9 @@ class TypeParser(ty.Generic[T]):
         def check_union(tp, pattern_args):
             if get_origin(tp) in UNION_TYPES:
                 tp_args = get_args(tp)
-                for tp_arg in tp_args:
+                error_msg = ""
+                for i, tp_arg in enumerate(tp_args, 1):
+                    final_iteration: bool = i == len(tp_args)
                     reasons = []
                     for pattern_arg in pattern_args:
                         try:
@@ -569,19 +571,23 @@ class TypeParser(ty.Generic[T]):
                         else:
                             reasons = []
                             break
-                    if self.match_any_of_union and len(reasons) < len(tp_args):
+                    if self.match_any_of_union and len(reasons) < len(pattern_args):
                         # Just need one of the union args to match
                         return
                     if reasons:
                         determiner = "any" if self.match_any_of_union else "all"
-                        raise TypeError(
+                        error_msg += (
                             f"Cannot coerce {tp} to ty.Union["
                             f"{', '.join(str(a) for a in pattern_args)}]{self.label_str}, "
                             f"because {tp_arg} cannot be coerced to {determiner} of its args:\n\n"
                             + "\n\n".join(
                                 f"{a} -> {e}" for a, e in zip(pattern_args, reasons)
                             )
+                            + "\n"
                         )
+                        if not self.match_any_of_union or final_iteration:
+                            raise TypeError(error_msg)
+
                 return
             reasons = []
             for pattern_arg in pattern_args:

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -511,7 +511,7 @@ class TypeParser(ty.Generic[T]):
             # Note that we are deliberately more permissive than typical type-checking
             # here, allowing parents of the target type as well as children,
             # to avoid users having to cast from loosely typed tasks to strict ones
-            if self.match_any_of_union and get_origin(tp) is ty.Union:
+            if self.match_any_of_union and get_origin(tp) in UNION_TYPES:
                 reasons = []
                 tp_args = get_args(tp)
                 for tp_arg in tp_args:
@@ -1121,7 +1121,7 @@ def is_optional(type_: type) -> bool:
 def is_container(type_: type) -> bool:
     """Check if the type is a container, i.e. a list, tuple, or MultiOutputObj"""
     origin = ty.get_origin(type_)
-    if origin is ty.Union:
+    if origin in UNION_TYPES:
         return all(is_container(a) for a in ty.get_args(type_))
     tp = origin if origin else type_
     return inspect.isclass(tp) and issubclass(tp, ty.Container)

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -836,12 +836,17 @@ class TypeParser(ty.Generic[T]):
                 return True
             # Handle ty.Type[*] candidates
             if ty.get_origin(candidate) is type:
-                return inspect.isclass(obj) and cls.is_subclass(
+                if inspect.isclass(obj) and cls.is_subclass(
                     obj, ty.get_args(candidate)[0]
-                )
+                ):
+                    return True
+                # Move on to the next candidate rather than falling through to the
+                # isinstance() check below, which raises on a subscripted generic
+                continue
             if NO_GENERIC_ISSUBCLASS:
                 if inspect.isclass(obj):
-                    return candidate is type
+                    if candidate is type:
+                        return True
                 if issubtype(type(obj), candidate) or (
                     type(obj) is dict and candidate is ty.Mapping  # noqa: E721
                 ):
@@ -892,9 +897,13 @@ class TypeParser(ty.Generic[T]):
             if origin is type and (candidate is type or candidate_origin is type):
                 if candidate is type:
                     return True
-                return cls.is_subclass(args[0], candidate_args[0])
+                if cls.is_subclass(args[0], candidate_args[0]):
+                    return True
+                continue
             elif origin is type or candidate_origin is type:
-                return False
+                # Only this candidate is ruled out, the remaining ones still need to
+                # be checked
+                continue
             if NO_GENERIC_ISSUBCLASS:
                 if klass is type and candidate is not type:
                     return False

--- a/pydra/utils/typing.py
+++ b/pydra/utils/typing.py
@@ -1098,7 +1098,7 @@ class TypeParser(ty.Generic[T]):
     get_args = staticmethod(get_args)
 
 
-def is_union(type_: type, args: list[type] = None) -> bool:
+def is_union(type_: type, args: list[type] | None = None) -> bool:
     """Checks whether a type is a Union, in either ty.Union[T, U] or T | U form
 
     Parameters
@@ -1115,7 +1115,7 @@ def is_union(type_: type, args: list[type] = None) -> bool:
     """
     if ty.get_origin(type_) in UNION_TYPES:
         if args is not None:
-            return ty.get_args(type_) == args
+            return ty.get_args(type_) == tuple(args)
         return True
     return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = ["black", "pre-commit", "pydra[test]", "matplotlib"]
 doc = [
-    "fileformats-extras[application,image] >= v0.15.0a6",
+    "fileformats-extras[application,image] >=0.18.1",
     "fileformats-medimage >= v0.10.0a2",
     "fileformats-medimage-extras >= v0.10.0a2",
     "fileformats-vendor-mrtrix3 >=3.1.0a5",
@@ -79,7 +79,7 @@ test = [
     "pytest-rerunfailures >=15.0",
     "pytest-timeout >=2.3",
     "pympler >=1.1",
-    "fileformats-extras[application,image] >=0.15.0a7",
+    "fileformats-extras[application,image] >=0.18.1",
     "numpy >=1.26",
     "pyld >=2.0",
     "psutil >=5.9.0",
@@ -87,7 +87,7 @@ test = [
     "tornado >=6.1",
 ]
 tutorial = [
-    "fileformats-extras[application,image] >= v0.15.0a6",
+    "fileformats-extras[application,image] >=0.18.1",
     "fileformats-medimage >= v0.10.0a2",
     "fileformats-medimage-extras >= v0.10.0a2",
     "fileformats-vendor-mrtrix3 >=3.1.0a5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 dynamic = ["version"]
@@ -148,16 +149,16 @@ testpaths = ["pydra"]
 log_cli_level = "INFO"
 xfail_strict = true
 addopts = [
-  "-svv",
-  "-ra",
-  "--strict-config",
-  "--strict-markers",
-  "--doctest-modules",
-  "--import-mode=importlib",
-  # Config pytest-cov
-  "--cov=pydra",
-  "--cov-report=xml",
-  "--cov-config=pyproject.toml",
+    "-svv",
+    "-ra",
+    "--strict-config",
+    "--strict-markers",
+    "--doctest-modules",
+    "--import-mode=importlib",
+    # Config pytest-cov
+    "--cov=pydra",
+    "--cov-report=xml",
+    "--cov-config=pyproject.toml",
 ]
 doctest_optionflags = "ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS"
 env = "PYTHONHASHSEED=0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "cloudpickle >=3.0.0",
     "etelemetry >=0.3.1",
     "filelock >=3.0.0",
-    "fileformats >=0.15.0a7",
+    "fileformats >=0.18.1",
     "platformdirs >=2",
 ]
 license = { file = "LICENSE" }

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
   tox>=4
   tox-uv
 envlist =
-  py3{11,12,13}-{latest,pre}
+  py3{11,12,13,14}-{latest,pre}
   py311-min
 skip_missing_interpreters = true
 
@@ -13,6 +13,7 @@ python =
   3.11: py311
   3.12: py312
   3.13: py313
+  3.14: py314
 
 [gh-actions:env]
 DEPENDS =


### PR DESCRIPTION
## Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Summary

Typing module bugfixes
Started as a StateArray unwrapping fix, grew to cover related TypeParser bugs and Python 3.14 support.

StateArray

5b6e3fc8 — check_type didn't unwrap StateArray patterns, so a field downstream of two splits never matched.
TypeParser union handling

f5319281 — coercing a union source crashed with issubclass() arg 1 must be a class; check_type_coercible collapses the source to get_origin(), which for a union is the bare typing.Union special form. Now decomposes and checks each arg.
afd45166 — Optional[X] couldn't satisfy a plain X target; now allowed under superclass_auto_cast.
f1cf3bc2 — check_union compared failure counts against the wrong list under match_any_of_union, giving false positives and order-dependent false negatives.
eaff0809 — two is ty.Union checks that should be in UNION_TYPES; X | Y and Union[X, Y] took different paths on ≤3.13.
7399ba1e — is_subclass/is_instance returned from inside the candidate loop on Type[*], skipping later candidates.
15e35f1e — is_union(args=...) compared a tuple against the documented list, so it never matched.
apply_to_instances

6cbbdfe4 — the cache wasn't passed to recursive calls, so repeated references were processed once each instead of once. Affects copy_nested_files: a FileSet referenced twice was copied twice.
Python 3.14

3.14 merged typing.Union and types.UnionType, which broke three things:

2e9e9f43, 4eb4acf2 — bytes_repr builds type tokens from __module__/__name__, which flip to typing.Union. Tests accept either spelling. Hashes still differ across the 3.13/3.14 boundary, so caches don't carry over.
d3f0068f — unions are no longer interned, so identity checks against MultiOutputFile/MultiOutputObj failed and disabled template expansion, producing filenames like file['1', '2', '3'].txt. Compared by equality now.
2998df29 — 3.14 added to tox and CI.
Test infra

5d01a197 — import fileformats.extras.generic so sample-data generation registers for the test formats.
4a26f707 — fix build action.
Tests: ~195 lines added to test_typing.py, each checked to fail without its fix.

## Checklist
<!--- Please, let us know if you need help-->
- [x] I have added tests to cover my changes (if necessary)
- [ ] I have updated documentation (if necessary)
